### PR TITLE
Sum the macroscopic cross section in name order

### DIFF
--- a/crates/yamc-materials/src/material/macro_xs.rs
+++ b/crates/yamc-materials/src/material/macro_xs.rs
@@ -394,7 +394,26 @@ impl Material {
             None
         };
 
-        for nuclide in self.nuclides.keys() {
+        // Name order, not `HashMap` order. Every nuclide accumulates into the
+        // same `macro_values[i]` below, so the iteration order IS the summation
+        // order, and float addition is not associative: walking the map
+        // directly moved the last bit of the macroscopic cross section at most
+        // grid points from one run to the next. Measured on the eight-nuclide
+        // steel of `tests/macro_xs_reproducibility.rs`, 76352 of 151285 points
+        // of MT 1 differed between two builds in a single process (#598).
+        //
+        // Same defect as #502 (`matrix.rs`), #576 (`composition.rs`) and the
+        // four sites of #597. This one was held back from that sweep because it
+        // feeds transport: it is the cross section a collision samples against,
+        // so re-ordering the sum moves transport results in the last bit.
+        //
+        // The rest of this file already sorts wherever it builds an index
+        // (the energy grid, `sorted_nuclide_keys`, `macroscopic_xs_mt_numbers`);
+        // the one place taking a cross-nuclide float sum did not.
+        let mut nuclide_names: Vec<&String> = self.nuclides.keys().collect();
+        nuclide_names.sort_unstable();
+
+        for nuclide in nuclide_names {
             let atoms_per_bcm = atoms_per_bcm_map.get(nuclide);
             let nuclide_data = micro_xs.get(nuclide);
             // Always try to store per-nuclide MT=1 if by_nuclide is true

--- a/crates/yamc-materials/tests/macro_xs_reproducibility.rs
+++ b/crates/yamc-materials/tests/macro_xs_reproducibility.rs
@@ -1,0 +1,126 @@
+//! The macroscopic cross section must be bit-reproducible (issue #598).
+//!
+//! Same defect as #502 (`matrix.rs`), #576 (`composition.rs`) and the four
+//! sites fixed in #597, one layer further in. `Material::nuclides` is a
+//! `HashMap`, Rust seeds each instance separately, and the accumulation loop
+//! in `macro_xs.rs` walked it directly:
+//!
+//! ```text
+//! for nuclide in self.nuclides.keys() {   // HashMap iteration order
+//!     ...
+//!     macro_values[i] += atoms_per_bcm * xs;   // every nuclide sums here
+//! }
+//! ```
+//!
+//! Every nuclide accumulates into the same slot, so the summation order, and
+//! with it the last bit of the material's macroscopic cross section at every
+//! grid point, differed between runs.
+//!
+//! This one feeds transport, which is why it was held back from #597: the
+//! cross sections these tests pin are what a collision samples against.
+//!
+//! Rebuilt rather than compared with itself: the map is constructed per
+//! material, so a fresh one is the only way to get a fresh iteration order.
+
+use std::collections::HashMap;
+
+use yamc_materials::Material;
+
+/// A simplified stainless steel: the eight nuclides of it that the fixture
+/// set (`scripts/fetch_test_fixtures.py`) carries with full transport
+/// sections, at their natural-abundance fractions.
+///
+/// Restricted to those on purpose, so this runs in CI rather than self-
+/// skipping. Eight is enough for the iteration order to vary between two
+/// `HashMap` instances, and the fractions span four orders of magnitude, so
+/// adding the small terms before or after the large ones rounds differently.
+/// The full 24-nuclide version is in `composition_reproducibility.rs`, which
+/// needs no nuclear data at all.
+fn steel() -> HashMap<String, f64> {
+    HashMap::from(
+        [
+            ("Fe54", 0.0380),
+            ("Fe56", 0.5966),
+            ("Fe57", 0.0138),
+            ("Fe58", 0.0018),
+            ("Cr52", 0.1423),
+            ("Si28", 0.0092),
+            ("Si29", 0.0005),
+            ("Si30", 0.0003),
+        ]
+        .map(|(n, f)| (n.to_string(), f)),
+    )
+}
+
+/// Cache paths for every nuclide of the composition, or `None` if any is absent.
+fn data_paths(composition: &HashMap<String, f64>) -> Option<HashMap<String, String>> {
+    composition
+        .keys()
+        .map(|n| yamc_test_cache::nuclide(n).map(|p| (n.clone(), p)))
+        .collect()
+}
+
+/// Built from a FRESH `steel()` every time, never from a clone.
+///
+/// `HashMap::clone` copies the hasher along with the contents, so a cloned
+/// composition iterates in exactly the order its source did. Cloning one map
+/// per build would hold the iteration order fixed and the test would pass
+/// against the unfixed code, which is what it did when first written.
+fn build(paths: &HashMap<String, String>) -> Material {
+    let mut m = Material::new(steel(), "atom", "g/cm3", Some(7.9)).expect("material");
+    m.set_temperature("294");
+    m.read_nuclear_data(paths, None).expect("nuclear data");
+    m
+}
+
+/// Every value of every MT, as raw bits, in a deterministic order.
+fn bits(macro_xs: &HashMap<i32, Vec<f64>>) -> Vec<(i32, Vec<u64>)> {
+    let mut out: Vec<(i32, Vec<u64>)> = macro_xs
+        .iter()
+        .map(|(&mt, xs)| (mt, xs.iter().map(|v| v.to_bits()).collect()))
+        .collect();
+    out.sort_by_key(|(mt, _)| *mt);
+    out
+}
+
+/// The whole point: the same material built twice gives the same numbers.
+#[test]
+fn the_macroscopic_cross_section_is_bit_identical_across_builds() {
+    let composition = steel();
+    let Some(paths) = data_paths(&composition) else {
+        eprintln!("SKIP: the steel nuclides are not in the test cache; this test checked nothing");
+        return;
+    };
+
+    let mts = vec![1, 2, 102];
+    let (grid, first) = build(&paths).calculate_macroscopic_xs(&mts, false);
+    let expected = bits(&first);
+    assert!(
+        expected.iter().any(|(_, xs)| xs.len() > 1000),
+        "the union grid is too small for this to mean anything: {:?}",
+        expected
+            .iter()
+            .map(|(mt, xs)| (mt, xs.len()))
+            .collect::<Vec<_>>()
+    );
+
+    for i in 1..8 {
+        let (grid_again, again) = build(&paths).calculate_macroscopic_xs(&mts, false);
+        assert_eq!(
+            grid_again.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            grid.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "the unified energy grid on build {i} differs from the first"
+        );
+
+        let again = bits(&again);
+        for ((mt, want), (_, got)) in expected.iter().zip(again.iter()) {
+            let differing = want.iter().zip(got.iter()).filter(|(a, b)| a != b).count();
+            assert_eq!(
+                differing,
+                0,
+                "MT {mt}: {differing} of {} grid points differ on build {i}",
+                want.len()
+            );
+        }
+    }
+}


### PR DESCRIPTION
Implements fusion-neutronics/core-aug-31#598 on this repository.

`macro_xs.rs` accumulated every nuclide's contribution into the same `macro_values[i]` while walking `self.nuclides` in `HashMap` order. Rust seeds each `HashMap` instance separately, so the iteration order was the summation order, float addition is not associative, and the last bit of the material's macroscopic cross section moved from one run to the next.

Same defect as #502 (`matrix.rs`), #576 (`composition.rs`) and the four sites of #597. This one was held back from that sweep because it feeds transport.

## Measured first

The issue asked for this before any change, and it is worth having: the eight-nuclide steel below, 151285 grid points, two builds in a single process.

| | |
|---|---|
| points of MT 1 differing between two builds | 73875 of 151285 |
| worst relative difference | 6.4e-16 (2.9x `f64::EPSILON`) |
| worst difference | 3 ULPs |

A direct probe of the per-nuclide contributions summed forward versus reverse differed at 80308 of 151285 points, confirming the sum is genuinely order-sensitive rather than the difference arriving from somewhere else in the path.

So: observable at over half the grid, last-bit in magnitude.

## The fix

`self.nuclides.keys()` collected and sorted before the accumulation loop, mirroring `in_name_order` in `composition.rs`.

`populate_per_nuclide_xs` is deliberately left alone. It writes each nuclide into its own slot with no cross-nuclide accumulation, so its iteration order cannot change a value and sorting there would be noise.

## Re-baselining was not needed

The issue anticipated that transport goldens would move. None did: `cargo test --workspace --exclude yamc-gpu` is **2284 passed, 0 failed**, the single addition over the previous baseline being the new test.

That is not because the change is inert. It is because nothing pins a multi-nuclide macroscopic cross section to the last bit:

- the Rust transport reproducibility tests (`crates/yamc/tests/reproducibility.rs` and friends) use single-nuclide `Li6` materials, where sorting one key is a no-op
- the Python regression suite compares against a reference code at 5% and sigma-band tolerances, which 3 ULPs cannot reach

Worth knowing rather than assuming, so it is recorded here.

## The test, and a trap in writing it

`crates/yamc-materials/tests/macro_xs_reproducibility.rs` builds the same material eight times and compares every value of MT 1, 2 and 102 bit for bit, alongside the unified energy grid.

The composition is the eight nuclides of a stainless steel that `scripts/fetch_test_fixtures.py` carries with full transport sections, so the test runs in CI rather than self-skipping. The full 24-nuclide version stays in `composition_reproducibility.rs`, which needs no nuclear data.

The first version of this test **passed against the unfixed code**. It built one composition and `clone()`d it per build, and `HashMap::clone` copies the hasher, so every build iterated in the same order. It now calls `steel()` fresh per build. Verified in both directions: it fails without the fix and passes with it.

## Verification

- `cargo test --workspace --exclude yamc-gpu --no-fail-fast`: 2284 passed, 0 failed, 15 ignored
- `cargo clippy --workspace --lib --bins --tests --examples -- -D warnings`: clean
- `cargo fmt --check --all`: clean
- new test verified to fail without the fix (73875 of 151285 points differing) and pass with it