### PR TITLE
Require all PR commits to be authored by shimwell

### DIFF
--- a/.github/workflows/commit-authors.yml
+++ b/.github/workflows/commit-authors.yml
@@ -1,0 +1,88 @@
+name: Commit authors
+
+# Merge gate: every commit in a pull request must be authored by the GitHub
+# account `shimwell`. The check is on the GitHub *account* linked to each
+# commit (the `author.login` the API reports), not on the free-text git author
+# name or email, so a local `git config user.name "shimwell"` does not pass it.
+#
+# Deliberately not path-filtered: a required check that gets skipped never
+# reports a conclusion and would leave every pull request unmergeable.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commit-authors:
+    name: All commits authored by shimwell
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ALLOWED_LOGIN: shimwell
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPO: ${{ github.repository }}
+    steps:
+      # No checkout: the commit list and its account links come from the API,
+      # and the local git objects carry only the unverified name/email strings.
+      - name: Check the GitHub account behind every commit
+        run: |
+          set -euo pipefail
+
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+            --jq '.[] | [
+                    .sha,
+                    (.author.login // "<no linked account>"),
+                    (.committer.login // "<no linked account>"),
+                    (.commit.message | split("\n")[0])
+                  ] | @tsv' > commits.tsv
+          sed -i '/^[[:space:]]*$/d' commits.tsv
+
+          if [ ! -s commits.tsv ]; then
+            echo "::error::No commits returned for PR #${PR_NUMBER}; refusing to pass a check that verified nothing."
+            exit 1
+          fi
+
+          failed=0
+          while IFS=$'\t' read -r sha author committer subject; do
+            bad=""
+            if [ "${author}" != "${ALLOWED_LOGIN}" ]; then
+              bad="author=${author}"
+            fi
+            # `web-flow` is GitHub's own committer for anything created through
+            # the web UI (merge commits, suggestion commits, in-browser edits),
+            # so it is allowed as committer as long as the author is shimwell.
+            case "${committer}" in
+              "${ALLOWED_LOGIN}"|web-flow) ;;
+              *) bad="${bad:+${bad} }committer=${committer}" ;;
+            esac
+
+            if [ -z "${bad}" ]; then
+              echo "ok    ${sha:0:8}  ${subject}"
+            else
+              echo "FAIL  ${sha:0:8}  ${subject}"
+              echo "      ${bad}"
+              echo "::error::Commit ${sha} is not authored by ${ALLOWED_LOGIN} (${bad})"
+              failed=1
+            fi
+          done < commits.tsv
+
+          if [ "${failed}" -ne 0 ]; then
+            cat >&2 <<'MSG'
+
+          Every commit in this pull request must belong to the GitHub account
+          `shimwell`. A commit shows "<no linked account>" when its email address
+          is not registered to any GitHub user, so add that address at
+          https://github.com/settings/emails and re-push, or rewrite the offending
+          commits:
+
+            git rebase -r --exec 'git commit --amend --no-edit --reset-author' origin/main
+            git push --force-with-lease
+
+          MSG
+            exit 1
+          fi
+
+          echo "All $(wc -l < commits.tsv) commit(s) are authored by ${ALLOWED_LOGIN}."


### PR DESCRIPTION
Adds a `Commit authors` workflow that fails a pull request if any commit in it is not authored by the GitHub account `shimwell`.

## How it checks

It reads `GET /repos/{repo}/pulls/{n}/commits` (paginated) and looks at the GitHub account linked to each commit, not the free-text git author name or email. Setting `git config user.name shimwell` locally does not pass it.

Per commit:

- `author.login` must be exactly `shimwell`
- `committer.login` must be `shimwell` or `web-flow` (GitHub's own committer for web-UI merges, suggestion commits, and in-browser edits)
- a commit whose email is not registered to any GitHub account reports `<no linked account>` and fails

Failures emit one `::error::` annotation per offending commit plus a hint on how to fix it. An empty commit list also fails, rather than passing a check that verified nothing. The job does no checkout and runs with a read-only token.

The workflow is deliberately not path-filtered: a required check that gets skipped never reports a conclusion, which would leave every pull request unmergeable.

## Enforcement

A branch ruleset on `main`, `Commits must be authored by shimwell`, requires the `All commits authored by shimwell` check (pinned to the GitHub Actions app). The repository-admin role is a bypass actor so force-pushes and direct pushes to `main` still work, and `strict_required_status_checks_policy` is off so branches do not have to be rebased onto latest `main` before merging.

## Known false positive

If a pull request merges `main` into its branch and `main` ever contains a commit by another account, that commit appears in the pull request's commit list and fails the check. Not reachable while the history is solo-authored.