### PR TITLE
Report primitives: chain scope, covariance coverage, production routes, isomeric branching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "yani-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "endf",
  "pyo3",

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -427,10 +427,17 @@ fn write_provenance(
 /// advertising one subsection while shipping four. An entry whose directory has
 /// gone is dropped rather than left advertising something removed, and a
 /// directory rebuilt for a different library starts over.
+/// `parents` is the set of nuclides the written subsections carry reactions
+/// for, recorded per subsection so a reader can tell what the chain can answer
+/// for before it solves anything. A chain built for one foil's isotopes solves
+/// a different foil to an inventory of nothing, silently, because every
+/// reaction it holds has the wrong parent; without this the only way to find
+/// that out is to notice the decay heat came back as zero.
 fn merge_manifest(
     out: &Path,
     provenance: &Provenance,
     written: &[&str],
+    parents: &[String],
 ) -> Result<(), Box<dyn Error>> {
     let manifest_path = out.join("manifest.json");
     let mut subsections = serde_json::Map::new();
@@ -445,9 +452,13 @@ fn merge_manifest(
         }
     }
     for subsection in written {
+        // Replaced rather than merged with what was there. The subsection's
+        // data was just overwritten, so its scope is whatever this call wrote;
+        // carrying over a previous call's parents would advertise reactions the
+        // directory no longer holds, which is the failure this exists to catch.
         subsections.insert(
             (*subsection).to_string(),
-            serde_json::json!({ "path": subsection }),
+            serde_json::json!({ "path": subsection, "parents": parents }),
         );
     }
     subsections.retain(|_, entry| {
@@ -554,7 +565,19 @@ pub fn convert_transmutation(
         )?;
     }
 
-    merge_manifest(out, provenance, subsections)?;
+    // The nuclides this chain can actually be driven from. A nuclide with no
+    // reactions is reachable as a product but cannot start anything, so it is
+    // not a parent and listing it would let a material through that the chain
+    // has nothing to say about.
+    let parents: Vec<String> = chain
+        .nuclides
+        .iter()
+        .filter(|n| !n.reactions.is_empty())
+        .map(|n| n.name.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    merge_manifest(out, provenance, subsections, &parents)?;
 
     Ok(chain)
 }
@@ -702,6 +725,12 @@ pub fn convert_branching_files(
         &provenance.data_version,
         &provenance.created_utc,
     )?;
-    merge_manifest(out, provenance, &["branching"])?;
+    let parents: Vec<String> = rows
+        .iter()
+        .map(|r| r.nuclide.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    merge_manifest(out, provenance, &["branching"], &parents)?;
     Ok(stats)
 }

--- a/crates/yani-python/Cargo.toml
+++ b/crates/yani-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "yani-python"
 # transport converter says nothing about the inventory package. Bump it with
 # `cargo set-version -p yani-python <version>`.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for the transmutation stack: materials, nuclides, chains, irradiation schedules and inventories. Shared by the yamc and yani wheels."

--- a/crates/yani-python/src/data_uncertainty.rs
+++ b/crates/yani-python/src/data_uncertainty.rs
@@ -179,6 +179,14 @@ pub fn info_to_dict<'py>(py: Python<'py>, info: &Info) -> PyResult<Bound<'py, Py
     }
     d.set_item("rate_fraction_covered", covered)?;
 
+    // The one number that says whether the sigmas above are a spread over the
+    // answer or over a corner of it. `None` for a decay-only schedule, which
+    // drove no production and so has no share to report.
+    d.set_item(
+        "rate_fraction_covered_total",
+        info.rate_fraction_covered_total,
+    )?;
+
     d.set_item("matrices_clipped", info.matrices_clipped)?;
     d.set_item("worst_relative_clip", info.worst_relative_clip)?;
     d.set_item("rates_floored", info.rates_floored)?;

--- a/crates/yani-python/src/transmutation_results.rs
+++ b/crates/yani-python/src/transmutation_results.rs
@@ -677,6 +677,143 @@ impl PyTransmutationResults {
         Some(out.into_any().unbind())
     }
 
+    /// Flux-weighted isomeric branching at one step.
+    ///
+    /// Which state a reaction leaves its product in is energy dependent, so the
+    /// single number describing a spectrum is the branching collapsed against
+    /// it, and that number exists only inside a solve. The chain file carries
+    /// the unweighted ratios, and where the branching overlay supplies the
+    /// split it carries a placeholder instead: on TENDL-2025 the dominant
+    /// tungsten channel reads ``W186 (n,2n) -> W185 1.000000`` and
+    /// ``W186 (n,2n) -> W185_m1 0.000000`` in the file, and the overlay
+    /// replaces both at solve time with roughly the 54/46 that spectrum gives.
+    /// On a foil whose decay heat comes from an isomer, that difference is the
+    /// whole answer.
+    ///
+    /// Only channels landing in more than one final state appear. A channel
+    /// with one product has no branching to report, and listing it at 1.0
+    /// buries the ones that do; ``get_reaction_rates`` has the unnormalised
+    /// edges if the rest is wanted.
+    ///
+    /// This is the number that says whether a disagreement belongs to a cross
+    /// section or to a branching ratio, which are different data and different
+    /// fixes.
+    ///
+    /// Args:
+    ///     material_id: Material ID number.
+    ///     step: Schedule step index, the same index ``get_reaction_rates``
+    ///         takes, which is one less than the composition getters' step.
+    ///
+    /// Returns:
+    ///     dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
+    ///     reaction kind -> [(target, fraction)], fractions summing to one and
+    ///     ordered with the largest first. Empty for a decay-only step, and
+    ///     None if the material or the step is unknown.
+    ///
+    /// Examples:
+    ///     >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
+    ///     {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+    fn get_isomeric_branching(
+        &self,
+        py: Python<'_>,
+        material_id: u32,
+        step: usize,
+    ) -> Option<Py<PyAny>> {
+        let split = self.inner.get_isomeric_branching(material_id, step)?;
+        let out = PyDict::new(py);
+        for (parent, kinds) in &split {
+            let per_kind = PyDict::new(py);
+            for (kind, targets) in kinds {
+                let list = PyList::empty(py);
+                for (target, fraction) in targets {
+                    list.append((target.as_str(), fraction)).unwrap();
+                }
+                per_kind.set_item(kind.as_str(), list).unwrap();
+            }
+            out.set_item(parent.as_str(), per_kind).unwrap();
+        }
+        Some(out.into_any().unbind())
+    }
+
+    /// Every way a product was made over one step, weighted by how much of it
+    /// arrived down each.
+    ///
+    /// Enumerating routes is easy and weighting them is not. Asked what makes
+    /// W187, a chain answers ``Os190(n,a)`` and ``Ir192(n,npa)`` as readily as
+    /// ``W186(n,gamma)``, and nothing in a tungsten foil is osmium. So the walk
+    /// starts from the nuclides the material actually began with, and each
+    /// route is weighted by what its own reactions drove rather than by
+    /// anything read off the chain.
+    ///
+    /// A route is ``reaction_depth`` neutron reactions followed by up to
+    /// ``decay_depth`` decays. Its weight is the atoms it starts from, times
+    /// each reaction step's per-atom production over the step, times the
+    /// branching of every decay it passes through: a route through a 1% branch
+    /// delivers 1% of what the reaction made. Reaction steps carry the step
+    /// duration, so a two-reaction route is in the same units as a one-reaction
+    /// route and comes out smaller by roughly a factor of the fluence, which is
+    /// the honest answer for an irradiation short enough that products barely
+    /// burn.
+    ///
+    /// Args:
+    ///     material_id: Material ID number.
+    ///     product: The nuclide whose production is being explained.
+    ///     step: Schedule step index, as ``get_reaction_rates`` takes it.
+    ///     reaction_depth (int): Neutron reactions a route may use. 1 is what
+    ///         the published pathway tables carry.
+    ///     decay_depth (int): Decays a route may follow after them.
+    ///
+    /// Returns:
+    ///     list[dict] | None: one entry per route, largest share first, each
+    ///     with ``route`` (the string the published tables print, e.g.
+    ///     ``"W186(n,2n)W185_m1(IT)W185"``), ``steps`` (the same thing as
+    ///     ``(parent, kind, target)`` triples), ``share`` (of this product's
+    ///     production, summing to one) and ``production`` (atoms per barn-cm,
+    ///     before normalising, so that 100% of almost nothing is
+    ///     distinguishable from 100% of the inventory). Empty when nothing in
+    ///     this material makes the product, which is an answer. None if the
+    ///     material, the step, or the chain is unknown.
+    ///
+    /// Examples:
+    ///     >>> for r in results.get_production_routes(1, "W185", 0):
+    ///     ...     print(f"{r['route']:<32} {r['share']:.1%}")
+    ///     W186(n,2n)W185_m1(IT)W185        53.0%
+    ///     W186(n,2n)W185                   46.8%
+    #[pyo3(signature = (material_id, product, step, reaction_depth=1, decay_depth=3))]
+    fn get_production_routes(
+        &self,
+        py: Python<'_>,
+        material_id: u32,
+        product: &str,
+        step: usize,
+        reaction_depth: usize,
+        decay_depth: usize,
+    ) -> Option<Py<PyAny>> {
+        let routes = self.inner.get_production_routes(
+            material_id,
+            product,
+            step,
+            reaction_depth,
+            decay_depth,
+        )?;
+        let out = PyList::empty(py);
+        for r in &routes {
+            let d = PyDict::new(py);
+            d.set_item("route", r.text()).unwrap();
+            let steps = PyList::empty(py);
+            for (parent, kind, target) in &r.steps {
+                steps
+                    .append((parent.as_str(), kind.as_str(), target.as_str()))
+                    .unwrap();
+            }
+            d.set_item("steps", steps).unwrap();
+            d.set_item("share", r.share).unwrap();
+            d.set_item("production", r.production).unwrap();
+            out.append(d).unwrap();
+        }
+        Some(out.into_any().unbind())
+    }
+
     /// List of material IDs that were transmuted.
     #[getter]
     fn material_ids(&self) -> Vec<u32> {

--- a/crates/yani-python/src/transmutation_results.rs
+++ b/crates/yani-python/src/transmutation_results.rs
@@ -479,6 +479,13 @@ impl PyTransmutationResults {
     ///
     /// - ``perturbed`` / ``no_covariance_data``: which nuclides had usable
     ///   MF=33 covariance and which had none.
+    /// - ``rate_fraction_covered_total``: the share of the production this run
+    ///   drove that a covariance actually spans, weighted by rate and by parent
+    ///   density. Read this before any sigma here. It is a different and much
+    ///   sharper question than how many nuclides carry MF=33: an evaluation can
+    ///   state covariance for every isotope in the material and none for the
+    ///   channel making the product of interest, and the count then reads as
+    ///   full coverage while the ensemble perturbs almost nothing.
     /// - ``rate_fraction_covered``: per nuclide and channel, the share of the
     ///   reaction rate the covariance grid actually spans. Below one means part
     ///   of the rate carries no stated uncertainty and the sigma is diluted.

--- a/crates/yani-transmute/src/covariance_fold.rs
+++ b/crates/yani-transmute/src/covariance_fold.rs
@@ -117,9 +117,40 @@ pub struct Coverage {
     /// gives no covariance for, so the relative uncertainty is diluted by
     /// exactly that much.
     pub rate_fraction_covered: BTreeMap<(String, String), f64>,
+    /// Production this spectrum drove through a channel a covariance spans, and
+    /// the production it drove in total. Both are per barn-cm per second, and
+    /// both are weighted by the parent's own density, so a channel on a trace
+    /// isotope counts for what it actually made.
+    ///
+    /// Kept as two sums rather than as their ratio because sums merge and a
+    /// ratio does not: the fold runs per nuclide and a schedule can name more
+    /// than one spectrum, and each part adds its own share without having to
+    /// know how many parts there are. [`Coverage::rate_fraction_total`]
+    /// divides them.
+    pub covered_production: f64,
+    pub total_production: f64,
 }
 
 impl Coverage {
+    /// Share of the production this run drove that carries a stated covariance.
+    ///
+    /// The number to read before any sigma from this fold. Counting nuclides
+    /// with MF=33 answers a different and much weaker question: an evaluation
+    /// can carry covariance for every isotope in the material and state none of
+    /// it for the channel that makes the product of interest, which leaves the
+    /// count reading as full coverage while the ensemble perturbs almost
+    /// nothing. Tungsten is the case that shows it, where two major libraries
+    /// state covariance for all five natural isotopes, give it for `(n,3n)` and
+    /// `(n,gamma)`, and give none for the `(n,2n)` that makes 98% of the decay
+    /// heat.
+    ///
+    /// `None` when this run drove no production at all, which is a decay-only
+    /// schedule and has no fraction to report rather than a fraction of zero.
+    pub fn rate_fraction_total(&self) -> Option<f64> {
+        (self.total_production > 0.0)
+            .then(|| (self.covered_production / self.total_production).clamp(0.0, 1.0))
+    }
+
     /// Fold one nuclide's report into this one.
     ///
     /// Every field is order-free: the sets union, the counters sum, and
@@ -141,6 +172,8 @@ impl Coverage {
                 .and_modify(|f| *f = f.min(fraction))
                 .or_insert(fraction);
         }
+        self.covered_production += other.covered_production;
+        self.total_production += other.total_production;
     }
 
     /// Whether anything at all was skipped or missing.
@@ -524,7 +557,84 @@ pub fn fold_rate_covariance(
         }
     }
 
+    // How much of the production this spectrum drove is covered, weighted by
+    // rate and by the parent's own density. Done here rather than per nuclide
+    // because it is a property of the material: the per-nuclide fold knows its
+    // own rates but not how many atoms of it there are, and a channel on a
+    // 0.1%-abundance isotope must not count the same as one on the bulk.
+    //
+    // Weighted by rate rather than counted per channel for the same reason the
+    // per-channel fraction exists: a channel with no covariance costs nothing
+    // if nothing went through it.
+    let densities = material.get_atoms_per_barn_cm().unwrap_or_default();
+    for (nuclide, kinds) in rates {
+        let density = densities.get(nuclide).copied().unwrap_or(0.0);
+        if density <= 0.0 {
+            continue;
+        }
+        for (kind, rate) in kinds {
+            let production = density * rate;
+            coverage.total_production += production;
+            let fraction = coverage
+                .rate_fraction_covered
+                .get(&(nuclide.clone(), kind.clone()))
+                .copied()
+                .unwrap_or(0.0);
+            coverage.covered_production += production * fraction;
+        }
+    }
+
     (out, coverage)
+}
+
+#[cfg(test)]
+mod coverage_total_tests {
+    use super::*;
+
+    /// Two nuclides, one covered and one not, weighted by what each produced.
+    ///
+    /// The point of the rate weighting: counting nuclides would call this half
+    /// covered, and half the production went through the channel with nothing
+    /// stated about it.
+    #[test]
+    fn the_total_is_weighted_by_production_and_not_by_nuclide_count() {
+        let mut a = Coverage {
+            covered_production: 3.0,
+            total_production: 4.0,
+            ..Default::default()
+        };
+        let b = Coverage {
+            covered_production: 0.0,
+            total_production: 4.0,
+            ..Default::default()
+        };
+        a.absorb(b);
+        // Sums merge; the ratio is taken once at the end over both.
+        assert_eq!(a.covered_production, 3.0);
+        assert_eq!(a.total_production, 8.0);
+        assert_eq!(a.rate_fraction_total(), Some(0.375));
+    }
+
+    /// A decay-only schedule drove no production, so there is no share to
+    /// report. Zero would be the wrong answer: it reads as "nothing is
+    /// covered", which is a statement about the data rather than about there
+    /// being nothing to cover.
+    #[test]
+    fn no_production_reports_no_fraction_rather_than_zero() {
+        assert_eq!(Coverage::default().rate_fraction_total(), None);
+    }
+
+    /// Floating point can put the ratio a hair over one when every channel is
+    /// fully covered; a coverage of 100.0000001% is not a thing to print.
+    #[test]
+    fn full_coverage_cannot_exceed_one() {
+        let c = Coverage {
+            covered_production: 1.0 + f64::EPSILON,
+            total_production: 1.0,
+            ..Default::default()
+        };
+        assert_eq!(c.rate_fraction_total(), Some(1.0));
+    }
 }
 
 #[cfg(test)]

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -222,6 +222,58 @@ pub fn transmute_material_shielded(
         }
     }
 
+    // A chain that can drive none of this material's nuclides. Every reaction
+    // it holds has a parent the material does not contain, so the irradiation
+    // produces nothing and the schedule solves to the composition it started
+    // with. That is a silent zero: no step fails, no rate is negative, and the
+    // mistake surfaces only as a decay heat of exactly zero much later, which
+    // names neither the chain nor what it was built for.
+    //
+    // It happens whenever chains are scoped per material and two of them share
+    // a path, since the second conversion replaces the first and leaves a
+    // directory whose name still says otherwise. The manifest now records the
+    // parents each subsection covers; this is the check that acts on them.
+    //
+    // Stronger than the membership check in `preload_activation_data`, which
+    // asks whether any of the material's nuclides appear in the chain at all.
+    // Appearing is not enough: a nuclide can be in the chain purely as somebody
+    // else's product, carrying no reactions of its own, and a material made
+    // only of those is exactly as undrivable as one that is absent. The two
+    // guards are kept separate because that one must also cover the decay-only
+    // path, where having no reactions is not a fault.
+    //
+    // Only when something is actually irradiated. A decay-only schedule drives
+    // no reactions by construction, and a chain holding none of this material's
+    // parents is the right chain for it.
+    if steps.iter().any(|st| st.irradiation.is_some()) {
+        let has_reactions =
+            |name: &String| chain.get(name).is_some_and(|cn| !cn.reactions.is_empty());
+        // Already sorted by `get_nuclides`, which the message relies on.
+        let held = material.get_nuclides();
+        if !held.iter().any(has_reactions) {
+            let mut parents: Vec<&str> = chain
+                .values()
+                .filter(|cn| !cn.reactions.is_empty())
+                .map(|cn| cn.name.as_str())
+                .collect();
+            parents.sort_unstable();
+            let covers = if parents.is_empty() {
+                "nothing".to_string()
+            } else {
+                parents.join(" ")
+            };
+            return Err(format!(
+                "this chain drives none of the material's nuclides, so the irradiation would \
+                 produce nothing and every step would return the starting composition.\n  \
+                 material holds: {}\n  chain has reactions for: {covers}\n\
+                 A chain is scoped to the nuclides it was built from, so build one for this \
+                 material rather than reusing one built for another.",
+                held.join(" "),
+            )
+            .into());
+        }
+    }
+
     // Load nuclear data for all chain nuclides (not just initial composition)
     // so reaction rates can be computed for daughter products. Into the
     // CALLER's material, so a second call on it finds the data already there.

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -390,6 +390,10 @@ pub fn transmute_material_shielded(
     // been shielded is the case #564 is about.
     results.shielding_info = Some(shielding_info);
 
+    // Kept so routes can be derived from the same topology the solve used,
+    // rather than from whatever a second load of the chain path returns.
+    results.chain = Some(Arc::clone(&chain));
+
     Ok(results)
 }
 
@@ -882,24 +886,16 @@ fn merge_coverage(
     into: &mut crate::covariance_fold::Coverage,
     from: crate::covariance_fold::Coverage,
 ) {
-    into.covered.extend(from.covered);
-    into.skipped_cross_material += from.skipped_cross_material;
-    into.skipped_nc += from.skipped_nc;
-    into.malformed += from.malformed;
-    for (lb, n) in from.unsupported_layouts {
-        *into.unsupported_layouts.entry(lb).or_insert(0) += n;
-    }
-    for (key, fraction) in from.rate_fraction_covered {
-        into.rate_fraction_covered
-            .entry(key)
-            .and_modify(|f| *f = f.min(fraction))
-            .or_insert(fraction);
-    }
-    // A nuclide covered under any spectrum is covered; `without_data` is
-    // resolved against that at the end rather than accumulated blindly.
-    for name in from.without_data {
-        into.without_data.insert(name);
-    }
+    // Every field merges the way `absorb` merges it, and delegating is what
+    // keeps that true: this function and `absorb` used to carry two copies of
+    // the same rules, and a field added to one of them was silently dropped by
+    // the other.
+    into.absorb(from);
+    // The one rule that is this function's own. `absorb` runs per nuclide
+    // within one spectrum, where "no data" is final. Across spectra it is not:
+    // a nuclide whose covariance was unusable against one spectrum and usable
+    // against another has data, so the two sets are resolved here rather than
+    // accumulated blindly.
     let covered = into.covered.clone();
     into.without_data.retain(|n| !covered.contains(n));
 }

--- a/crates/yani-transmute/src/results.rs
+++ b/crates/yani-transmute/src/results.rs
@@ -57,6 +57,68 @@ pub struct TransmutationResults {
     /// `None` and "shielded, but nothing moved" are different claims, and only
     /// this tells them apart.
     pub shielding_info: Option<crate::self_shielding::ShieldingInfo>,
+
+    /// The chain the solve was driven with, for deriving routes afterwards.
+    ///
+    /// An `Arc` clone of the one already held, so keeping it costs a refcount
+    /// rather than a copy. It is here because a route is a statement about the
+    /// topology AND about the rates, and without it every caller that wants
+    /// [`Self::get_production_routes`] has to load the chain a second time and
+    /// hope it is the same one the solve used. That is not a hypothetical: a
+    /// chain is loaded from a path in a global, and the path can have been
+    /// repointed between the solve and the question.
+    ///
+    /// `None` on results built by hand, which is what the tests do.
+    pub chain: Option<std::sync::Arc<HashMap<String, yani::ChainNuclide>>>,
+}
+
+/// Flux-weighted isomeric branching: `parent -> kind -> [(target, fraction)]`.
+///
+/// Named for the same reason [`yani::EdgeRates`] is: it is three levels deep
+/// and appears in a signature, a return and a binding, and spelling it out
+/// three times is three chances to spell it differently.
+pub type IsomericBranching = HashMap<String, HashMap<String, Vec<(String, f64)>>>;
+
+/// One way a product is made: the steps, and the share of it arriving this way.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductionRoute {
+    /// `(parent, kind, target)` per step, the neutron reactions first and then
+    /// the decays that carry the product on. `kind` is the chain's own
+    /// spelling, so `"(n,2n)"` for a reaction and `"it"` or `"beta-"` for a
+    /// decay.
+    pub steps: Vec<(String, String, String)>,
+    /// Share of this product's production over the step that arrived down this
+    /// route, in `[0, 1]` and summing to one across the routes returned.
+    pub share: f64,
+    /// Atoms of the product this route made per barn-cm over the step, before
+    /// normalising. Kept because a share of 100% of almost nothing and a share
+    /// of 100% of the whole inventory read the same otherwise.
+    pub production: f64,
+}
+
+impl ProductionRoute {
+    /// The route as the published pathway tables write it, e.g.
+    /// `"W186(n,2n)W185_m1(IT)W185"`.
+    ///
+    /// Decay kinds are upper-cased in that convention and reaction kinds are
+    /// not, which is the only reason this is not `format!` at the call site.
+    pub fn text(&self) -> String {
+        let mut out = String::new();
+        for (i, (parent, kind, target)) in self.steps.iter().enumerate() {
+            if i == 0 {
+                out.push_str(parent);
+            }
+            if kind.starts_with('(') {
+                out.push_str(kind);
+            } else {
+                out.push('(');
+                out.push_str(&kind.to_uppercase());
+                out.push(')');
+            }
+            out.push_str(target);
+        }
+        out
+    }
 }
 
 impl TransmutationResults {
@@ -79,6 +141,7 @@ impl TransmutationResults {
             uncertainty: HashMap::new(),
             uncertainty_info: None,
             shielding_info: None,
+            chain: None,
         }
     }
 
@@ -119,6 +182,232 @@ impl TransmutationResults {
     /// `Some(&empty)` for a decay-only step.
     pub fn get_reaction_rates(&self, material_id: u32, step: usize) -> Option<&EdgeRates> {
         self.reaction_rates.get(&material_id)?.get(step)
+    }
+
+    /// Flux-weighted isomeric branching for one material over one step:
+    /// `parent -> kind -> [(target, fraction)]`, fractions summing to one.
+    ///
+    /// Which state a reaction leaves its product in is energy dependent, so the
+    /// one number describing a given spectrum is the branching collapsed
+    /// against it, and that number exists only inside a solve. The chain file
+    /// carries the unweighted ratios, and where the overlay supplies the split
+    /// it carries a placeholder: on TENDL-2025 the dominant tungsten channel is
+    /// `W186 (n,2n) -> W185 1.000000` and `W186 (n,2n) -> W185_m1 0.000000` in
+    /// the file, and the overlay replaces both at solve time with roughly the
+    /// 54/46 that spectrum actually gives. Reading the file answers a different
+    /// question from reading this, and on a foil whose decay heat comes from an
+    /// isomer the difference is the whole answer.
+    ///
+    /// Only channels landing in more than one final state are returned: a
+    /// channel with a single product has no branching to report, and listing it
+    /// at 1.0 buries the ones that do. [`Self::get_reaction_rates`] has the
+    /// unnormalised edges if the rest is wanted.
+    ///
+    /// This is what says whether a disagreement belongs to a cross section or
+    /// to a branching ratio, which are different data and different fixes.
+    ///
+    /// `step` indexes [`Self::timesteps`], exactly as
+    /// [`Self::get_reaction_rates`] does. `None` when the material or the step
+    /// is unknown, and empty for a decay-only step, which splits nothing.
+    pub fn get_isomeric_branching(
+        &self,
+        material_id: u32,
+        step: usize,
+    ) -> Option<IsomericBranching> {
+        let edges = self.get_reaction_rates(material_id, step)?;
+        let mut out: IsomericBranching = HashMap::new();
+        for (parent, kinds) in edges {
+            for (kind, targets) in kinds {
+                // A channel naming no single product (fission) has no split to
+                // report: its products come from the yields, not from an edge.
+                let named: Vec<(&String, f64)> = targets
+                    .iter()
+                    .filter_map(|(t, r)| t.as_ref().map(|t| (t, *r)))
+                    .collect();
+                if named.len() < 2 {
+                    continue;
+                }
+                let total: f64 = named.iter().map(|(_, r)| r).sum();
+                if total <= 0.0 {
+                    continue;
+                }
+                let mut split: Vec<(String, f64)> = named
+                    .into_iter()
+                    .map(|(t, r)| (t.clone(), r / total))
+                    .collect();
+                // Largest share first, so the state the channel mostly makes is
+                // read first; ties by name, so the order is stable run to run.
+                split.sort_by(|a, b| {
+                    b.1.partial_cmp(&a.1)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.0.cmp(&b.0))
+                });
+                out.entry(parent.clone())
+                    .or_default()
+                    .insert(kind.clone(), split);
+            }
+        }
+        Some(out)
+    }
+
+    /// Every way `product` was made over one step, weighted by how much of it
+    /// arrived down each.
+    ///
+    /// Enumerating routes is easy and weighting them is not: the chain will
+    /// happily say that W187 is made by `Os190(n,a)` and `Ir192(n,npa)` as
+    /// readily as by `W186(n,gamma)`, and nothing in a tungsten foil is osmium.
+    /// So the walk starts from the nuclides the material actually began with,
+    /// and each route is weighted by what its own reactions drove.
+    ///
+    /// A route is `reaction_depth` neutron reactions and then any number of
+    /// decays, up to `decay_depth`. Decays are followed regardless of depth
+    /// budget because a decay is not a fluence-dependent step: it moves what a
+    /// reaction already made rather than making more of it.
+    ///
+    /// The weight of a route is the atoms of the nuclide it starts from, times
+    /// each reaction step's per-atom production over the step, times the
+    /// branching of each decay it passes through. Reaction steps carry the step
+    /// duration, so a two-reaction route is in the same units as a one-reaction
+    /// route and is smaller by roughly a factor of the fluence, which is the
+    /// honest answer for irradiations short enough that the products barely
+    /// burn. Decay branchings are included because a route through a 1% branch
+    /// delivers 1% of what the reaction made.
+    ///
+    /// Routes are returned largest share first. `None` when the material, the
+    /// step or the chain is unknown; empty when nothing in this material makes
+    /// `product` at all, which is a real answer and not a failure.
+    ///
+    /// `step` indexes [`Self::timesteps`], as [`Self::get_reaction_rates`] does.
+    pub fn get_production_routes(
+        &self,
+        material_id: u32,
+        product: &str,
+        step: usize,
+        reaction_depth: usize,
+        decay_depth: usize,
+    ) -> Option<Vec<ProductionRoute>> {
+        let chain = self.chain.as_ref()?;
+        let edges = self.get_reaction_rates(material_id, step)?;
+        let dt = self.timesteps.get(step).copied().unwrap_or(0.0);
+        let densities = self
+            .get_material(material_id, 0)?
+            .get_atoms_per_barn_cm()
+            .unwrap_or_default();
+
+        // The rate of one production edge, per atom of its parent, over this
+        // step. `None` when the solve drove no such edge, which prunes the walk
+        // to what actually happened rather than to what the chain permits.
+        let edge_rate = |parent: &str, kind: &str, target: &str| -> Option<f64> {
+            edges
+                .get(parent)?
+                .get(kind)?
+                .iter()
+                .find(|(t, _)| t.as_deref() == Some(target))
+                .map(|(_, r)| *r)
+        };
+
+        /// One partly-walked route: where it has got to, how it got there, what
+        /// it carries, and how much of its reaction budget it has spent.
+        struct Partial {
+            here: String,
+            steps: Vec<(String, String, String)>,
+            weight: f64,
+            reactions_used: usize,
+        }
+
+        let mut found: Vec<ProductionRoute> = Vec::new();
+        let mut stack: Vec<Partial> = densities
+            .iter()
+            .filter(|(_, &n)| n > 0.0)
+            .map(|(name, &n)| Partial {
+                here: name.clone(),
+                steps: Vec::new(),
+                weight: n,
+                reactions_used: 0,
+            })
+            .collect();
+
+        while let Some(Partial {
+            here,
+            steps: path,
+            weight,
+            reactions_used: used,
+        }) = stack.pop()
+        {
+            if !path.is_empty() && here == product {
+                found.push(ProductionRoute {
+                    steps: path.clone(),
+                    share: 0.0,
+                    production: weight,
+                });
+                // Not returned early: a route can pass through its own product
+                // on the way to making more of it, and stopping here would drop
+                // the longer one.
+            }
+            if path.len() >= reaction_depth + decay_depth {
+                continue;
+            }
+            let Some(node) = chain.get(&here) else {
+                continue;
+            };
+            if used < reaction_depth {
+                for rx in &node.reactions {
+                    let Some(target) = rx.target.as_deref() else {
+                        continue;
+                    };
+                    let Some(rate) = edge_rate(&here, &rx.kind, target) else {
+                        continue;
+                    };
+                    if rate <= 0.0 {
+                        continue;
+                    }
+                    let mut next = path.clone();
+                    next.push((here.clone(), rx.kind.clone(), target.to_string()));
+                    stack.push(Partial {
+                        here: target.to_string(),
+                        steps: next,
+                        weight: weight * rate * dt,
+                        reactions_used: used + 1,
+                    });
+                }
+            }
+            // Decays are followed only after something has been made: a route
+            // is a production route, and a nuclide the material started with
+            // decaying is not production.
+            if !path.is_empty() {
+                for dk in &node.decays {
+                    let Some(target) = dk.target.as_deref() else {
+                        continue;
+                    };
+                    if dk.branching <= 0.0 {
+                        continue;
+                    }
+                    let mut next = path.clone();
+                    next.push((here.clone(), dk.kind.clone(), target.to_string()));
+                    stack.push(Partial {
+                        here: target.to_string(),
+                        steps: next,
+                        weight: weight * dk.branching,
+                        reactions_used: used,
+                    });
+                }
+            }
+        }
+
+        let total: f64 = found.iter().map(|r| r.production).sum();
+        if total > 0.0 {
+            for r in &mut found {
+                r.share = r.production / total;
+            }
+        }
+        found.sort_by(|a, b| {
+            b.share
+                .partial_cmp(&a.share)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.steps.len().cmp(&b.steps.len()))
+                .then_with(|| a.text().cmp(&b.text()))
+        });
+        Some(found)
     }
 
     /// Get material composition at a specific timestep.
@@ -268,6 +557,103 @@ mod tests {
         m
     }
 
+    /// W185 is made two ways: straight off the (n,2n), and via the isomer that
+    /// then decays to it. Both must be found, and weighted by what each drove.
+    #[test]
+    fn production_routes_find_both_the_direct_and_the_isomeric_path() {
+        use std::sync::Arc;
+        let nuclide =
+            |name: &str, reactions: Vec<yani::ChainReaction>, decays: Vec<yani::ChainReaction>| {
+                yani::ChainNuclide {
+                    name: name.to_string(),
+                    half_life: None,
+                    half_life_uncertainty: None,
+                    decay_energy: 0.0,
+                    decay_energy_uncertainty: None,
+                    reactions,
+                    decays,
+                    fission_yields: None,
+                    sources: Vec::new(),
+                }
+            };
+        let rx = |kind: &str, target: &str| yani::ChainReaction {
+            kind: kind.to_string(),
+            target: Some(target.to_string()),
+            branching: 1.0,
+            q_value: Some(0.0),
+        };
+
+        let chain = Arc::new(HashMap::from([
+            (
+                "W186".to_string(),
+                nuclide(
+                    "W186",
+                    vec![rx("(n,2n)", "W185"), rx("(n,2n)", "W185_m1")],
+                    vec![],
+                ),
+            ),
+            (
+                "W185_m1".to_string(),
+                nuclide("W185_m1", vec![], vec![rx("it", "W185")]),
+            ),
+            ("W185".to_string(), nuclide("W185", vec![], vec![])),
+        ]));
+
+        let mut m = Material::new(
+            HashMap::from([("W186".to_string(), 1.0)]),
+            "atom",
+            "g/cm3",
+            Some(19.3),
+        )
+        .expect("tungsten");
+        m.name = Some("foil".to_string());
+
+        let mut results = TransmutationResults::new(vec![300.0], vec![1.0e10]);
+        results.add_initial(7, m);
+        let mut irradiation = EdgeRates::new();
+        irradiation.insert(
+            "W186".to_string(),
+            HashMap::from([(
+                "(n,2n)".to_string(),
+                vec![
+                    (Some("W185".to_string()), 1.0e-12),
+                    (Some("W185_m1".to_string()), 3.0e-12),
+                ],
+            )]),
+        );
+        results.add_step_rates(7, irradiation);
+        results.add_step(7, material("after"));
+        results.chain = Some(chain);
+
+        let routes = results
+            .get_production_routes(7, "W185", 0, 1, 3)
+            .expect("routes");
+        let text: Vec<String> = routes.iter().map(|r| r.text()).collect();
+        assert_eq!(
+            text,
+            vec!["W186(n,2n)W185_m1(IT)W185", "W186(n,2n)W185"],
+            "largest share first, and the decay rendered as the tables write it"
+        );
+        // 3:1 in the rates, and the IT branch carries all of its share on.
+        assert!((routes[0].share - 0.75).abs() < 1e-12);
+        assert!((routes[1].share - 0.25).abs() < 1e-12);
+    }
+
+    /// A product nothing in this material makes has no routes, which is an
+    /// answer rather than a failure.
+    #[test]
+    fn production_routes_are_empty_for_an_unreachable_product() {
+        let mut results = TransmutationResults::new(vec![300.0], vec![1.0e10]);
+        results.add_initial(7, material("initial"));
+        results.add_step_rates(7, EdgeRates::new());
+        results.add_step(7, material("after"));
+        results.chain = Some(std::sync::Arc::new(HashMap::new()));
+        assert!(results
+            .get_production_routes(7, "Pu239", 0, 1, 3)
+            .expect("a known material and step")
+            .is_empty());
+    }
+
     /// The initial composition sits at index 0 and is not a step, so the
     /// per-step view has to skip it or every step is off by one.
     #[test]
@@ -296,6 +682,62 @@ mod tests {
         let mut results = TransmutationResults::new(Vec::new(), Vec::new());
         results.add_initial(7, material("initial"));
         assert!(results.step_materials(7).is_empty());
+    }
+
+    /// A channel that splits is reported as fractions; one that does not is
+    /// left out entirely rather than reported at 1.0.
+    #[test]
+    fn isomeric_branching_normalises_splits_and_omits_single_product_channels() {
+        let mut results = TransmutationResults::new(vec![1.0], vec![1.0e14]);
+        results.add_initial(7, material("initial"));
+
+        let mut irradiation = EdgeRates::new();
+        irradiation.insert(
+            "W186".to_string(),
+            HashMap::from([
+                // Splits: 3 to the ground state and 1 to the isomer.
+                (
+                    "(n,2n)".to_string(),
+                    vec![
+                        (Some("W185".to_string()), 3.0e-12),
+                        (Some("W185_m1".to_string()), 1.0e-12),
+                    ],
+                ),
+                // Does not split, so it has no branching to report.
+                (
+                    "(n,gamma)".to_string(),
+                    vec![(Some("W187".to_string()), 5.0e-13)],
+                ),
+            ]),
+        );
+        results.add_step_rates(7, irradiation);
+        results.add_step(7, material("after"));
+
+        let split = results.get_isomeric_branching(7, 0).expect("step 0");
+        let w186 = &split["W186"];
+        assert!(
+            !w186.contains_key("(n,gamma)"),
+            "a channel with one product has no branching to report"
+        );
+        // Largest share first, so the state the channel mostly makes leads.
+        assert_eq!(w186["(n,2n)"][0].0, "W185");
+        assert!((w186["(n,2n)"][0].1 - 0.75).abs() < 1e-12);
+        assert_eq!(w186["(n,2n)"][1].0, "W185_m1");
+        assert!((w186["(n,2n)"][1].1 - 0.25).abs() < 1e-12);
+    }
+
+    /// A decay-only step splits nothing, and says so rather than being absent.
+    #[test]
+    fn isomeric_branching_is_empty_for_a_decay_only_step() {
+        let mut results = TransmutationResults::new(vec![1.0], vec![0.0]);
+        results.add_initial(7, material("initial"));
+        results.add_step_rates(7, EdgeRates::new());
+        results.add_step(7, material("after"));
+        assert!(results
+            .get_isomeric_branching(7, 0)
+            .expect("step 0")
+            .is_empty());
+        assert!(results.get_isomeric_branching(7, 9).is_none());
     }
 
     /// `get_reaction_rates` indexes the schedule steps, one less than the

--- a/crates/yani-transmute/src/uncertainty.rs
+++ b/crates/yani-transmute/src/uncertainty.rs
@@ -172,6 +172,16 @@ pub struct Info {
     /// spans. Below one means part of the rate carries no stated uncertainty
     /// and the sigma is diluted accordingly.
     pub rate_fraction_covered: BTreeMap<(String, String), f64>,
+    /// Share of the production this run drove that carries a stated covariance,
+    /// weighted by rate and by parent density, or `None` for a decay-only
+    /// schedule that drove none.
+    ///
+    /// The number to read before any sigma here, and not the same question as
+    /// how many nuclides carry MF=33: an evaluation can state covariance for
+    /// every isotope in the material and none of it for the channel making the
+    /// product of interest, which leaves the count reading as full coverage
+    /// while the ensemble perturbs almost nothing.
+    pub rate_fraction_covered_total: Option<f64>,
     /// Covariance matrices that were not positive semi-definite as evaluated,
     /// and the worst repair that had to be made.
     pub matrices_clipped: usize,
@@ -208,6 +218,7 @@ impl Info {
             unsupported_layouts: coverage.unsupported_layouts.clone(),
             malformed_blocks: coverage.malformed,
             rate_fraction_covered: coverage.rate_fraction_covered.clone(),
+            rate_fraction_covered_total: coverage.rate_fraction_total(),
             matrices_clipped: clipping.matrices_clipped,
             worst_relative_clip: clipping.worst_relative_clip,
             not_perturbed: [

--- a/crates/yani-transmute/tests/chain_scope.rs
+++ b/crates/yani-transmute/tests/chain_scope.rs
@@ -1,0 +1,127 @@
+//! A chain that drives none of the material's nuclides is refused.
+//!
+//! Chains are routinely scoped to the nuclides they were built from, because
+//! walking a whole library to activate one foil is wasted work. Scoping them
+//! makes them substitutable by mistake: two conversions sharing an output path
+//! leave the second one's chain behind under a name that still says the first,
+//! and the material that name refers to then solves against reactions whose
+//! parents it does not contain.
+//!
+//! Nothing about that fails. Every step runs, no rate is negative, and the
+//! composition comes back exactly as it went in, so the mistake is a decay heat
+//! of precisely zero discovered much later with nothing to point at.
+//!
+//! Needs no nuclear data for the refusal case: it is checked before any cross
+//! section is read.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use yamc_materials::Material;
+use yani_transmute::{transmute_material, MultigroupSpectrum, TransmuteStep};
+
+/// A chain that can be driven from `parent` and from nothing else.
+///
+/// Built here rather than loaded, because the point is what the chain does NOT
+/// contain and a published chain contains almost everything. `Fe57` is present
+/// as a product so the chain is not trivially empty, and carries no reactions
+/// of its own, which is what makes it a product rather than a parent.
+fn chain_driven_by(parent: &str) -> Arc<HashMap<String, yani::ChainNuclide>> {
+    let nuclide = |name: &str, reactions: Vec<yani::ChainReaction>| yani::ChainNuclide {
+        name: name.to_string(),
+        half_life: None,
+        half_life_uncertainty: None,
+        decay_energy: 0.0,
+        decay_energy_uncertainty: None,
+        reactions,
+        decays: Vec::new(),
+        fission_yields: None,
+        sources: Vec::new(),
+    };
+    let capture = yani::ChainReaction {
+        kind: "(n,gamma)".to_string(),
+        target: Some("Fe57".to_string()),
+        branching: 1.0,
+        q_value: Some(0.0),
+    };
+    Arc::new(HashMap::from([
+        (parent.to_string(), nuclide(parent, vec![capture])),
+        ("Fe57".to_string(), nuclide("Fe57", Vec::new())),
+    ]))
+}
+
+fn material(nuclide: &str, density: f64) -> Material {
+    let mut m = Material::new(
+        HashMap::from([(nuclide.to_string(), 1.0)]),
+        "atom",
+        "sum",
+        None,
+    )
+    .expect("material");
+    m.density = Some(density);
+    m.set_temperature("294");
+    m
+}
+
+fn spectrum() -> MultigroupSpectrum {
+    MultigroupSpectrum {
+        boundaries: vec![1.0e-5, 1.0e6, 2.0e7],
+        masses: vec![0.5, 0.5],
+        relative_std_dev: None,
+    }
+}
+
+fn run(mut m: Material, driver: &str, irradiation: Option<(usize, f64)>) -> Result<(), String> {
+    let steps = vec![TransmuteStep {
+        dt: 3600.0,
+        irradiation,
+    }];
+    transmute_material(
+        &mut m,
+        &[spectrum()],
+        &steps,
+        chain_driven_by(driver),
+        &Default::default(),
+        Default::default(),
+        None,
+    )
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+#[test]
+fn a_chain_with_no_parent_in_the_material_is_refused_rather_than_solving_to_zero() {
+    // Fe57 IS in this chain, as the product of Fe56 capture, and carries no
+    // reactions of its own. So the older membership check passes it and there
+    // is still nothing here to drive: this is the gap between "appears in the
+    // chain" and "can be driven from".
+    let err = run(material("Fe57", 7.87), "Fe56", Some((0, 1.0e14)))
+        .expect_err("a chain that drives nothing must be refused");
+    assert!(
+        err.contains("drives none of the material's nuclides"),
+        "the error must say what is wrong: {err}"
+    );
+    // Both halves have to be named. Which chain was loaded is exactly what the
+    // silent-zero version of this could not tell anyone.
+    assert!(
+        err.contains("Fe57"),
+        "must name what the material holds: {err}"
+    );
+    assert!(
+        err.contains("chain has reactions for"),
+        "must name what the chain covers: {err}"
+    );
+}
+
+#[test]
+fn a_decay_only_schedule_is_allowed_against_any_chain() {
+    // Nothing is irradiated, so no reaction was ever going to be driven and a
+    // chain that cannot drive this material is the right chain for it. Refusing
+    // here would break every cooldown of an already-activated inventory.
+    run(material("Fe57", 7.87), "Fe56", None).expect("a decay-only schedule needs no parents");
+}
+
+#[test]
+fn a_chain_that_does_drive_the_material_still_runs() {
+    run(material("Fe56", 7.87), "Fe56", Some((0, 1.0e14))).expect("iron against an iron chain");
+}

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -4469,6 +4469,13 @@ class TransmutationResults:
         
         - ``perturbed`` / ``no_covariance_data``: which nuclides had usable
           MF=33 covariance and which had none.
+        - ``rate_fraction_covered_total``: the share of the production this run
+          drove that a covariance actually spans, weighted by rate and by parent
+          density. Read this before any sigma here. It is a different and much
+          sharper question than how many nuclides carry MF=33: an evaluation can
+          state covariance for every isotope in the material and none for the
+          channel making the product of interest, and the count then reads as
+          full coverage while the ensemble perturbs almost nothing.
         - ``rate_fraction_covered``: per nuclide and channel, the share of the
           reaction rate the covariance grid actually spans. Below one means part
           of the rate carries no stated uncertainty and the sigma is diluted.
@@ -4790,6 +4797,92 @@ class TransmutationResults:
             ...     for target, rate in edges
             ...     if target == "Mn56"
             ... ]
+        """
+    def get_isomeric_branching(self, material_id: builtins.int, step: builtins.int) -> typing.Optional[typing.Any]:
+        r"""
+        Flux-weighted isomeric branching at one step.
+        
+        Which state a reaction leaves its product in is energy dependent, so the
+        single number describing a spectrum is the branching collapsed against
+        it, and that number exists only inside a solve. The chain file carries
+        the unweighted ratios, and where the branching overlay supplies the
+        split it carries a placeholder instead: on TENDL-2025 the dominant
+        tungsten channel reads ``W186 (n,2n) -> W185 1.000000`` and
+        ``W186 (n,2n) -> W185_m1 0.000000`` in the file, and the overlay
+        replaces both at solve time with roughly the 54/46 that spectrum gives.
+        On a foil whose decay heat comes from an isomer, that difference is the
+        whole answer.
+        
+        Only channels landing in more than one final state appear. A channel
+        with one product has no branching to report, and listing it at 1.0
+        buries the ones that do; ``get_reaction_rates`` has the unnormalised
+        edges if the rest is wanted.
+        
+        This is the number that says whether a disagreement belongs to a cross
+        section or to a branching ratio, which are different data and different
+        fixes.
+        
+        Args:
+            material_id: Material ID number.
+            step: Schedule step index, the same index ``get_reaction_rates``
+                takes, which is one less than the composition getters' step.
+        
+        Returns:
+            dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
+            reaction kind -> [(target, fraction)], fractions summing to one and
+            ordered with the largest first. Empty for a decay-only step, and
+            None if the material or the step is unknown.
+        
+        Examples:
+            >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
+            {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+        """
+    def get_production_routes(self, material_id: builtins.int, product: builtins.str, step: builtins.int, reaction_depth: builtins.int = 1, decay_depth: builtins.int = 3) -> typing.Optional[typing.Any]:
+        r"""
+        Every way a product was made over one step, weighted by how much of it
+        arrived down each.
+        
+        Enumerating routes is easy and weighting them is not. Asked what makes
+        W187, a chain answers ``Os190(n,a)`` and ``Ir192(n,npa)`` as readily as
+        ``W186(n,gamma)``, and nothing in a tungsten foil is osmium. So the walk
+        starts from the nuclides the material actually began with, and each
+        route is weighted by what its own reactions drove rather than by
+        anything read off the chain.
+        
+        A route is ``reaction_depth`` neutron reactions followed by up to
+        ``decay_depth`` decays. Its weight is the atoms it starts from, times
+        each reaction step's per-atom production over the step, times the
+        branching of every decay it passes through: a route through a 1% branch
+        delivers 1% of what the reaction made. Reaction steps carry the step
+        duration, so a two-reaction route is in the same units as a one-reaction
+        route and comes out smaller by roughly a factor of the fluence, which is
+        the honest answer for an irradiation short enough that products barely
+        burn.
+        
+        Args:
+            material_id: Material ID number.
+            product: The nuclide whose production is being explained.
+            step: Schedule step index, as ``get_reaction_rates`` takes it.
+            reaction_depth (int): Neutron reactions a route may use. 1 is what
+                the published pathway tables carry.
+            decay_depth (int): Decays a route may follow after them.
+        
+        Returns:
+            list[dict] | None: one entry per route, largest share first, each
+            with ``route`` (the string the published tables print, e.g.
+            ``"W186(n,2n)W185_m1(IT)W185"``), ``steps`` (the same thing as
+            ``(parent, kind, target)`` triples), ``share`` (of this product's
+            production, summing to one) and ``production`` (atoms per barn-cm,
+            before normalising, so that 100% of almost nothing is
+            distinguishable from 100% of the inventory). Empty when nothing in
+            this material makes the product, which is an answer. None if the
+            material, the step, or the chain is unknown.
+        
+        Examples:
+            >>> for r in results.get_production_routes(1, "W185", 0):
+            ...     print(f"{r['route']:<32} {r['share']:.1%}")
+            W186(n,2n)W185_m1(IT)W185        53.0%
+            W186(n,2n)W185                   46.8%
         """
     def __repr__(self) -> builtins.str: ...
 

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -1869,6 +1869,13 @@ class TransmutationResults:
         
         - ``perturbed`` / ``no_covariance_data``: which nuclides had usable
           MF=33 covariance and which had none.
+        - ``rate_fraction_covered_total``: the share of the production this run
+          drove that a covariance actually spans, weighted by rate and by parent
+          density. Read this before any sigma here. It is a different and much
+          sharper question than how many nuclides carry MF=33: an evaluation can
+          state covariance for every isotope in the material and none for the
+          channel making the product of interest, and the count then reads as
+          full coverage while the ensemble perturbs almost nothing.
         - ``rate_fraction_covered``: per nuclide and channel, the share of the
           reaction rate the covariance grid actually spans. Below one means part
           of the rate carries no stated uncertainty and the sigma is diluted.
@@ -2190,6 +2197,92 @@ class TransmutationResults:
             ...     for target, rate in edges
             ...     if target == "Mn56"
             ... ]
+        """
+    def get_isomeric_branching(self, material_id: builtins.int, step: builtins.int) -> typing.Optional[typing.Any]:
+        r"""
+        Flux-weighted isomeric branching at one step.
+        
+        Which state a reaction leaves its product in is energy dependent, so the
+        single number describing a spectrum is the branching collapsed against
+        it, and that number exists only inside a solve. The chain file carries
+        the unweighted ratios, and where the branching overlay supplies the
+        split it carries a placeholder instead: on TENDL-2025 the dominant
+        tungsten channel reads ``W186 (n,2n) -> W185 1.000000`` and
+        ``W186 (n,2n) -> W185_m1 0.000000`` in the file, and the overlay
+        replaces both at solve time with roughly the 54/46 that spectrum gives.
+        On a foil whose decay heat comes from an isomer, that difference is the
+        whole answer.
+        
+        Only channels landing in more than one final state appear. A channel
+        with one product has no branching to report, and listing it at 1.0
+        buries the ones that do; ``get_reaction_rates`` has the unnormalised
+        edges if the rest is wanted.
+        
+        This is the number that says whether a disagreement belongs to a cross
+        section or to a branching ratio, which are different data and different
+        fixes.
+        
+        Args:
+            material_id: Material ID number.
+            step: Schedule step index, the same index ``get_reaction_rates``
+                takes, which is one less than the composition getters' step.
+        
+        Returns:
+            dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
+            reaction kind -> [(target, fraction)], fractions summing to one and
+            ordered with the largest first. Empty for a decay-only step, and
+            None if the material or the step is unknown.
+        
+        Examples:
+            >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
+            {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+        """
+    def get_production_routes(self, material_id: builtins.int, product: builtins.str, step: builtins.int, reaction_depth: builtins.int = 1, decay_depth: builtins.int = 3) -> typing.Optional[typing.Any]:
+        r"""
+        Every way a product was made over one step, weighted by how much of it
+        arrived down each.
+        
+        Enumerating routes is easy and weighting them is not. Asked what makes
+        W187, a chain answers ``Os190(n,a)`` and ``Ir192(n,npa)`` as readily as
+        ``W186(n,gamma)``, and nothing in a tungsten foil is osmium. So the walk
+        starts from the nuclides the material actually began with, and each
+        route is weighted by what its own reactions drove rather than by
+        anything read off the chain.
+        
+        A route is ``reaction_depth`` neutron reactions followed by up to
+        ``decay_depth`` decays. Its weight is the atoms it starts from, times
+        each reaction step's per-atom production over the step, times the
+        branching of every decay it passes through: a route through a 1% branch
+        delivers 1% of what the reaction made. Reaction steps carry the step
+        duration, so a two-reaction route is in the same units as a one-reaction
+        route and comes out smaller by roughly a factor of the fluence, which is
+        the honest answer for an irradiation short enough that products barely
+        burn.
+        
+        Args:
+            material_id: Material ID number.
+            product: The nuclide whose production is being explained.
+            step: Schedule step index, as ``get_reaction_rates`` takes it.
+            reaction_depth (int): Neutron reactions a route may use. 1 is what
+                the published pathway tables carry.
+            decay_depth (int): Decays a route may follow after them.
+        
+        Returns:
+            list[dict] | None: one entry per route, largest share first, each
+            with ``route`` (the string the published tables print, e.g.
+            ``"W186(n,2n)W185_m1(IT)W185"``), ``steps`` (the same thing as
+            ``(parent, kind, target)`` triples), ``share`` (of this product's
+            production, summing to one) and ``production`` (atoms per barn-cm,
+            before normalising, so that 100% of almost nothing is
+            distinguishable from 100% of the inventory). Empty when nothing in
+            this material makes the product, which is an answer. None if the
+            material, the step, or the chain is unknown.
+        
+        Examples:
+            >>> for r in results.get_production_routes(1, "W185", 0):
+            ...     print(f"{r['route']:<32} {r['share']:.1%}")
+            W186(n,2n)W185_m1(IT)W185        53.0%
+            W186(n,2n)W185                   46.8%
         """
     def __repr__(self) -> builtins.str: ...
 


### PR DESCRIPTION
Four things an activation report needs that consumers currently rebuild by hand from primitives, plus the version bump. Prompted by an example repo where 25% of the report generator (519 lines) was route-walking code derived from what yani already knows.

## 1. A chain records what it can drive, and a solve refuses one that cannot

Chains are routinely scoped to the nuclides they were built from, which makes them substitutable by mistake: two conversions sharing an output path leave the second one's chain under a name that still says the first. Nothing fails. Every step runs, no rate is negative, the composition comes back as it went in, and the mistake surfaces as a decay heat of exactly zero much later with nothing to point at. In the repo that prompted this, 12 of 24 runs failed that way.

- The chain manifest now records `parents` per subsection.
- An irradiated schedule whose material has no drivable nuclide is refused, naming both sides.

Stronger than the existing membership check in `preload_activation_data`: appearing in the chain is not enough, because a nuclide can be there purely as somebody else's product and carry no reactions of its own. Decay-only schedules are untouched, since driving nothing is correct for them.

## 2. `rate_fraction_covered_total`

`rate_fraction_covered` says per channel how much of a rate a covariance grid spans, but the number a reader needs is the total, and forming it means joining that map against the reaction rates by **string key** (`f"{parent} {kind}"`) — which silently returns 0% if either side ever respells anything.

Computed where both already are, weighted by rate **and by parent density**:

| library | foil | rate covered | nuclides with MF=33 |
|---|---|---|---|
| tendl-2025 | W | 99.29% | 5 of 5 |
| jeff-4.0 | W | **5.64%** | 5 of 5 |
| endf-b8.1 | W | **5.64%** | 5 of 5 |
| jendl-5.0 | W | 0.00% | 0 of 5 |
| endf-b8.1 | Fe | 95.56% | 2 of 4 |

The tungsten rows are the point. Two major libraries state covariance for all five natural isotopes, give it for `(n,3n)` and `(n,gamma)`, and give none for the `(n,2n)` that makes 98% of the decay heat. The isotope count reads as complete coverage while the ensemble perturbs 5.6% of the production and reports a spread under 0.1%.

Density weighting matters and is easy to get wrong by hand: the same foil computed rate-weighted but *not* density-weighted gives 32% for endf-b8.1 iron instead of 95.6%, because Fe56 is 91.75% of natural iron and carries MF=33.

## 3. `get_production_routes`

Enumerating routes is the easy half. Asked what makes W187, a chain answers `Os190(n,a)` and `Ir192(n,npa)` as readily as `W186(n,gamma)`, and nothing in a tungsten foil is osmium. So the walk starts from the nuclides the material began with, and each route is weighted by the atoms it starts from, each reaction step's production over the step, and the branching of every decay it passes through. Reaction steps carry the step duration, so routes of different depth are in the same units.

Reproduces the published FNS tungsten pathway table:

| route | yani | published |
|---|---|---|
| `W186(n,2n)W185_m1(IT)W185` | 53.1% | 53.0 |
| `W186(n,2n)W185` | 46.2% | 46.8 |
| `W186(n,gamma)W187` | 100.0% | 100.0 |
| `W184(n,p)Ta184` | 99.8% | 99.8 |

## 4. `get_isomeric_branching`

The flux-weighted split per channel, which exists only inside a solve. The chain file carries the unweighted ratios and, where the overlay supplies the split, a placeholder: TENDL-2025 has `W186 (n,2n) -> W185 1.000000` and `-> W185_m1 0.000000` in the file, and this reports the **53.5/46.5** that spectrum actually gives. On a foil whose decay heat comes from an isomer, that difference is the whole answer. It is what says whether a disagreement belongs to a cross section or to a branching ratio.

3 and 4 both need the chain the solve ran with rather than a second load of whatever the chain path now points at, so the results keep an `Arc` clone of it.

## 5. Not a change

The fifth item on the list was ambiguous units on `get_reaction_rates`. Investigated first and it is **correct as documented** — per atom of the parent, in 1/s. The confusion was downstream arithmetic that divided a fluence-integrated weight (`rate x 300 s`) by flux and forgot the duration, giving 570 b for W182(n,2n). Correctly reduced it is 1.90 b, which is right at 14 MeV. No change made.

## Incidental

`merge_coverage` now delegates to `Coverage::absorb` rather than repeating its rules. The two had drifted, which is how the new coverage totals initially came back as `None` across spectra.

## Testing

`cargo check`, `cargo fmt --check`, `cargo clippy --all-targets` (clean; the one remaining workspace warning is pre-existing in a `yamc-gpu` bench) and `cargo test` all pass, 15 suites. New tests cover the chain-scope refusal and its decay-only exemption, the coverage total's merge and its `None` case, isomeric-branching normalisation, and both route cases. Verified end to end against the FNS tungsten foil with a `maturin develop --release` build, which is where the published-table numbers above come from.

`ruff` is not installed in this environment and no Python files changed.

yani-core 0.12.0 -> 0.13.0.