### PR TITLE
Pin the goldens oracle, and pin the readback gate that replaced the fork

### DIFF
--- a/.github/workflows/ci-endf-goldens.yml
+++ b/.github/workflows/ci-endf-goldens.yml
@@ -38,16 +38,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      # The branch is load-bearing twice over. The reader has to be the fork
+      # The fork is load-bearing twice over. The reader has to be the fork
       # (upstream has no Chain, no from_njoy, no radionuclide_production), and
-      # it has to be the branch that teaches it to read `.xz`, because every
+      # it has to be the revision that teaches it to read `.xz`, because every
       # fixture here is stored compressed. `local-develop` has the first and not
       # the second, so it cannot regenerate these.
       #
-      # Move this to `local-develop` once the Rust-rewrite branch merges there.
+      # Pinned to a commit, not to the branch that carries it. A mutable ref
+      # means the oracle can be redefined without a commit here: a new push to
+      # that branch silently changes what all 28 goldens are compared against,
+      # and deleting the branch (which is the convention once it merges) turns
+      # this job red on an unrelated PR that only touched crates/endf. The Rust
+      # side already pins its git dependencies by revision in Cargo.lock, so
+      # this is the same rule applied to the one Python dependency.
+      #
+      # 8f42576 is the tip of shimwell/endf-python's
+      # `claude/rust-rewrite-python-layer-1upmmo`, 44 commits ahead of
+      # `local-develop` and not merged into it. Bumping it is a deliberate act:
+      # a fix to the fork's reader does not reach these goldens until someone
+      # changes this line, which is the trade a reproducible oracle asks for.
+      # Repoint at `local-develop` once the Rust-rewrite work merges there.
       - name: Install the endf reader the goldens are generated from
         run: |
-          pip install "endf @ git+https://github.com/shimwell/endf-python@claude/rust-rewrite-python-layer-1upmmo"
+          pip install "endf @ git+https://github.com/shimwell/endf-python@8f42576be57b464672bc5f6a0ae66041b336c148"
 
       # Regenerates all 28 single-file goldens from the fixtures and diffs them
       # against what is committed. The chain golden is built by a second tool

--- a/packages/yani-core/tests/test_yani_public_surface.py
+++ b/packages/yani-core/tests/test_yani_public_surface.py
@@ -72,6 +72,21 @@ def test_the_transmutation_surface_is_intact():
         assert name in yani.__all__, f"yani no longer advertises {name}"
 
 
+def test_the_readback_gate_is_on_this_wheel_too():
+    """The pair that replaced the Python reader, on the wheel that also writes.
+
+    A conversion is checked by reading it back, and these two bind the real
+    Rust loaders so the gate is the consumer rather than a second
+    implementation of the format (issue #525). They are registered outside the
+    `transport` gate in `register_classes` on purpose, because yani converts as
+    well as yamc does, and nothing else pins that: the only Python tests for
+    the pair live in the yamc package, so re-gating them behind `transport`
+    would quietly drop them from this wheel with every test still green.
+    """
+    for name in ("read_nuclide_from_arrow", "read_element_from_arrow"):
+        assert name in yani.__all__, f"yani no longer advertises {name}"
+
+
 def test_the_stub_reexports_every_submodule():
     """Working at runtime is the half that hides the other half.
 


### PR DESCRIPTION
Closes the last two loose ends from "drop the endf-python fork from data
generation" (fusion-neutronics/core-aug-31#525). The substance of that issue is
already done in this repository, so this is small on purpose. What was asked
for and what is already true here:

| Task from the issue | State here |
| --- | --- |
| PyO3 bindings for the two Rust readers | Done. `read_nuclide_from_arrow` (`crates/yani-python/src/read.rs:75`) and `read_element_from_arrow` (`:180`), over `yamc_nuclide::nuclide_arrow` and `yamc_element::photon_arrow` |
| Retire `packages/nuclear_data_to_arrow` | Done, in #2. `packages/` holds `yamc-core` and `yani-core` and nothing else |
| Drop `endf` from its `pyproject.toml` | Moot, the package is gone. Both surviving `pyproject.toml` files declare `dependencies = []` |
| Fix the stale "Work in progress" in `yamc-convert/src/lib.rs` | Done. The module doc now enumerates the twelve sections it writes |
| Switch `validate_arrow.py` / `compare_builds.py` | Out of scope, they live in `nuclear_data_generation_scripts` |

The issue's own title keeps the goldens oracle, so the fork stays where it is
the oracle. What is left is that the oracle was not pinned.

## The pin

`ci-endf-goldens.yml` installed the reader from
`shimwell/endf-python@claude/rust-rewrite-python-layer-1upmmo`. That branch is
genuinely still needed (44 commits ahead of `local-develop`, not merged, and it
is the revision that teaches the reader to open the `.xz` fixtures), but a
mutable ref gives the job two silent failure modes:

- a new commit on that branch redefines what all 28 goldens are compared
  against, with no commit in this repository to show for it
- deleting the branch, which is the convention once it merges, turns the job
  red on an unrelated pull request that only touched `crates/endf` or `tools/`

Pinned to `8f42576` instead. The Rust side already pins its git dependencies by
revision in `Cargo.lock`; this is the same rule applied to the one Python
dependency. The trade is stated in the comment: a fix to the fork's reader no
longer reaches these goldens until someone bumps the line, and that is now a
deliberate act rather than a surprise.

## The readback gate

`read_nuclide_from_arrow` and `read_element_from_arrow` are registered outside
the `transport` gate on purpose, because yani converts as well as yamc does.
Nothing pinned that. The only Python tests for the pair live in
`packages/yamc-core/tests/unit_tests/test_read_from_arrow.py`, so re-gating them
behind `transport` would quietly drop them from the yani wheel with every test
still green, which is the failure the readback gate exists to prevent, applied
to the gate itself.

## Follow-up, not done here

`8f42576` is only reachable through the branch. GitHub serves unadvertised
commits to `git fetch`, so deleting the branch will not break the job
immediately, but the durable fix is a stable ref (a tag or a `goldens-oracle`
branch) on `shimwell/endf-python`, which is a change to another repository. The
fork currently has no tags.