### PR TITLE
Bump yani-core to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "yani-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "endf",
  "pyo3",

--- a/crates/yani-python/Cargo.toml
+++ b/crates/yani-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "yani-python"
 # transport converter says nothing about the inventory package. Bump it with
 # `cargo set-version -p yani-python <version>`.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for the transmutation stack: materials, nuclides, chains, irradiation schedules and inventories. Shared by the yamc and yani wheels."


### PR DESCRIPTION
The committed version names the **next** release, and `main` was still carrying `0.12.0` -- the version already on PyPI (uploaded 2026-08-30). Meanwhile `main` holds changes that ship inside the `yani-core` wheel:

- `crates/yani-python/src/read.rs`
- `crates/yamc-nuclide/src/arrow/nuclide_arrow.rs`
- `crates/yamc-nuclide/src/storage/url_cache.rs`
- `crates/nuclear-data-schema/src/lib.rs`

So the number has to move before a `yani-core-0.13.0` tag can ship them. As it stood, `verify-versions` would have refused the release anyway, since 0.12.0 is already on PyPI.

`yamc-python` is deliberately left at `0.9.0`. The two versions move independently, and nothing here says anything about the transport wheel.

Made with `cargo set-version -p yani-python 0.13.0`, which updates the manifest and `Cargo.lock` in one step, per `docs/developer_info.md`.

Follow-up, once this is tagged and published: the `yani` repo pins `yani-core==0.12.0` in its `pyproject.toml` and will need its own PR to move to `0.13.0`.