### PR TITLE
Check the written sections against the evaluations they came from

### DIFF
--- a/crates/yamc-convert/tests/section_values/mod.rs
+++ b/crates/yamc-convert/tests/section_values/mod.rs
@@ -1,0 +1,344 @@
+//! Shared plumbing for the value-comparison tests, and nothing else.
+//!
+//! Every helper here decompresses a fixture, parses it, opens a written
+//! section or reads one cell out of it. None of them assert anything, so a
+//! failure always reports from a named test rather than from a helper three
+//! frames down.
+//!
+//! # Why these tests exist
+//!
+//! `sections.rs` is thorough about STRUCTURE: which sections exist, which MTs
+//! are present, which labels resolve. What it does not do is compare the
+//! NUMBERS against the evaluation they were converted from, and it says so
+//! outright: `reactions_section_matches_the_published_file` notes that "the
+//! cross sections cannot be compared value for value". A retired Python
+//! package used to make that comparison. These files make it in Rust, against
+//! `crates/endf` rather than against a second implementation of the format.
+//!
+//! # Hermetic, by construction
+//!
+//! Every fixture is `include_bytes!` out of `crates/endf/fixtures/`, so these
+//! run on a clean checkout with no NJOY, no nuclear-data cache and no network.
+//! That is the point: the strongest tests in `sections.rs` need an ENDF tree
+//! and an njoy binary that no CI job provides, so they report green by not
+//! running. Nothing here can do that. A test that cannot reach its writer with
+//! vendored bytes is not written at all, and is recorded in the pull request
+//! instead of added as a silent skip.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use arrow_array::{cast::AsArray, Array, RecordBatch};
+use endf::{IncidentNeutron, IncidentPhoton, Material};
+
+// ---------------------------------------------------------------------------
+// The vendored fixtures.
+// ---------------------------------------------------------------------------
+
+/// The Li6 ACE table. One temperature, a real 721-point grid, 18 parsed MTs.
+/// The only vendored input that reaches `write_fast_xs`.
+pub const LI6_ACE: &[u8] = include_bytes!("../../../endf/fixtures/Li6.ace.xz");
+/// The only vendored source of a non-empty `IncidentNeutron::urr`.
+pub const URR_ACE: &[u8] = include_bytes!("../../../endf/fixtures/synthetic-urr.ace.xz");
+/// Denormal cross sections, for the writer's refusal paths.
+pub const DENORMAL_ACE: &[u8] = include_bytes!("../../../endf/fixtures/synthetic-denormal.ace.xz");
+/// The seven ACE energy laws, as blocks. This table has no MTR/SIG/ESZ, so
+/// `IncidentNeutron::from_ace` cannot read it; the laws are decoded per DLW
+/// locator and wrapped in a scaffold.
+pub const LAWS_ACE: &[u8] = include_bytes!("../../../endf/fixtures/synthetic-laws.ace.xz");
+
+/// Li6 as ENDF. Reaches the 0 K branch of `write_nuclide` and carries MF=33.
+pub const LI6_ENDF: &[u8] = include_bytes!("../../../endf/fixtures/n-003_Li_006_trimmed.endf.xz");
+/// Fe56 as ENDF. Carries MF=33 MT=103.
+pub const FE56_ENDF: &[u8] = include_bytes!("../../../endf/fixtures/n-026_Fe_056_trimmed.endf.xz");
+/// U235 as ENDF. MF=1 MT=452, 455, 456 and 458, so it reaches both
+/// `write_total_nu` and `write_fission_photon`.
+pub const U235_ENDF: &[u8] = include_bytes!("../../../endf/fixtures/n-092_U_235_trimmed.endf.xz");
+/// Am244 as ENDF. MT=458 with LFC=0 and NPLY=2, so both energy-release terms
+/// are polynomial where U235's prompt term is tabulated.
+pub const AM244_ENDF: &[u8] = include_bytes!("../../../endf/fixtures/n-095_Am_244.endf.xz");
+
+/// Hydrogen photoatomic, and the atomic relaxation that goes with it. The
+/// photon route runs on these with no NJOY at all.
+pub const H_PHOTOAT: &[u8] = include_bytes!("../../../endf/fixtures/photoat-001_H_000.endf.xz");
+pub const H_ATOM: &[u8] = include_bytes!("../../../endf/fixtures/atom-001_H_000.endf.xz");
+
+// ---------------------------------------------------------------------------
+// Fixtures on disk, and parsed.
+// ---------------------------------------------------------------------------
+
+/// A compressed fixture as text.
+pub fn text(compressed: &[u8]) -> String {
+    let mut out = Vec::new();
+    lzma_rs::xz_decompress(&mut &compressed[..], &mut out).expect("fixture decompresses");
+    String::from_utf8(out).expect("fixture is UTF-8")
+}
+
+/// A compressed fixture written out under `dir`, for the parsers that take a
+/// path rather than a string.
+pub fn write_fixture(compressed: &[u8], dir: &Path, name: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, text(compressed)).expect("fixture is written");
+    path
+}
+
+/// A scratch directory that removes itself even when an assertion panics,
+/// which the hand-rolled `temp_dir` join in `sections.rs` does not.
+pub fn scratch() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+/// An ACE table parsed into the value the writers are handed.
+pub fn ace_nuclide(compressed: &[u8]) -> IncidentNeutron {
+    let tables = endf::ace::tables_from_str(&text(compressed), None).expect("ACE parses");
+    IncidentNeutron::from_ace(&tables[0], endf::ace::MetastableScheme::Mcnp).expect("ACE reads")
+}
+
+/// The first ACE table itself, for the checks that go behind the parser to the
+/// raw XSS array.
+pub fn ace_table(compressed: &[u8]) -> endf::Table {
+    let tables = endf::ace::tables_from_str(&text(compressed), None).expect("ACE parses");
+    tables.into_iter().next().expect("one table")
+}
+
+pub fn li6_ace() -> IncidentNeutron {
+    ace_nuclide(LI6_ACE)
+}
+
+/// The first material in a compressed ENDF fixture.
+pub fn endf_material(compressed: &[u8]) -> Material {
+    let materials = endf::materials_from_str(&text(compressed)).expect("ENDF parses");
+    materials.into_iter().next().expect("one material")
+}
+
+/// An ENDF evaluation parsed into the value the writers are handed.
+///
+/// Note what this route does NOT carry: `IncidentNeutron::from_endf` sets no
+/// `k_ts`, no `atomic_weight_ratio` and leaves `energy` empty, keying every
+/// cross section at `"0K"`. That is not a defect in the fixture, it is what
+/// the ENDF route is before NJOY runs, and it is the only hermetic way to
+/// reach those branches of the writers.
+pub fn endf_nuclide(compressed: &[u8]) -> IncidentNeutron {
+    IncidentNeutron::from_endf(&endf_material(compressed)).expect("ENDF reads")
+}
+
+/// The hydrogen photoatomic evaluation, with its relaxation data attached.
+///
+/// `tabulations` decides whether `compton_profiles` and `bremsstrahlung` come
+/// back `Some`. No evaluation carries either; they are read from the three
+/// text files that ship in the wheel, and without them `write_compton` and
+/// `write_bremsstrahlung` return early and write no file at all.
+pub fn h_photon(tabulations: bool) -> IncidentPhoton {
+    let photoatomic = endf_material(H_PHOTOAT);
+    let relaxation = endf_material(H_ATOM);
+    let mut data = IncidentPhoton::from_endf(&photoatomic, Some(&relaxation))
+        .expect("the photoatomic evaluation reads");
+    if tabulations {
+        data.add_photon_data(&photon_tabulations());
+    }
+    data
+}
+
+/// The three auxiliary tabulations, parsed.
+pub fn photon_tabulations() -> endf::PhotonData {
+    let d = photon_tabulation_dir();
+    endf::PhotonData::from_files(
+        d.join("compton_profiles_biggs1975.txt"),
+        d.join("density_effect_sternheimer1982.txt"),
+        d.join("bremsstrahlung_seltzer_berger1986.txt"),
+    )
+    .expect("the auxiliary tabulations parse")
+}
+
+/// Where the three auxiliary photon tabulations live.
+///
+/// Resolved from `CARGO_MANIFEST_DIR`, not from a cache: these are git-tracked
+/// text files that ship inside the wheel, so they are present on a clean
+/// checkout and a test that reads them is still hermetic.
+pub fn photon_tabulation_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/yamc-core/python/yamc/data")
+}
+
+// ---------------------------------------------------------------------------
+// Reading a written section back.
+// ---------------------------------------------------------------------------
+
+/// One written section, read through the loader's own reader.
+///
+/// This is `yamc_nuclide::arrow_helpers::read_arrow_file`, and using it rather
+/// than a local `FileReader` matters twice. It fuses `reactions.arrow`'s
+/// batch-per-row framing into one row space, where taking `batches[0]` (which
+/// is what `sections.rs:41` does) yields the first MT alone. And it runs
+/// `nuclear_data_schema::check_batch` on the way in, so a column the
+/// declaration does not know is an error here rather than a downcast panic in
+/// a test.
+pub fn section(dir: &Path, file: &str) -> RecordBatch {
+    yamc_nuclide::arrow_helpers::read_arrow_file(&dir.join(file))
+        .unwrap_or_else(|e| panic!("{file}: {e}"))
+}
+
+/// True when a section file was not written at all.
+pub fn absent(dir: &Path, file: &str) -> bool {
+    !dir.join(file).is_file()
+}
+
+pub fn f64_at(batch: &RecordBatch, col: &str, row: usize) -> f64 {
+    yamc_nuclide::arrow_helpers::get_f64(batch, col, row).unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn i32_at(batch: &RecordBatch, col: &str, row: usize) -> i32 {
+    yamc_nuclide::arrow_helpers::get_i32(batch, col, row).unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn str_at(batch: &RecordBatch, col: &str, row: usize) -> String {
+    yamc_nuclide::arrow_helpers::get_str(batch, col, row).unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn bool_at(batch: &RecordBatch, col: &str, row: usize) -> bool {
+    yamc_nuclide::arrow_helpers::get_bool(batch, col, row).unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn f64_list(batch: &RecordBatch, col: &str, row: usize) -> Vec<f64> {
+    yamc_nuclide::arrow_helpers::get_f64_list(batch, col, row)
+        .unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn i32_list(batch: &RecordBatch, col: &str, row: usize) -> Vec<i32> {
+    yamc_nuclide::arrow_helpers::get_i32_list(batch, col, row)
+        .unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+pub fn str_list(batch: &RecordBatch, col: &str, row: usize) -> Vec<String> {
+    yamc_nuclide::arrow_helpers::get_str_list(batch, col, row)
+        .unwrap_or_else(|e| panic!("{col}: {e}"))
+}
+
+/// A `list<list<double>>` cell as owned rows.
+pub fn nested_f64_list(batch: &RecordBatch, col: &str, row: usize) -> Vec<Vec<f64>> {
+    yamc_nuclide::arrow_helpers::borrow_nested_f64_list(batch, col, row)
+        .unwrap_or_else(|e| panic!("{col}: {e}"))
+        .into_iter()
+        .map(|b| b.to_vec())
+        .collect()
+}
+
+/// Whether a cell is null, as distinct from an empty list.
+///
+/// The two are different files and the loader can tell them apart, but
+/// `try_get_f64_list` collapses both to an empty `Vec`, so a test that wants
+/// the distinction has to go to the array. `subshells.arrow` writes null for a
+/// shell with no relaxation cascade, and the published files do the same, so
+/// an empty list there would load identically and still not be the same file.
+pub fn is_null(batch: &RecordBatch, col: &str, row: usize) -> bool {
+    batch
+        .column_by_name(col)
+        .unwrap_or_else(|| panic!("no column {col}"))
+        .is_null(row)
+}
+
+/// The number of rows in a `list` cell's inner list, without materialising it.
+pub fn list_len(batch: &RecordBatch, col: &str, row: usize) -> usize {
+    let arr = batch
+        .column_by_name(col)
+        .unwrap_or_else(|| panic!("no column {col}"));
+    arr.as_list::<i32>().value(row).len()
+}
+
+// ---------------------------------------------------------------------------
+// Comparison.
+// ---------------------------------------------------------------------------
+
+/// Element-for-element `assert_eq!` on two f64 slices, with the index and both
+/// values in the message.
+///
+/// Exact, deliberately. A column that is a verbatim clone of parsed data goes
+/// through Arrow Float64 with LZ4, which is lossless, so any tolerance here
+/// could only hide the mistakes the comparison exists to find: a unit
+/// conversion applied twice, a column written into the wrong slot, a curve
+/// shifted by one grid point.
+#[track_caller]
+pub fn assert_f64_slice_eq(what: &str, written: &[f64], expected: &[f64]) {
+    assert_eq!(
+        written.len(),
+        expected.len(),
+        "{what}: wrote {} values, the evaluation has {}",
+        written.len(),
+        expected.len()
+    );
+    for (i, (&w, &e)) in written.iter().zip(expected).enumerate() {
+        assert_eq!(w, e, "{what}[{i}]: wrote {w:e}, the evaluation has {e:e}");
+    }
+}
+
+#[track_caller]
+pub fn assert_i32_slice_eq(what: &str, written: &[i32], expected: &[i32]) {
+    assert_eq!(
+        written, expected,
+        "{what}: wrote {written:?}, the evaluation has {expected:?}"
+    );
+}
+
+/// Element-for-element comparison to a relative tolerance, for the columns
+/// that are recomputed rather than copied.
+///
+/// `rel` is a fraction, not a count of ulps. Zero on both sides passes; zero
+/// on one side alone does not, since that is exactly the threshold-shift
+/// mistake these tests are looking for.
+#[track_caller]
+pub fn assert_f64_slice_close(what: &str, written: &[f64], expected: &[f64], rel: f64) {
+    assert_eq!(
+        written.len(),
+        expected.len(),
+        "{what}: wrote {} values, expected {}",
+        written.len(),
+        expected.len()
+    );
+    for (i, (&w, &e)) in written.iter().zip(expected).enumerate() {
+        let tol = rel * e.abs();
+        assert!(
+            (w - e).abs() <= tol,
+            "{what}[{i}]: wrote {w:e}, expected {e:e}, off by {:e} which is more than {rel:e} relative",
+            (w - e).abs()
+        );
+    }
+}
+
+#[track_caller]
+pub fn assert_close(what: &str, written: f64, expected: f64, rel: f64) {
+    let tol = rel * expected.abs();
+    assert!(
+        (written - expected).abs() <= tol,
+        "{what}: wrote {written:e}, expected {expected:e}, off by {:e} which is more than {rel:e} relative",
+        (written - expected).abs()
+    );
+}
+
+/// The declared schema, field for field, in order.
+///
+/// Worth stating plainly what this does NOT do: `write_section` builds every
+/// batch against the declared schema (`sections.rs:38-50`), so swapping two
+/// same-typed argument expressions produces a batch that satisfies this and
+/// carries the wrong numbers. It catches schema drift. Only a per-column value
+/// comparison catches a transposition, which is why nothing in these files
+/// substitutes this for one.
+#[track_caller]
+pub fn assert_schema_is_declared(batch: &RecordBatch, section_name: &str) {
+    let declared = nuclear_data_schema::section(section_name)
+        .unwrap_or_else(|| panic!("no declared schema for {section_name}"));
+    let written: Vec<_> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| (f.name().clone(), f.data_type().clone()))
+        .collect();
+    let expected: Vec<_> = declared
+        .fields()
+        .iter()
+        .map(|f| (f.name().clone(), f.data_type().clone()))
+        .collect();
+    assert_eq!(
+        written, expected,
+        "{section_name} was written with a schema the declaration does not match"
+    );
+}

--- a/crates/yamc-convert/tests/section_values_fast_xs.rs
+++ b/crates/yamc-convert/tests/section_values_fast_xs.rs
@@ -1,0 +1,1024 @@
+//! `fast_xs.arrow`, column for column, against the evaluation it was built
+//! from.
+//!
+//! The accelerator is the section a collision reads on every flight, and it is
+//! also the one whose columns are interchangeable at the schema level: six
+//! `list<int32>` fields and six `list<double>` fields that
+//! `RecordBatch::try_new` matches by position and data type alone. Swapping any
+//! two of the same type gives a file that satisfies the declared schema and
+//! loads without complaint, so only a per-column value comparison can see it.
+//!
+//! `Li6.ace.xz` is the only vendored evaluation that reaches this writer with
+//! real cross sections. `IncidentNeutron::from_endf` leaves `data.energy`
+//! empty, so every ENDF fixture is refused for want of a grid (that refusal is
+//! asserted below), and `entry::convert_neutron_transport` declines an ACE
+//! source, so `write_fast_xs` is called here directly rather than through the
+//! entry point. `synthetic-urr.ace.xz` reaches it too, with a grid of four
+//! zeros, and what it produces is pinned in
+//! `a_grid_with_no_positive_extent_is_written_rather_than_refused` as a
+//! suspected defect rather than as correct behaviour.
+//!
+//! # Where the input is CONSTRUCTED rather than parsed
+//!
+//! Li6 is not fissile, has no redundant reaction that emits a neutron, and has
+//! exactly one temperature, so three of this writer's decisions cannot be
+//! discriminated by any vendored evaluation in the tree. Each of the three was
+//! checked by deleting the writer's code and watching every test here stay
+//! green:
+//!
+//! - absorption is MT 27 LESS fission. On a nuclide whose fission column is
+//!   zero everywhere the subtraction can simply be deleted. That is the exact
+//!   wrong answer `fast_xs.rs:18-20` names, the one that double counts every
+//!   fission against the total.
+//! - the per-MT loop skips `rx.redundant`. Every redundant Li6 reaction also
+//!   fails `emits_neutron`, so the guard never decides anything here, and it is
+//!   the Be9 double-count defence `synthesis.rs:124-134` cites.
+//! - the row set follows `temperatures()`, not `data.energy.keys()`. On Li6
+//!   those are the same one-element set.
+//!
+//! Those three are covered by `IncidentNeutron` values built in this file, with
+//! `built_nuclide` and `built_reaction`. They are NOT evaluation parity, and
+//! nothing about them says the parser agrees with a real ACE table: what they
+//! establish is that the writer's arithmetic and its filters do what the module
+//! doc says. Their fields are given deliberately DISTINCT values, which is the
+//! whole point, since two columns that happen to be equal cannot discriminate a
+//! swap between them.
+
+mod section_values;
+use section_values::*;
+
+use std::collections::BTreeMap;
+
+use arrow_array::RecordBatch;
+use endf::IncidentNeutron;
+use yamc_convert::fast_xs::{write_fast_xs, FISSION_MTS};
+use yamc_convert::synthesis;
+
+/// The number of bins in the logarithmic index, as `fast_xs.rs:50` fixes it.
+/// Duplicated rather than imported because the writer's constant is private,
+/// which is the point: a change that misses one of the two sites shows up here.
+const LOG_BINS: usize = 8000;
+
+/// `fast_xs.arrow` written from a nuclide and read back through the loader's
+/// own reader.
+///
+/// The scratch directory goes out of scope on the way out, which is safe:
+/// `read_arrow_file` collects every batch into memory before returning
+/// (`arrow_helpers.rs:71-87`), so the returned batch does not refer to the
+/// file.
+fn written(data: &IncidentNeutron) -> RecordBatch {
+    let dir = scratch();
+    write_fast_xs(data, dir.path()).expect("this nuclide has an energy grid");
+    section(dir.path(), "fast_xs.arrow")
+}
+
+/// The Li6 table converted, with the section read back.
+fn li6_fast_xs() -> (IncidentNeutron, RecordBatch) {
+    let data = li6_ace();
+    let batch = written(&data);
+    (data, batch)
+}
+
+/// One of the four summed channels, out of the row-major `[n_energy, 4]`
+/// buffer: 0 total, 1 absorption, 2 scattering, 3 fission.
+fn channel(xs: &[f64], k: usize, n_energy: usize) -> Vec<f64> {
+    (0..n_energy).map(|i| xs[i * 4 + k]).collect()
+}
+
+/// Whether a reaction puts a neutron into the transport.
+///
+/// One line, reimplemented rather than imported: `fast_xs::emits_neutron` is
+/// private, and reimplementing it is what makes the comparison worth something,
+/// since it asks the parsed products the same question the sampler asks later.
+fn emits_neutron(rx: &endf::Reaction) -> bool {
+    rx.products.iter().any(|p| p.name == "neutron")
+}
+
+/// One reaction's parsed cross section, on the nuclide grid.
+///
+/// This calls `synthesis::on_grid` rather than rebuilding the zero-fill from
+/// `xs.x`, deliberately: `on_grid` ignores `xs.x` entirely and clips instead of
+/// panicking when `y` runs past the end of the grid (`synthesis.rs:102-110`),
+/// so a reimplementation would disagree for reasons that have nothing to do
+/// with the writer. The threshold offset itself is pinned independently, from
+/// `y` alone, in `the_per_mt_matrices_are_the_parsed_cross_sections_on_the_nuclide_grid`.
+fn parsed_on_grid(data: &IncidentNeutron, mt: i32, t: &str, n_energy: usize) -> Vec<f64> {
+    let xs = data.reactions[&mt].xs[t].clone();
+    synthesis::on_grid(&xs.y, xs.threshold_idx.unwrap_or(0), n_energy)
+}
+
+/// Every reaction that is not one of the synthesized sums, on the grid: the map
+/// the writer hands `synthesis::synthesize` (`fast_xs.rs:206-211`).
+///
+/// Redundant reactions stay in, which is the writer's distinction and not an
+/// oversight: the per-MT matrices skip them, the partials keep them and filter
+/// only `SYNTHETIC_MTS`.
+fn partials_on_grid(data: &IncidentNeutron, t: &str, n_energy: usize) -> BTreeMap<i32, Vec<f64>> {
+    data.reactions
+        .iter()
+        .filter(|(mt, _)| !synthesis::SYNTHETIC_MTS.contains(mt))
+        .filter_map(|(&mt, rx)| {
+            rx.xs.get(t).map(|xs| {
+                (
+                    mt,
+                    synthesis::on_grid(&xs.y, xs.threshold_idx.unwrap_or(0), n_energy),
+                )
+            })
+        })
+        .collect()
+}
+
+/// The log lookup table rebuilt from the grid, WITHOUT the writer's top-entry
+/// override.
+///
+/// Not the writer's running scan restated: this asks `partition_point` for each
+/// bin independently, so a scan that failed to advance, or advanced twice,
+/// would show up. `saturating_sub(1)` is what the running scan's `at = 0` start
+/// amounts to at bin 0, whose probe energy lands below the first grid point.
+fn scanned_index(grid: &[f64]) -> Vec<i32> {
+    let lo = grid[0].ln();
+    let delta = (grid[grid.len() - 1].ln() - lo) / LOG_BINS as f64;
+    (0..=LOG_BINS)
+        .map(|bin| {
+            let e = (lo + bin as f64 * delta).exp();
+            grid.partition_point(|&g| g <= e).saturating_sub(1) as i32
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Constructed inputs. See the module doc: these are NOT parsed evaluations, and
+// they exist only for the branches no vendored evaluation reaches.
+// ---------------------------------------------------------------------------
+
+/// The temperature the constructed nuclides below are built at.
+///
+/// `temperatures()` derives this string from `k_ts` rather than storing it, so
+/// the key used for `data.energy` and for every reaction's `xs` has to be the
+/// one `temperature_str(294.0)` writes. When it is not, no reaction has a cross
+/// section at the temperature the writer iterates and the row comes out empty,
+/// which is loud rather than silent.
+const BUILT_T: &str = "294K";
+
+/// One constructed reaction: a cross section covering the whole grid from index
+/// 0, and the products that decide which group the writer puts it in.
+///
+/// `emits` names the product particles, because `emits_neutron` reads the
+/// products rather than an MT table (`fast_xs.rs:52-59`); a capture channel is
+/// therefore built with a photon and no neutron.
+fn built_reaction(
+    mt: i32,
+    grid: &[f64],
+    y: &[f64],
+    emits: &[&str],
+    redundant: bool,
+) -> endf::Reaction {
+    let mut rx = endf::Reaction::new(mt);
+    let mut xs = endf::Tabulated1D::new(grid.to_vec(), y.to_vec());
+    xs.threshold_idx = Some(0);
+    rx.xs.insert(BUILT_T.to_string(), xs);
+    rx.products = emits.iter().map(|p| endf::Product::new(p)).collect();
+    rx.redundant = redundant;
+    rx
+}
+
+/// An `IncidentNeutron` with one temperature, one grid and the reactions given.
+///
+/// The Z and A are arbitrary and nothing in this writer reads them.
+fn built_nuclide(grid: &[f64], reactions: Vec<endf::Reaction>) -> IncidentNeutron {
+    let mut data = IncidentNeutron::new(94, 239, 0);
+    data.k_ts = vec![294.0 * endf::K_BOLTZMANN];
+    data.energy.insert(BUILT_T.to_string(), grid.to_vec());
+    for rx in reactions {
+        data.reactions.insert(rx.mt, rx);
+    }
+    data
+}
+
+/// A failure means a nuclide with no usable energy grid produced a file instead
+/// of an error, or the row set stopped following `data.temperatures()`.
+///
+/// WIRING ONLY on the filter. On this fixture `temperatures()` and
+/// `data.energy.keys()` are the same one-element set, `["294K"]`, so the
+/// `filter` in the expected expression is inert and a writer rewritten to
+/// iterate `data.energy.keys()` passes this test unchanged. That rewrite is
+/// discriminated by
+/// `a_grid_at_a_temperature_the_nuclide_has_no_kt_for_gets_no_row`, on a
+/// constructed nuclide. The row column here is also a one-row loop, so it says
+/// nothing about row ordering.
+///
+/// What IS discriminated is the pair of refusals. A nuclide with no grid at all
+/// and a nuclide whose only grid is present and empty must both be errors: a
+/// regression there publishes an accelerator with a missing temperature rather
+/// than failing the conversion.
+#[test]
+fn the_fast_xs_row_set_is_the_temperatures_that_have_a_grid() {
+    let (data, batch) = li6_fast_xs();
+    assert_schema_is_declared(&batch, "fast_xs.arrow");
+
+    let expected: Vec<String> = data
+        .temperatures()
+        .into_iter()
+        .filter(|t| data.energy.get(t).is_some_and(|g| !g.is_empty()))
+        .collect();
+    assert_eq!(
+        expected,
+        vec!["294K".to_string()],
+        "the Li6 table carries one kT, 2.53e-8 MeV, which rounds to 294K"
+    );
+    let written: Vec<String> = (0..batch.num_rows())
+        .map(|row| str_at(&batch, "temperature", row))
+        .collect();
+    assert_eq!(
+        written, expected,
+        "the temperature column is the row's only identity; every other \
+         assertion in this file maps a row through it rather than by index"
+    );
+
+    // The ENDF route reaches the writer with reactions but no energy grid at
+    // all, because `IncidentNeutron::from_endf` never fills `data.energy`.
+    let endf_dir = scratch();
+    let refused = write_fast_xs(&endf_nuclide(LI6_ENDF), endf_dir.path())
+        .expect_err("an ENDF evaluation has no nuclide-wide energy grid before NJOY");
+    assert!(
+        refused
+            .to_string()
+            .contains("no energy grid to build fast_xs.arrow from"),
+        "the refusal must name the missing grid, not something else: {refused}"
+    );
+    assert!(
+        absent(endf_dir.path(), "fast_xs.arrow"),
+        "a refused conversion must leave no file behind for a later pass to read"
+    );
+
+    // The other refusal: a temperature that IS in `temperatures()` and IS in
+    // `data.energy`, with an empty grid behind it.
+    let denormal = ace_nuclide(DENORMAL_ACE);
+    let temperatures = denormal.temperatures();
+    assert_eq!(
+        denormal.energy.get(&temperatures[0]).map(|g| g.len()),
+        Some(0),
+        "the denormal fixture's value is that its grid is present and empty; \
+         without that this is the same case as the ENDF one"
+    );
+    let denormal_dir = scratch();
+    let refused = write_fast_xs(&denormal, denormal_dir.path())
+        .expect_err("an empty grid is skipped, and skipping every temperature is an error");
+    assert!(
+        refused
+            .to_string()
+            .contains("no energy grid to build fast_xs.arrow from"),
+        "the refusal must name the missing grid, not something else: {refused}"
+    );
+    assert!(
+        absent(denormal_dir.path(), "fast_xs.arrow"),
+        "a refused conversion must leave no file behind for a later pass to read"
+    );
+}
+
+/// A failure means the accelerator gained a row for a temperature the nuclide
+/// was never processed at, or mapped a row onto the wrong one.
+///
+/// NO VENDORED EVALUATION REACHES THIS AND THE INPUT IS CONSTRUCTED, not
+/// parsed: the ACE route has no 0 K grid and the ENDF route has no grid at all,
+/// so `temperatures()` and `data.energy.keys()` are the same set on every
+/// fixture in the tree, and every fixture has exactly one temperature. The NJOY
+/// route is the one that differs: `entry.rs:225-232` puts a 0 K grid into
+/// `data.energy` that is never in `temperatures()`, and a writer that iterated
+/// the map would publish a row that every consumer then maps to a temperature
+/// the nuclide has no cross sections at.
+///
+/// The two real temperatures are given DIFFERENT grid lengths and DIFFERENT
+/// elastic cross sections on purpose, so the row-to-temperature mapping is
+/// discriminated as well as the row set: `temperatures()` follows the order of
+/// `k_ts` and gives `["294K", "1200K"]`, where the map's own lexicographic walk
+/// gives `["0K", "1200K", "294K"]`.
+#[test]
+fn a_grid_at_a_temperature_the_nuclide_has_no_kt_for_gets_no_row() {
+    let warm = [1.0e-5, 1.0e0, 1.0e3, 1.0e6];
+    let hot = [2.0e-5, 3.0e0, 4.0e3, 5.0e6, 6.0e7];
+    // The 0 K grid NJOY leaves behind. Nothing has a cross section at it.
+    let unprocessed = [9.0e-4, 8.0e0, 7.0e4];
+    let warm_elastic = [10.0, 11.0, 12.0, 13.0];
+    let hot_elastic = [20.0, 21.0, 22.0, 23.0, 24.0];
+
+    let mut data = IncidentNeutron::new(3, 6, 0);
+    data.k_ts = vec![294.0 * endf::K_BOLTZMANN, 1200.0 * endf::K_BOLTZMANN];
+    data.energy.insert("294K".to_string(), warm.to_vec());
+    data.energy.insert("1200K".to_string(), hot.to_vec());
+    data.energy.insert("0K".to_string(), unprocessed.to_vec());
+
+    let mut elastic = endf::Reaction::new(2);
+    elastic.products = vec![endf::Product::new("neutron")];
+    for (t, grid, y) in [
+        ("294K", warm.as_slice(), warm_elastic.as_slice()),
+        ("1200K", hot.as_slice(), hot_elastic.as_slice()),
+    ] {
+        let mut xs = endf::Tabulated1D::new(grid.to_vec(), y.to_vec());
+        xs.threshold_idx = Some(0);
+        elastic.xs.insert(t.to_string(), xs);
+    }
+    data.reactions.insert(2, elastic);
+
+    // The premise, pinned so this cannot quietly become the same set twice.
+    assert_eq!(
+        data.temperatures(),
+        ["294K", "1200K"],
+        "temperatures() follows the order of k_ts, which is not the order the \
+         energy map is keyed in"
+    );
+    assert_eq!(
+        data.energy.keys().collect::<Vec<_>>(),
+        ["0K", "1200K", "294K"],
+        "the energy map carries a grid at a temperature temperatures() does \
+         not, and walks its keys lexicographically"
+    );
+
+    let batch = written(&data);
+    let rows: Vec<String> = (0..batch.num_rows())
+        .map(|row| str_at(&batch, "temperature", row))
+        .collect();
+    assert_eq!(
+        rows,
+        ["294K", "1200K"],
+        "the 0K grid must produce no row, and the rows must come out in the \
+         order temperatures() gives rather than the order the map is keyed in"
+    );
+
+    // Row for row, with the position pinned by the equality above.
+    for (row, (grid, elastic_xs)) in [
+        (warm.as_slice(), warm_elastic.as_slice()),
+        (hot.as_slice(), hot_elastic.as_slice()),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let t = &rows[row];
+        assert_f64_slice_eq(
+            &format!("energy at {t}"),
+            &f64_list(&batch, "energy", row),
+            grid,
+        );
+        let xs = f64_list(&batch, "xs", row);
+        assert_f64_slice_eq(
+            &format!("xs total at {t}"),
+            &channel(&xs, 0, grid.len()),
+            elastic_xs,
+        );
+    }
+}
+
+/// A failure means the sampler's binary search starts in the wrong place.
+///
+/// If an entry is too high, `FastXSGrid::lookup` starts its narrowed search
+/// past the answer, `partition_point` returns 0, `i_grid` pins at `i_low`, and
+/// the interpolation fraction goes negative: it extrapolates backwards off a
+/// pair that does not bracket E, which at a resonance edge returns a wildly
+/// wrong or a negative cross section. Nothing raises, because
+/// `log_grid_index_u32` (`nuclide_arrow.rs:714-753`) checks only that entries
+/// are in range and non-decreasing and deliberately does not require the last
+/// entry to be `n_energy - 1`. The energy column is checked here too because
+/// the index means nothing without the grid it indexes.
+///
+/// Two things this does NOT do, both of which it used to claim.
+///
+/// It no longer loops over the grid asserting that each point lands inside its
+/// bin's bracket. With the index pinned entry for entry against the scan below,
+/// that loop is a fact about the fixture's grid rather than about the writer,
+/// and could not fail while the equality held.
+///
+/// It does not discriminate the scan's boundary comparison. The writer advances
+/// while `energy[at + 1] <= e`, and changing that to `<` leaves this test green,
+/// because no bin's probe energy coincides exactly with a grid point on Li6.
+/// That variant starts the search one point low, which the writer's own comment
+/// at `fast_xs.rs:98-101` says is the safe direction, so it is recorded here
+/// rather than built for.
+#[test]
+fn the_log_lookup_index_is_the_last_grid_point_at_or_below_every_bin() {
+    let (data, batch) = li6_fast_xs();
+    let temperature = str_at(&batch, "temperature", 0);
+    let grid = &data.energy[&temperature];
+    let n = grid.len();
+    assert_eq!(n, 721, "the Li6 ACE grid is 721 points");
+
+    // The grid itself: a verbatim clone of the parsed one, so exact.
+    let energy = f64_list(&batch, "energy", 0);
+    assert_f64_slice_eq("energy", &energy, grid);
+
+    // One `ln` of one grid point, and one reciprocal of one difference. Both
+    // exact: a tolerance here could only hide a wrong grid point or a wrong
+    // bin count.
+    let log_e_min = f64_at(&batch, "log_e_min", 0);
+    assert_eq!(
+        log_e_min,
+        grid[0].ln(),
+        "log_e_min is ln of the first energy"
+    );
+    assert!(
+        log_e_min.exp() < grid[0],
+        "bin 0's probe energy, {:e}, is expected to land BELOW the first grid \
+         point, {:e}; the index recomputation's saturating_sub depends on it",
+        log_e_min.exp(),
+        grid[0]
+    );
+    let inv_log_delta = f64_at(&batch, "inv_log_delta", 0);
+    let delta = (grid[n - 1].ln() - grid[0].ln()) / LOG_BINS as f64;
+    assert_eq!(inv_log_delta, 1.0 / delta, "inv_log_delta is 1 / delta");
+
+    let index = i32_list(&batch, "log_grid_index", 0);
+    assert_eq!(
+        index.len(),
+        LOG_BINS + 1,
+        "the lookup reads bin and bin + 1, so the table is LOG_BINS + 1 long"
+    );
+
+    // Value for value against an independent reconstruction.
+    let mut expected = scanned_index(grid);
+    assert_eq!(
+        expected[LOG_BINS], 719,
+        "this fixture is worth using because exp(ln(e_max)) lands at \
+         199999999.99999928 eV, below grid[720] = 2e8, so the scan yields 719 \
+         and only the deliberate override at fast_xs.rs:102-104 puts 720 in the \
+         file; if the scan ever reaches 720 on its own, the override has stopped \
+         being exercised here"
+    );
+    expected[LOG_BINS] = (n - 1) as i32;
+    assert_i32_slice_eq("log_grid_index", &index, &expected);
+}
+
+/// PINS A SUSPECTED DEFECT rather than endorsing it.
+///
+/// `write_fast_xs` refuses an EMPTY grid (`fast_xs.rs:144-146`) and accepts a
+/// grid with no positive extent, which is what `synthetic-urr.ace.xz` parses to:
+/// four zeros. The accelerator it then writes is poisoned. `log_e_min` is
+/// `ln(0.0)`, negative infinity (`fast_xs.rs:77`), and `inv_log_delta` is
+/// `1.0 / ((-inf) - (-inf))`, NaN (`fast_xs.rs:79-80`).
+///
+/// Nothing downstream catches it. `log_grid_index_u32`
+/// (`nuclide_arrow.rs:714-753`) checks only that the entries are in range and
+/// non-decreasing, and all 8001 of them are, so the file loads.
+/// `FastXSGrid::lookup` then computes `((ln E - (-inf)) * NaN) as usize`, and a
+/// NaN cast to `usize` saturates to 0 in Rust, so every energy would silently
+/// take bin 0's bracket.
+///
+/// The assertions below therefore state what the writer DOES today, not what it
+/// should do. When it learns to refuse a grid with no positive extent, replace
+/// them with the refusal, in the shape of the two in
+/// `the_fast_xs_row_set_is_the_temperatures_that_have_a_grid`.
+#[test]
+fn a_grid_with_no_positive_extent_is_written_rather_than_refused() {
+    let data = ace_nuclide(URR_ACE);
+    let temperatures = data.temperatures();
+    let grid = &data.energy[&temperatures[0]];
+    assert_f64_slice_eq("the fixture's own grid", grid, &[0.0; 4]);
+
+    let dir = scratch();
+    write_fast_xs(&data, dir.path())
+        .expect("a grid of zeros is accepted today, which is what this test pins");
+    let batch = section(dir.path(), "fast_xs.arrow");
+    assert_eq!(batch.num_rows(), 1, "the degenerate grid is not skipped");
+
+    let log_e_min = f64_at(&batch, "log_e_min", 0);
+    assert!(
+        log_e_min.is_infinite() && log_e_min.is_sign_negative(),
+        "log_e_min is ln(0.0), so negative infinity, not {log_e_min}"
+    );
+    assert!(
+        f64_at(&batch, "inv_log_delta", 0).is_nan(),
+        "inv_log_delta is 1 / ((-inf) - (-inf)), so NaN"
+    );
+
+    // Every probe energy is NaN, so `energy[at + 1] <= e` is false at every bin
+    // and the scan never advances; only the top-entry override moves anything.
+    let index = i32_list(&batch, "log_grid_index", 0);
+    assert_eq!(index.len(), LOG_BINS + 1);
+    assert!(
+        index[..LOG_BINS].iter().all(|&v| v == 0),
+        "the scan cannot advance past a NaN probe"
+    );
+    assert_eq!(
+        index[LOG_BINS],
+        (grid.len() - 1) as i32,
+        "the top entry is set rather than derived, so it is the one entry that \
+         is not zero: in range and non-decreasing, which is all the loader \
+         checks before accepting the file"
+    );
+}
+
+/// A failure means one of total, absorption, scattering or fission is not the
+/// sum of the channels it is defined over, so a collision would sample a
+/// reaction out of a set whose probabilities do not add up to the total it
+/// flew a free path against.
+///
+/// What each assertion is worth, plainly.
+///
+/// Total against `synthesize(&partials)[&1]`, absorption against
+/// `synthesize(&partials)[&27]` less the written fission, and scattering
+/// against `elastic + non_elastic_scattering(&partials)` all run the same
+/// functions the writer ran (`synthesis.rs:218-219` is `partials[2] + mt3`,
+/// `fast_xs.rs:270` is `elastic + non_elastic`). They pin the value written
+/// against the expression and prove nothing about the arithmetic.
+///
+/// Total against the ACE table's own MT 1 is the one independent oracle here,
+/// and its bound is 1e-7 relative rather than the 1e-6 it was. The measured
+/// worst residual is 4.252890222678634e-9 at 573554.7 eV, so 1e-7 still leaves
+/// 23x of headroom, and 1e-6 was loose enough that scaling every term inside
+/// `synthesis::non_elastic_scattering` by `(1.0 + 1e-6)` passed. That defect
+/// moves `total` and `scattering` together, so the cross-grouping identity
+/// below is blind to it and this bound is the only thing that can see it: at
+/// 2e8 eV the non-elastic scattering is 73.6% of the total, so the scaling
+/// shows up as a 7.36e-7 residual.
+///
+/// Absorption against the ACE table's own MT 101 is independent (MT 101 comes
+/// straight off the ESZ block, `incident_neutron.rs:150-166`) but DEGENERATE:
+/// MT 102 is Li6's only disappearance channel, so it compares a one-term sum
+/// against its one term. The subtraction that makes absorption differ from
+/// MT 27 is undiscriminated here because fission is zero everywhere; the
+/// fissile case is
+/// `the_absorption_column_is_the_disappearance_sum_less_fission`, on a
+/// constructed nuclide.
+///
+/// The cross-grouping identity is the check that survives a channel landing on
+/// one side only. It is deliberately not exact, per `fast_xs.rs:263-267`: an
+/// identity that holds because one side was defined as the other cannot detect
+/// that the side it was defined from is wrong.
+#[test]
+fn the_four_summed_channels_are_the_curves_they_are_summed_from() {
+    let (data, batch) = li6_fast_xs();
+    let temperature = str_at(&batch, "temperature", 0);
+    let grid = &data.energy[&temperature];
+    let n = grid.len();
+
+    // The reader takes n_energy from xs_shape[0] and zero-fills past the end of
+    // the flat buffer (nuclide_arrow.rs:806-816), so a short shape truncates
+    // the nuclide's grid and a long one appends rows of zero cross section.
+    let xs_shape = i32_list(&batch, "xs_shape", 0);
+    assert_i32_slice_eq("xs_shape", &xs_shape, &[n as i32, 4]);
+    let xs = f64_list(&batch, "xs", 0);
+    assert_eq!(
+        xs.len(),
+        (xs_shape[0] * xs_shape[1]) as usize,
+        "the flat xs buffer must hold exactly the shape it declares"
+    );
+
+    let total = channel(&xs, 0, n);
+    let absorption = channel(&xs, 1, n);
+    let scattering = channel(&xs, 2, n);
+    let fission = channel(&xs, 3, n);
+
+    let partials = partials_on_grid(&data, &temperature, n);
+    let synthesized = synthesis::synthesize(&partials, n);
+    let elastic = parsed_on_grid(&data, 2, &temperature, n);
+
+    // Total: the writer's own arithmetic restated, then the real check against
+    // the table's own stored MT 1. Not exact, and it cannot be: the stored copy
+    // reaches the file through ENDF's 11-character field and so carries seven
+    // significant digits where the re-derived sum carries full precision.
+    assert_f64_slice_eq("xs total", &total, &synthesized[&1]);
+    assert_f64_slice_close(
+        "xs total against the ACE table's own MT 1",
+        &total,
+        &parsed_on_grid(&data, 1, &temperature, n),
+        1e-7,
+    );
+
+    // Absorption is MT 27 less what fissions, which is the disappearance sum.
+    let want_absorption: Vec<f64> = (0..n).map(|i| synthesized[&27][i] - fission[i]).collect();
+    assert_f64_slice_eq("xs absorption", &absorption, &want_absorption);
+    // The comment at fast_xs.rs:226-228 says the derived absorption and the
+    // table's own MT 101 disagree by 5e-5 barns on Li6. On this vendored table
+    // the measured difference is exactly zero at all 721 points, so this is
+    // asserted exactly and the comment is what needs revisiting.
+    assert_f64_slice_eq(
+        "xs absorption against the ACE table's own MT 101",
+        &absorption,
+        &parsed_on_grid(&data, 101, &temperature, n),
+    );
+
+    // Scattering is elastic plus the neutron-emitting part of MT 3, summed from
+    // non-negative terms rather than reached by subtracting absorption back off
+    // MT 3. Restated arithmetic again.
+    let non_elastic_scatter = synthesis::non_elastic_scattering(&partials, n);
+    let want_scattering: Vec<f64> = (0..n)
+        .map(|i| elastic[i] + non_elastic_scatter[i])
+        .collect();
+    assert_f64_slice_eq("xs scattering", &want_scattering, &scattering);
+
+    // Li6 is not fissile, so the fourth slot is zeros. Against the literal
+    // rather than against a row sum over a matrix with no columns, which was
+    // the same literal reached the long way round.
+    assert_f64_slice_eq("xs fission", &fission, &vec![0.0; n]);
+
+    // The cross-grouping identity, at every energy. The bound is a few ulp of
+    // TOTAL, the largest term, not of the partial being compared: absorption
+    // comes out of a subtraction whose error scales with absorption plus
+    // fission. `m` is the number of channels that entered the sums, and the
+    // extra 1 pays for that subtraction. Measured worst on this fixture is 0.97
+    // ulp of total, at 5400000.0 eV, so 10 * EPSILON leaves an order of
+    // magnitude of headroom while staying about 4.5e5 times tighter than the
+    // 1e-9 in use at crates/yamc/tests/urr_fissile_capture.rs:52-77, which
+    // tolerates a whole channel vanishing from one side.
+    let scatter_mts = i32_list(&batch, "scatter_mt_numbers", 0);
+    let fission_mts = i32_list(&batch, "fission_mt_numbers", 0);
+    let disappearance = endf::data::sum_rule(101)
+        .unwrap_or(&[])
+        .iter()
+        .filter(|mt| data.reactions.contains_key(mt))
+        .count();
+    let m = scatter_mts.len() + fission_mts.len() + disappearance;
+    for i in 0..n {
+        let sum = absorption[i] + scattering[i] + fission[i];
+        let residual = (total[i] - sum).abs();
+        if total[i] == 0.0 {
+            assert_eq!(
+                sum, 0.0,
+                "at {:e} eV the total is zero but its channels sum to {sum:e}",
+                grid[i]
+            );
+            continue;
+        }
+        let bound = ((m + 1) as f64) * f64::EPSILON * total[i];
+        assert!(
+            residual <= bound,
+            "at {:e} eV total is {:e} but absorption + scattering + fission is \
+             {sum:e}, off by {residual:e}, which is {:.1} ulp of total over {} \
+             channels: the two sides are the same channels in a different \
+             order, so anything above the rounding of the largest term means a \
+             channel is on one side only",
+            grid[i],
+            total[i],
+            residual / (f64::EPSILON * total[i]),
+            m
+        );
+    }
+
+    // Radiative capture, against the parsed channel it is a copy of. The
+    // comparison this used to make beside it, against the absorption slice, was
+    // a self-comparison: MT 102 is Li6's only member of sum_rule(101), so
+    // absorption IS on_grid(102) bit for bit and the two sides were one value.
+    let ngamma = f64_list(&batch, "xs_ngamma", 0);
+    assert_f64_slice_eq(
+        "xs_ngamma",
+        &ngamma,
+        &parsed_on_grid(&data, 102, &temperature, n),
+    );
+
+    // Format parity only: the reader recomputes photon production whenever this
+    // column is empty or all zeros (nuclide_arrow.rs:1012-1014), so no
+    // transport answer depends on it. It is pinned because it is the one
+    // list<double> whose contents are constant, which makes it the cheapest
+    // tripwire for a positional swap among the six interchangeable ones.
+    assert!(
+        !is_null(&batch, "photon_prod", 0),
+        "photon_prod is written as zeros, not as a null"
+    );
+    let photon_prod = f64_list(&batch, "photon_prod", 0);
+    assert_f64_slice_eq("photon_prod", &photon_prod, &vec![0.0; n]);
+}
+
+/// A failure means every fission is counted twice against the total. That is
+/// the wrong answer `fast_xs.rs:18-20` names outright: absorption is MT 27 LESS
+/// fission, and MT 27 is the one that includes it.
+///
+/// NO VENDORED EVALUATION REACHES THIS AND THE INPUT IS CONSTRUCTED, not
+/// parsed. Li6 is not fissile and no other ACE fixture carries a reaction set
+/// at all, so on parsed data the fission column is zero everywhere and the
+/// `- fission[i]` at `fast_xs.rs:229-231` can be deleted with every other test
+/// in this file still green. Nothing here says anything about parity with a
+/// real evaluation.
+///
+/// The fields are given distinct values for exactly that reason. Elastic,
+/// capture and fission are 10, 4 and 1 barns at the first grid point and rise
+/// differently, so absorption cannot be confused with capture plus fission, and
+/// the two fission partials differ from each other at every energy, so a
+/// swapped column or a column-major ravel in the fission matrix cannot hide
+/// behind an equality. Every value is an exact binary fraction, so the writer's
+/// association order and this test's agree bit for bit and the comparisons stay
+/// exact.
+///
+/// Both shapes an evaluation may take are built: MT 18 alone, which is
+/// `has_partial_fission == false`, and MT 19 beside MT 20, which is `true`. The
+/// flag gates a random draw (`sample_fission_reaction` skips `draw_xi()` when it
+/// is false, `yamc-nuclide/src/nuclide.rs:729-733`), so flipping it moves the
+/// shared PCG stream out of step with the GPU twin.
+#[test]
+fn the_absorption_column_is_the_disappearance_sum_less_fission() {
+    let grid = [1.0e-5, 1.0e0, 1.0e3, 1.0e6];
+    let n = grid.len();
+    let elastic = [10.0, 11.0, 12.0, 13.0];
+    let capture = [4.0, 4.5, 5.0, 5.5];
+
+    // The evaluation gives the fission total, MT 18.
+    let mt18 = [1.0, 2.0, 3.0, 4.0];
+    let batch = written(&built_nuclide(
+        &grid,
+        vec![
+            built_reaction(2, &grid, &elastic, &["neutron"], false),
+            built_reaction(18, &grid, &mt18, &["neutron"], false),
+            built_reaction(102, &grid, &capture, &["photon"], false),
+        ],
+    ));
+    assert_i32_slice_eq("xs_shape", &i32_list(&batch, "xs_shape", 0), &[n as i32, 4]);
+    let xs = f64_list(&batch, "xs", 0);
+
+    // The whole point of this test: absorption is the capture channel, and NOT
+    // capture plus the 1 to 4 barns of fission beside it.
+    assert_f64_slice_eq("xs absorption", &channel(&xs, 1, n), &capture);
+    assert_f64_slice_eq("xs fission", &channel(&xs, 3, n), &mt18);
+    assert_f64_slice_eq("xs scattering", &channel(&xs, 2, n), &elastic);
+    let total: Vec<f64> = (0..n).map(|i| elastic[i] + capture[i] + mt18[i]).collect();
+    assert_f64_slice_eq("xs total", &channel(&xs, 0, n), &total);
+
+    assert_i32_slice_eq(
+        "fission_mt_numbers",
+        &i32_list(&batch, "fission_mt_numbers", 0),
+        &[18],
+    );
+    assert_f64_slice_eq(
+        "fission_mt_xs",
+        &f64_list(&batch, "fission_mt_xs", 0),
+        &mt18,
+    );
+    assert_i32_slice_eq(
+        "fission_mt_shape",
+        &i32_list(&batch, "fission_mt_shape", 0),
+        &[n as i32, 1],
+    );
+    assert!(
+        !bool_at(&batch, "has_partial_fission", 0),
+        "MT 18 is the fission total, not a chance-by-chance partial"
+    );
+
+    // The same nuclide with the first and second chance partials instead.
+    let mt19 = [1.0, 2.0, 3.0, 4.0];
+    let mt20 = [0.25, 0.5, 0.75, 1.0];
+    let batch = written(&built_nuclide(
+        &grid,
+        vec![
+            built_reaction(2, &grid, &elastic, &["neutron"], false),
+            built_reaction(19, &grid, &mt19, &["neutron"], false),
+            built_reaction(20, &grid, &mt20, &["neutron"], false),
+            built_reaction(102, &grid, &capture, &["photon"], false),
+        ],
+    ));
+    let xs = f64_list(&batch, "xs", 0);
+    let fission: Vec<f64> = (0..n).map(|i| mt19[i] + mt20[i]).collect();
+    assert_f64_slice_eq("xs absorption, partials", &channel(&xs, 1, n), &capture);
+    assert_f64_slice_eq("xs fission, partials", &channel(&xs, 3, n), &fission);
+    let total: Vec<f64> = (0..n)
+        .map(|i| elastic[i] + capture[i] + fission[i])
+        .collect();
+    assert_f64_slice_eq("xs total, partials", &channel(&xs, 0, n), &total);
+
+    assert_i32_slice_eq(
+        "fission_mt_numbers",
+        &i32_list(&batch, "fission_mt_numbers", 0),
+        &[19, 20],
+    );
+    // Row-major [n_energy, 2], with the two columns different at every energy.
+    let expected: Vec<f64> = (0..n).flat_map(|i| [mt19[i], mt20[i]]).collect();
+    assert_f64_slice_eq(
+        "fission_mt_xs",
+        &f64_list(&batch, "fission_mt_xs", 0),
+        &expected,
+    );
+    assert_i32_slice_eq(
+        "fission_mt_shape",
+        &i32_list(&batch, "fission_mt_shape", 0),
+        &[n as i32, 2],
+    );
+    assert!(
+        bool_at(&batch, "has_partial_fission", 0),
+        "MT 19 and MT 20 are the chance-by-chance partials"
+    );
+}
+
+/// A failure means the matrix that answers "what is MT 51 at this energy" is
+/// sheared or column-shifted, which loads without complaint and hands every
+/// reaction someone else's cross section.
+///
+/// `shape[1]` is the row stride the reader de-ravels with
+/// (`nuclide_arrow.rs:860-868`), so a stride one too large or too small returns
+/// a real, plausible cross section from the wrong (energy, MT) cell at every
+/// lookup.
+///
+/// Two parts of the expected set are WIRING ONLY on this fixture. The
+/// `!rx.redundant` filter decides nothing: Li6's redundant reactions are 1, 101,
+/// 203 to 207, 301 and 444, and every one of them also fails `emits_neutron`,
+/// so deleting the writer's guard changes nothing here. The discriminating case
+/// is `the_per_mt_columns_leave_out_a_redundant_total_whose_own_levels_are_present`,
+/// on a constructed nuclide. And the fission group compares an empty set against
+/// a predicate that yields the empty set, so it says nothing about fission; the
+/// non-empty case, including the `has_partial_fission` truth table, is in
+/// `the_absorption_column_is_the_disappearance_sum_less_fission`. It is still
+/// asserted because empty is a different file from null.
+///
+/// The MT 51 pin below is the only assertion ON A PARSED EVALUATION that
+/// survives a defect in `synthesis::on_grid`. Everything else that runs on Li6,
+/// including the ACE MT 1 oracle in the test above, routes through `on_grid` on
+/// both sides and cannot see a threshold shifted inside it. The two constructed
+/// tests survive one too, but for a different reason: their expected values are
+/// literals rather than anything `on_grid` produced.
+#[test]
+fn the_per_mt_matrices_are_the_parsed_cross_sections_on_the_nuclide_grid() {
+    let (data, batch) = li6_fast_xs();
+    let temperature = str_at(&batch, "temperature", 0);
+    let n = data.energy[&temperature].len();
+
+    let expected_scatter: Vec<i32> = data
+        .reactions
+        .iter()
+        .filter(|(mt, rx)| {
+            !rx.redundant
+                && rx.xs.contains_key(&temperature)
+                && emits_neutron(rx)
+                && !FISSION_MTS.contains(mt)
+        })
+        .map(|(&mt, _)| mt)
+        .collect();
+    let scatter_mts = i32_list(&batch, "scatter_mt_numbers", 0);
+    assert_i32_slice_eq("scatter_mt_numbers", &scatter_mts, &expected_scatter);
+    assert_i32_slice_eq(
+        "scatter_mt_numbers",
+        &scatter_mts,
+        &[2, 5, 51, 52, 53, 54, 55, 91],
+    );
+
+    let scatter_mt_shape = i32_list(&batch, "scatter_mt_shape", 0);
+    assert_i32_slice_eq(
+        "scatter_mt_shape",
+        &scatter_mt_shape,
+        &[n as i32, scatter_mts.len() as i32],
+    );
+    let scatter_mt_xs = f64_list(&batch, "scatter_mt_xs", 0);
+    assert_eq!(
+        scatter_mt_xs.len(),
+        n * scatter_mts.len(),
+        "the flat matrix must hold exactly the shape it declares"
+    );
+
+    // Every cell, against the parsed cross section it is a copy of. Exact:
+    // there is no arithmetic between the evaluation and this buffer.
+    let stride = scatter_mts.len();
+    for (j, &mt) in scatter_mts.iter().enumerate() {
+        let expected = parsed_on_grid(&data, mt, &temperature, n);
+        let written: Vec<f64> = (0..n).map(|i| scatter_mt_xs[i * stride + j]).collect();
+        assert_f64_slice_eq(
+            &format!("scatter_mt_xs column {j} (MT {mt})"),
+            &written,
+            &expected,
+        );
+    }
+
+    // The threshold zero-fill, pinned on a real threshold channel from the
+    // parsed `y` alone rather than through `on_grid`. MT 51 starts at grid
+    // index 511 with 210 points, and its first strictly positive value is
+    // y[1], so the curve must sit at grid index 512 and nowhere else. A
+    // one-point shift in either direction moves that edge.
+    let mt51 = data.reactions[&51].xs[&temperature].clone();
+    let threshold = mt51.threshold_idx.expect("MT 51 is a threshold reaction");
+    assert_eq!(
+        (threshold, mt51.y.len()),
+        (511, 210),
+        "MT 51 is this fixture's threshold channel: 210 points starting at grid \
+         index 511. If that ever changes, the zero-fill below is checking \
+         nothing"
+    );
+    let j51 = scatter_mts
+        .iter()
+        .position(|&mt| mt == 51)
+        .expect("MT 51 has a column");
+    let column: Vec<f64> = (0..n).map(|i| scatter_mt_xs[i * stride + j51]).collect();
+    assert!(
+        column[..threshold].iter().all(|&v| v == 0.0),
+        "MT 51 must be exactly zero below its threshold at grid index {threshold}"
+    );
+    let parsed_first_positive = mt51
+        .y
+        .iter()
+        .position(|&v| v > 0.0)
+        .expect("MT 51 rises above zero somewhere");
+    let first_positive = column
+        .iter()
+        .position(|&v| v > 0.0)
+        .expect("so its column must too");
+    assert_eq!(
+        first_positive,
+        threshold + parsed_first_positive,
+        "MT 51's first positive point must land at the grid index its threshold \
+         and its own array put it at"
+    );
+    assert_eq!(
+        column[first_positive], mt51.y[parsed_first_positive],
+        "and carry the parsed value"
+    );
+    assert_f64_slice_eq(
+        "scatter_mt_xs MT 51 above its threshold",
+        &column[threshold..],
+        &mt51.y,
+    );
+
+    // Fission. Empty and PRESENT, not null: `int_lists` and `float_lists`
+    // (sections.rs:138-155) append unconditionally, and the or_null variants
+    // used by other sections would produce a different file that loads the same.
+    let expected_fission: Vec<i32> = data
+        .reactions
+        .iter()
+        .filter(|(mt, rx)| {
+            !rx.redundant
+                && rx.xs.contains_key(&temperature)
+                && emits_neutron(rx)
+                && FISSION_MTS.contains(mt)
+        })
+        .map(|(&mt, _)| mt)
+        .collect();
+    assert!(
+        expected_fission.is_empty(),
+        "Li6 is not fissile; if this fixture ever gains a fission channel the \
+         assertions below stop being the empty case"
+    );
+    let fission_mts = i32_list(&batch, "fission_mt_numbers", 0);
+    assert_i32_slice_eq("fission_mt_numbers", &fission_mts, &expected_fission);
+    assert!(
+        !is_null(&batch, "fission_mt_numbers", 0) && !is_null(&batch, "fission_mt_xs", 0),
+        "the fission columns are empty lists, not nulls"
+    );
+    assert_eq!(list_len(&batch, "fission_mt_xs", 0), 0);
+    assert_i32_slice_eq(
+        "fission_mt_shape",
+        &i32_list(&batch, "fission_mt_shape", 0),
+        &[n as i32, 0],
+    );
+    assert_eq!(
+        bool_at(&batch, "has_partial_fission", 0),
+        fission_mts.iter().any(|&mt| mt != 18),
+        "has_partial_fission is true only when the evaluation gives the \
+         chance-by-chance partials rather than the MT 18 total"
+    );
+}
+
+/// A failure means a reaction is counted twice in the per-MT matrix the sampler
+/// picks from, so the same (n,2n) can be drawn under two MT numbers and the
+/// column probabilities do not add up to the scattering channel beside them.
+///
+/// NO VENDORED EVALUATION REACHES THIS AND THE INPUT IS CONSTRUCTED, not
+/// parsed. Deleting the `if rx.redundant { continue; }` guard at
+/// `fast_xs.rs:169-171` leaves every test that runs on Li6 green, because every
+/// redundant Li6 reaction also fails `emits_neutron` and so is dropped one line
+/// later anyway.
+///
+/// The shape built here is the one `synthesis.rs:124-134` names. JEFF-4.0's Be9
+/// has no evaluated MF=3 MT 16, so the parser builds MT 16 as the sum of the
+/// residual levels MT 875 and MT 876 and flags it redundant. Both forms emit a
+/// neutron, so the flag is the only thing that separates them, and counting
+/// both put MT 3 (and with it the total) 35% above the evaluation's own MT 1.
+/// The levels are given different values from each other and from the elastic
+/// channel so a wrong column cannot land on a right number.
+#[test]
+fn the_per_mt_columns_leave_out_a_redundant_total_whose_own_levels_are_present() {
+    let grid = [1.0e-5, 1.0e0, 1.0e3, 1.0e6];
+    let n = grid.len();
+    let elastic = [10.0, 11.0, 12.0, 13.0];
+    let level0 = [1.0, 1.25, 1.5, 1.75];
+    let level1 = [2.0, 2.5, 3.0, 3.5];
+    let capture = [4.0, 4.5, 5.0, 5.5];
+    let n2n: Vec<f64> = (0..n).map(|i| level0[i] + level1[i]).collect();
+
+    let batch = written(&built_nuclide(
+        &grid,
+        vec![
+            built_reaction(2, &grid, &elastic, &["neutron"], false),
+            built_reaction(16, &grid, &n2n, &["neutron"], true),
+            built_reaction(875, &grid, &level0, &["neutron"], false),
+            built_reaction(876, &grid, &level1, &["neutron"], false),
+            built_reaction(102, &grid, &capture, &["photon"], false),
+        ],
+    ));
+
+    assert_i32_slice_eq(
+        "scatter_mt_numbers",
+        &i32_list(&batch, "scatter_mt_numbers", 0),
+        &[2, 875, 876],
+    );
+    assert_i32_slice_eq(
+        "scatter_mt_shape",
+        &i32_list(&batch, "scatter_mt_shape", 0),
+        &[n as i32, 3],
+    );
+    let expected: Vec<f64> = (0..n)
+        .flat_map(|i| [elastic[i], level0[i], level1[i]])
+        .collect();
+    assert_f64_slice_eq(
+        "scatter_mt_xs",
+        &f64_list(&batch, "scatter_mt_xs", 0),
+        &expected,
+    );
+
+    // And the summed channels above the matrix count (n,2n) once, which is the
+    // consequence the missing column would otherwise show up as.
+    let xs = f64_list(&batch, "xs", 0);
+    let scattering: Vec<f64> = (0..n).map(|i| elastic[i] + n2n[i]).collect();
+    assert_f64_slice_eq("xs scattering", &channel(&xs, 2, n), &scattering);
+    let total: Vec<f64> = (0..n).map(|i| scattering[i] + capture[i]).collect();
+    assert_f64_slice_eq("xs total", &channel(&xs, 0, n), &total);
+}

--- a/crates/yamc-convert/tests/section_values_fission.rs
+++ b/crates/yamc-convert/tests/section_values_fission.rs
@@ -1,0 +1,691 @@
+//! `total_nu.arrow` and `fission_photon.arrow`, column by column, against the
+//! evaluation the writer was handed.
+//!
+//! Every column of both sections is a verbatim clone of something the parser
+//! already built: `Vec::clone`, `extend_from_slice`, or a literal role string.
+//! No arithmetic happens in `crates/yamc-convert/src/fission_nu.rs` at all, so
+//! every numeric assertion here is exact equality and a tolerance anywhere
+//! would only hide the wrong-slot and wrong-unit mistakes these tests exist to
+//! find.
+//!
+//! Neither section is reachable through `entry::convert_neutron_transport`
+//! without NJOY, so both writers are called directly. That loses nothing:
+//! `entry.rs:257` builds the release with `heating::fission_energy_release`,
+//! and `entry.rs:402-405` then calls `write_total_nu` on the `IncidentNeutron`
+//! unchanged and `write_fission_photon` on that release, behind
+//! `if let Some(release)`. The only production step not exercised is the NJOY
+//! run that fills the energy grids, which neither writer reads.
+//!
+//! # Two kinds of input, and they are not interchangeable
+//!
+//! The first two tests are handed VENDORED evaluations, and are parity checks
+//! against them. The last three are handed inputs this file BUILDS BY HAND, and
+//! are not parity checks against anything: no vendored evaluation reaches those
+//! branches, so a constructed `IncidentNeutron` or `FissionEnergyRelease` is
+//! the only way to reach them at all. Each says so in its own doc comment, and
+//! each gives its constructed fields values that differ from every constant the
+//! writer might hard-code, because two fields that happen to be equal on a
+//! fixture cannot tell a copy from a constant.
+
+mod section_values;
+use section_values::*;
+
+use endf::fission_energy::Component;
+use endf::mf::mf1::FissionEnergyRelease as Mt458Component;
+use endf::product::Yield;
+use endf::{Polynomial, Tabulated1D};
+
+/// The index of one MF=1/MT=458 component in the raw section, by its ENDF-102
+/// name.
+///
+/// Read off `FISSION_ENERGY_COMPONENTS` rather than hard coded, so the
+/// comparison follows the format's own ordering instead of a transcribed 3
+/// and 4.
+fn component_index(name: &str) -> usize {
+    endf::mf::mf1::FISSION_ENERGY_COMPONENTS
+        .iter()
+        .position(|&n| n == name)
+        .unwrap_or_else(|| panic!("no MF=1/MT=458 component named {name}"))
+}
+
+/// The written fission multiplicity must be the evaluation's TOTAL nu-bar.
+///
+/// A failure means one of two things. Either the multiplicity written is the
+/// prompt yield rather than the total, which is issue #364 and a roughly 1.6%
+/// undercount of fission neutrons for U235 with nothing on disk to say so, or
+/// the tabulated pair was reshaped on the way out.
+///
+/// Nothing downstream would notice most of this. `parse_fission_nu`
+/// (`nuclide_arrow.rs:1935-1967`) reads only `yield_type`, `yield_data` and
+/// `yield_shape`, so a load round trip cannot see `particle`, `emission_mode`,
+/// `decay_rate`, `yield_breakpoints` or `yield_interpolation` at all, and a
+/// direct comparison is the only thing that can.
+///
+/// What this FIXTURE can and cannot separate, measured rather than assumed:
+///
+/// - `emission_mode` is discriminated: the derived total says "total" where the
+///   prompt product beside it says "prompt", so reading the wrong product fails.
+/// - `yield_breakpoints` and `yield_interpolation` are discriminated: they are
+///   adjacent `list<int32>` columns filled from adjacent lines of the writer,
+///   and their values differ here ([85] against [2]), so pushing them in the
+///   wrong order fails rather than passing as a matched pair.
+/// - `particle` and `decay_rate` are NOT. U235's derived total and its prompt
+///   product both carry the name "neutron" and a zero decay rate, which are
+///   also the two constants a writer would reach for, so a writer that
+///   hard-coded either would pass every assertion below. All the comparisons
+///   here defend is the `particle`/`emission_mode` transposition, since those
+///   two adjacent utf8 columns do differ on this fixture. The hard-coding is
+///   caught in `total_nu_columns_are_the_products_own_fields_on_every_fission_mt`,
+///   which has to construct its input to do it.
+/// - The writer's search across every fission MT rather than MT 18 alone
+///   (`fission_nu.rs:26-41`) is not exercised: U235 puts fission on MT 18, as
+///   does every other vendored fissile evaluation. Same constructed test.
+///
+/// The `Yield::Polynomial` arm of `write_total_nu` (`fission_nu.rs:44-50`) is
+/// not reached here either: every derived total-nu product in every vendored
+/// fixture is `Yield::Tabulated`. It is covered by
+/// `total_nu_polynomial_yield_is_written_as_bare_coefficients`, again from a
+/// constructed input.
+#[test]
+fn total_nu_is_the_derived_total_and_not_the_prompt_yield() {
+    let data = endf_nuclide(U235_ENDF);
+    let fission = data.reactions.get(&18).expect("U235 gives MT 18");
+    let total = fission
+        .derived_products
+        .first()
+        .expect("MF=1/MT=452 is attached to MT 18 as a derived product");
+
+    let dir = scratch();
+    assert!(
+        yamc_convert::fission_nu::write_total_nu(&data, dir.path()).expect("the writer runs"),
+        "U235 carries MF=1/MT=452 beside MF=1/MT=456, so a total nu-bar must be written"
+    );
+    let batch = section(dir.path(), "total_nu.arrow");
+    assert_schema_is_declared(&batch, "total_nu.arrow");
+    assert_eq!(batch.num_rows(), 1, "total_nu.arrow is one row per nuclide");
+
+    // This product and the prompt one beside it are both called "neutron" on
+    // this fixture, so the comparison catches the transposition with the
+    // adjacent `emission_mode` column and nothing else. See the doc comment.
+    assert_eq!(str_at(&batch, "particle", 0), total.name);
+
+    assert_eq!(
+        str_at(&batch, "emission_mode", 0),
+        total.emission_mode.name()
+    );
+    assert_eq!(
+        str_at(&batch, "emission_mode", 0),
+        "total",
+        "a \"prompt\" here means write_total_nu read products[0] rather than \
+         derived_products[0], which is issue #364"
+    );
+
+    // Zero on this fixture: the total nu-bar covers prompt and delayed together
+    // and has no single precursor, so it carries no decay rate. Zero is also
+    // what a writer would hard-code, which is why this comparison alone does
+    // not defend the column.
+    assert_eq!(f64_at(&batch, "decay_rate", 0), total.decay_rate);
+
+    let Yield::Tabulated(t) = &total.yield_ else {
+        panic!("U235's MF=1/MT=452 is LNU=2, so the derived total is a Tabulated1D");
+    };
+    assert_eq!(str_at(&batch, "yield_type", 0), "Tabulated1D");
+
+    let shape = i32_list(&batch, "yield_shape", 0);
+    assert_i32_slice_eq("yield_shape", &shape, &[2, t.x.len() as i32]);
+    assert_i32_slice_eq("yield_shape", &shape, &[2, 85]);
+
+    // The shape is read from the column and then USED to split the data, which
+    // is how the loader reads it (`nuclide_arrow.rs:1942-1948`). Worth being
+    // straight about what that is worth: the two assertions above already pin
+    // the shape to [2, 85], so the split is equivalent to splitting at half,
+    // and it is those two that catch a transposed shape, not the split. The
+    // length check below earns its place only by reporting a `yield_data` that
+    // disagrees with the declared shape as that, instead of as a panic inside
+    // `split_at` or a slice-length mismatch two lines later.
+    let written = f64_list(&batch, "yield_data", 0);
+    assert_eq!(
+        written.len(),
+        (shape[0] * shape[1]) as usize,
+        "yield_data holds {} values but yield_shape declares {shape:?}, so the \
+         loader would read past the energies or stop short of them",
+        written.len()
+    );
+    let (energy, nu) = written.split_at(shape[1] as usize);
+    assert_f64_slice_eq("total_nu energies", energy, &t.x);
+    assert_f64_slice_eq("total_nu values", nu, &t.y);
+    assert_eq!(energy[0], 1.0e-5);
+    assert_eq!(nu[0], 2.42985);
+
+    let breakpoints = i32_list(&batch, "yield_breakpoints", 0);
+    let interpolation = i32_list(&batch, "yield_interpolation", 0);
+    assert_i32_slice_eq("yield_breakpoints", &breakpoints, &t.breakpoints);
+    assert_i32_slice_eq("yield_interpolation", &interpolation, &t.interpolation);
+    // Asserted by name and separately, and their values differ on this
+    // fixture, so pushing them in the wrong order at `fission_nu.rs:74-75`
+    // fails here rather than passing as a matched pair.
+    assert_i32_slice_eq("yield_breakpoints", &breakpoints, &[85]);
+    assert_i32_slice_eq("yield_interpolation", &interpolation, &[2]);
+
+    // The #364 regression pin. Not a re-derivation of the written values: the
+    // MF=1/MT=456 prompt table is a different parsed object on the same
+    // reaction, and the whole bug is writing that one instead.
+    let prompt = fission
+        .products
+        .first()
+        .expect("MF=1/MT=456 is attached to MT 18 as an ordinary product");
+    assert_eq!(prompt.emission_mode, endf::EmissionMode::Prompt);
+    let Yield::Tabulated(p) = &prompt.yield_ else {
+        panic!("U235's MF=1/MT=456 is LNU=2 as well");
+    };
+    assert_ne!(
+        nu,
+        p.y.as_slice(),
+        "the written nu-bar is the MF=1/MT=456 PROMPT table, not the MF=1/MT=452 total"
+    );
+    assert_eq!(p.y[0], 2.414, "the prompt yield at 1e-5 eV, for contrast");
+    // Total is prompt plus delayed, so it can never be below prompt on a
+    // shared abscissa. A swap of the two products fails this on every point,
+    // not just the first.
+    assert_f64_slice_eq("prompt energies", &p.x, &t.x);
+    for (i, (&total_nu, &prompt_nu)) in nu.iter().zip(&p.y).enumerate() {
+        assert!(
+            total_nu > prompt_nu,
+            "at {:e} eV the written total nu-bar is {total_nu}, which is not above \
+             the prompt yield {prompt_nu}",
+            energy[i]
+        );
+    }
+
+    // Absence is the loader's signal for "this nuclide has no total nu-bar",
+    // so an empty table would be a different answer rather than the same one.
+    // This half does reach the writer and it has teeth: a search widened from
+    // the fission MTs to `data.reactions.values()`, falling back to
+    // `products.first()`, finds Li6's ordinary neutron products and writes a
+    // nu-bar for a nuclide that does not fission at all.
+    let non_fissile = scratch();
+    assert!(
+        !yamc_convert::fission_nu::write_total_nu(&li6_ace(), non_fissile.path())
+            .expect("the writer runs"),
+        "Li6 has no fission reaction and so no derived total nu-bar to write"
+    );
+    assert!(
+        absent(non_fissile.path(), "total_nu.arrow"),
+        "a nuclide with no total nu-bar must leave the section absent, not empty"
+    );
+}
+
+/// Both fission energy release photon terms must survive in their own forms.
+///
+/// A failure means the photon release scaling was dropped, halved or made
+/// unloadable. The reader forms `(prompt + delayed) / prompt` from the two
+/// rows and refuses half a section (`nuclide_arrow.rs:107-118`), so the row
+/// count and the role order are load-bearing. So is the interpolation column:
+/// `ReleaseFunction::from_tabulated`
+/// (`crates/yamc-nuclide/src/fission_photon.rs:74-83`) hard-errors on any
+/// scheme other than 2, so writing the breakpoints ([18]) into that slot makes
+/// the whole nuclide unloadable rather than merely wrong.
+///
+/// This test pins those two slots BY VALUE and does not run the loader. An
+/// earlier draft fed the written columns back through `from_tabulated` and
+/// called that a load test; it was deleted rather than kept, because every gate
+/// inside that function (`x.len() == y.len()`, at least two points, one region,
+/// scheme 2) is entailed by the value assertions that come first, so the call
+/// could not fail and its result could not differ from the expected one. It
+/// restated the assertions above it.
+///
+/// Note the asymmetry this pins: `write_fission_photon` pushes interpolation
+/// BEFORE breakpoints (`fission_nu.rs:171-172`) while `write_total_nu` pushes
+/// breakpoints BEFORE interpolation (`fission_nu.rs:74-75`), and the two
+/// declared schemas genuinely differ in that order. Reading by name in both
+/// tests is what keeps a "tidy-up" of one from silently corrupting the other.
+///
+/// The Li6 tail is a negative on the PRODUCTION GUARD and not on this writer:
+/// `fission_energy_release` gives `Ok(None)` and the `if let Some(release)` at
+/// `entry.rs:404` then never calls `write_fission_photon` at all, so no defect
+/// inside the writer can make that half fail. The writer's own refusal path,
+/// a polynomial term with no coefficients at `fission_nu.rs:145-152`, is
+/// unreachable from any vendored evaluation and is covered separately by
+/// `a_polynomial_release_term_with_no_coefficients_is_refused`.
+///
+/// Before this test no column of this section had ever been compared to
+/// anything: the existing hermetic test (`sections.rs:597`) builds the
+/// `FissionEnergyRelease` and stops one call short of the writer.
+#[test]
+fn fission_photon_carries_both_release_terms_in_their_own_forms() {
+    let material = endf_material(U235_ENDF);
+    let release = yamc_convert::heating::fission_energy_release(&material)
+        .expect("the release reads")
+        .expect("U235 carries MF=1/MT=458");
+
+    let dir = scratch();
+    yamc_convert::fission_nu::write_fission_photon(&release, dir.path()).expect("the writer runs");
+    let batch = section(dir.path(), "fission_photon.arrow");
+    assert_schema_is_declared(&batch, "fission_photon.arrow");
+    assert_eq!(
+        batch.num_rows(),
+        2,
+        "both terms are written or neither; the reader refuses half a section"
+    );
+    assert_eq!(str_at(&batch, "role", 0), "prompt_photons");
+    assert_eq!(str_at(&batch, "role", 1), "delayed_photons");
+
+    // `kind` is per row rather than per file, and U235 is the case that proves
+    // it: LFC=1 puts an IFC=4 TAB1 on the prompt term while NPLY=0 sends the
+    // delayed one down the Sher-Beck branch at `fission_energy.rs:146-149`.
+    let raw = material.mf1_mt458().expect("U235 carries MF=1/MT=458");
+    assert_eq!(raw.lfc, 1);
+    assert_eq!(raw.nply, 0);
+    assert!(matches!(release.prompt_photons, Component::Tabulated(_)));
+    assert_eq!(str_at(&batch, "kind", 0), "tabulated");
+    assert!(matches!(release.delayed_photons, Component::Polynomial(_)));
+    assert_eq!(str_at(&batch, "kind", 1), "polynomial");
+
+    // Row 0 is compared against the RAW MF=1/MT=458 EIFC table rather than
+    // against the derived `Component`, so this checks the whole chain from the
+    // evaluation's own record to the column and not just the last clone.
+    let Mt458Component::Tabulated { eifc, .. } = &raw.components[component_index("EGP")] else {
+        panic!("U235's EGP component is the LFC=1 tabulation");
+    };
+    let x = f64_list(&batch, "x", 0);
+    let y = f64_list(&batch, "y", 0);
+    assert_f64_slice_eq("prompt_photons x", &x, &eifc.x);
+    assert_f64_slice_eq("prompt_photons y", &y, &eifc.y);
+    assert_eq!(x.len(), 18);
+    // Not implied by the comparisons above, which measure each column against
+    // its own side of the same parse: a y column LONGER than x passes all of
+    // them, and still produces a file the reader refuses at load
+    // (`fission_photon.rs:52`). A y column SHORTER than x is caught either way,
+    // by the `y[17]` literal below.
+    assert_eq!(x.len(), y.len());
+    assert_eq!(x[0], 1.0e-5);
+    assert_eq!(x[17], 3.0e7);
+    assert_eq!(y[0], 7.281253e6);
+    assert_eq!(y[17], 1.262714e7);
+
+    let interpolation = i32_list(&batch, "interpolation", 0);
+    let breakpoints = i32_list(&batch, "breakpoints", 0);
+    assert_i32_slice_eq("prompt_photons interpolation", &interpolation, &[2]);
+    assert_i32_slice_eq("prompt_photons breakpoints", &breakpoints, &[18]);
+    assert_i32_slice_eq(
+        "prompt_photons interpolation",
+        &interpolation,
+        &eifc.interpolation,
+    );
+    assert_i32_slice_eq(
+        "prompt_photons breakpoints",
+        &breakpoints,
+        &eifc.breakpoints,
+    );
+
+    // `float_lists`, not `float_lists_or_null`, so the unused half of a row is
+    // an empty list and not a null. The two load identically and are still
+    // different files, so this goes to the array rather than through a decoded
+    // Vec.
+    assert!(!is_null(&batch, "coefficients", 0));
+    assert_eq!(list_len(&batch, "coefficients", 0), 0);
+
+    // Row 1. The constant is the evaluation's own EGD coefficient and the
+    // slope is the Sher-Beck one the parser supplies, so the two halves have
+    // independent provenance and are asserted separately.
+    let Mt458Component::Polynomial(egd) = &raw.components[component_index("EGD")] else {
+        panic!("U235's EGD component is a single polynomial coefficient");
+    };
+    let coefficients = f64_list(&batch, "coefficients", 1);
+    assert_eq!(coefficients.len(), 2);
+    assert_eq!(coefficients[0], egd[0].0);
+    assert_eq!(coefficients[0], 6.33e6);
+    assert_eq!(
+        coefficients[1], -0.075,
+        "the Sher-Beck slope from fission_energy.rs:149"
+    );
+    let Component::Polynomial(delayed) = &release.delayed_photons else {
+        unreachable!("checked above");
+    };
+    assert_f64_slice_eq(
+        "delayed_photons coefficients",
+        &coefficients,
+        &delayed.coefficients,
+    );
+    for column in ["x", "y", "interpolation", "breakpoints"] {
+        assert!(!is_null(&batch, column, 1), "{column} row 1 is null");
+        assert_eq!(
+            list_len(&batch, column, 1),
+            0,
+            "{column} row 1 is not empty"
+        );
+    }
+
+    // The other shape this file takes. Am244 is LFC=0 with NPLY=2, so both
+    // terms are polynomials of three coefficients and every list column is
+    // empty on both rows.
+    let am_material = endf_material(AM244_ENDF);
+    let am_release = yamc_convert::heating::fission_energy_release(&am_material)
+        .expect("the release reads")
+        .expect("Am244 carries MF=1/MT=458");
+    let am_dir = scratch();
+    yamc_convert::fission_nu::write_fission_photon(&am_release, am_dir.path())
+        .expect("the writer runs");
+    let am_batch = section(am_dir.path(), "fission_photon.arrow");
+    assert_eq!(am_batch.num_rows(), 2);
+    assert_eq!(str_at(&am_batch, "role", 0), "prompt_photons");
+    assert_eq!(str_at(&am_batch, "role", 1), "delayed_photons");
+
+    let am_raw = am_material.mf1_mt458().expect("Am244 carries MF=1/MT=458");
+    assert_eq!(am_raw.lfc, 0);
+    assert_eq!(am_raw.nply, 2);
+    for (row, name) in [(0, "EGP"), (1, "EGD")] {
+        assert_eq!(str_at(&am_batch, "kind", row), "polynomial");
+        let Mt458Component::Polynomial(pairs) = &am_raw.components[component_index(name)] else {
+            panic!("Am244's {name} component is a polynomial");
+        };
+        // The (coefficient, uncertainty) pairs with the uncertainties dropped.
+        // The NPLY=2 unit correction at `fission_energy.rs:132-138` only fires
+        // when the second-order term is large enough to be the ENDF/B-VII.1
+        // MeV mistake, and Am244's is exactly zero, so the raw coefficients
+        // are an independent oracle here rather than a partial one.
+        let expected: Vec<f64> = pairs.iter().map(|&(c, _)| c).collect();
+        assert_eq!(expected.len(), 3, "NPLY=2 gives three coefficients");
+        assert_eq!(expected[2], 0.0);
+        assert_f64_slice_eq(
+            &format!("Am244 {name} coefficients"),
+            &f64_list(&am_batch, "coefficients", row),
+            &expected,
+        );
+        for column in ["x", "y", "interpolation", "breakpoints"] {
+            assert!(!is_null(&am_batch, column, row), "{column} is null");
+            assert_eq!(list_len(&am_batch, column, row), 0, "{column} is not empty");
+        }
+    }
+
+    // The negative, on the production guard rather than on the writer. Li6 has
+    // no MF=1/MT=458, so there is no release and the `if let Some(release)` at
+    // `entry.rs:404` never reaches `write_fission_photon`: `Ok(None)` is the
+    // whole of "this nuclide has no fission_photon.arrow". It is distinct from
+    // an `Err`, which is what a fissile evaluation whose release cannot be read
+    // gives.
+    let li6 = endf_material(LI6_ENDF);
+    assert!(li6.mf1_mt458().is_none());
+    assert!(
+        yamc_convert::heating::fission_energy_release(&li6)
+            .expect("the release reads")
+            .is_none(),
+        "a nuclide with no MF=1/MT=458 must give no release rather than an empty one"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Constructed inputs.
+//
+// Everything below is BUILT BY HAND rather than parsed, because no vendored
+// evaluation reaches the branch under test. None of it is evaluation parity and
+// none of it should be read as such: the values are chosen to be different from
+// one another and from the constants the writer might hard-code, which is the
+// one thing a fixture whose two columns happen to agree cannot do.
+// ---------------------------------------------------------------------------
+
+/// The `name` on the constructed total-nu product.
+///
+/// Deliberately not "neutron". Every real evaluation's total and prompt
+/// products are both called "neutron", so that is exactly the constant a writer
+/// could hard-code and stay green on every vendored fixture.
+const SENTINEL_PARTICLE: &str = "sentinel-particle";
+
+/// The `decay_rate` on the constructed total-nu product, in inverse seconds.
+///
+/// Deliberately not 0.0, for the same reason: a real total nu-bar has no
+/// precursor and carries zero here, so zero is the constant to defend against.
+const SENTINEL_DECAY_RATE: f64 = 3.75e-3;
+
+/// A fissionable `IncidentNeutron` built by hand, with a derived total nu-bar
+/// on `fission_mt`.
+///
+/// CONSTRUCTED, not parsed: there is no evaluation behind this and no parity
+/// claim attached to it. The shape is the one the writer's own comment
+/// (`fission_nu.rs:26-34`) describes for U240: MT 18 is present and redundant
+/// and carries an ordinary PROMPT product, while the derived total sits on
+/// whichever fission MT the caller asks for. Two consequences are deliberate.
+/// A search narrowed to MT 18 finds a reaction with no derived product at all
+/// and writes nothing, so the narrowing shows up as an absent file rather than
+/// as wrong values. And a search that fell back to `products.first()` finds the
+/// MT 18 prompt product, whose fields differ from the sentinel ones on every
+/// column below.
+fn constructed_fissile_nuclide(fission_mt: i32, total_yield: Yield) -> endf::IncidentNeutron {
+    let mut mt18 = endf::Reaction::new(18);
+    mt18.redundant = true;
+    mt18.products.push(endf::Product {
+        name: "neutron".to_string(),
+        emission_mode: endf::EmissionMode::Prompt,
+        decay_rate: 0.0,
+        yield_: Yield::Tabulated(Tabulated1D::new(vec![1.0e-5, 2.0e7], vec![2.41, 4.20])),
+        ..Default::default()
+    });
+
+    let total = endf::Product {
+        name: SENTINEL_PARTICLE.to_string(),
+        // Neither "total" (what the section is for) nor "prompt" (what #364
+        // wrote instead), so a writer that hard-codes either one fails.
+        emission_mode: endf::EmissionMode::Delayed,
+        decay_rate: SENTINEL_DECAY_RATE,
+        yield_: total_yield,
+        ..Default::default()
+    };
+
+    let mut data = endf::IncidentNeutron::new(92, 240, 0);
+    if fission_mt == 18 {
+        mt18.derived_products.push(total);
+        data.reactions.insert(18, mt18);
+    } else {
+        data.reactions.insert(18, mt18);
+        let mut chance = endf::Reaction::new(fission_mt);
+        chance.derived_products.push(total);
+        data.reactions.insert(fission_mt, chance);
+    }
+    data
+}
+
+/// A `FissionEnergyRelease` with the two photon terms given and a distinct
+/// placeholder in each of the other five components.
+///
+/// CONSTRUCTED, not parsed. `write_fission_photon` reads `prompt_photons` and
+/// `delayed_photons` and nothing else (`fission_nu.rs:130-133`), so the other
+/// five only have to exist; they are given non-empty, mutually different
+/// coefficients so that a writer reaching for the wrong component would take a
+/// well formed term and change the outcome of the refusal test below.
+fn constructed_release(
+    prompt_photons: Component,
+    delayed_photons: Component,
+) -> endf::FissionEnergyRelease {
+    let term = |zeroth: f64| Component::Polynomial(Polynomial::new(vec![zeroth, -0.075]));
+    endf::FissionEnergyRelease {
+        fragments: term(1.69e8),
+        prompt_neutrons: term(4.94e6),
+        delayed_neutrons: term(7.4e3),
+        prompt_photons,
+        delayed_photons,
+        betas: term(6.5e6),
+        neutrinos: term(8.75e6),
+    }
+}
+
+/// `particle`, `emission_mode`, `decay_rate` and both region lists are copies of
+/// the product's own fields, and the product is looked for on every fission MT
+/// rather than on 18 alone.
+///
+/// CONSTRUCTED INPUT, and no vendored evaluation can stand in for it. Three
+/// writer defects survive every assertion in
+/// `total_nu_is_the_derived_total_and_not_the_prompt_yield`:
+///
+/// - `strings(std::slice::from_ref(&total.name))` replaced by a literal
+///   `"neutron"`, which is right on every evaluation there is;
+/// - `floats(&[total.decay_rate])` replaced by `floats(&[0.0])`, likewise;
+/// - `FISSION_MTS.iter()` narrowed back to `[18].iter()`, the U240 regression
+///   the writer's own comment (`fission_nu.rs:26-34`) is about, which is right
+///   for every vendored fissile evaluation since all of them fission on 18. The
+///   only test that covered the narrowing is `sections.rs:833`, which announces
+///   a skip without NJOY and a full ENDF tree, so it covers nothing on CI.
+///
+/// A hard-coded `"total"` in the `emission_mode` slot survives the parity tests
+/// as well, for the same reason, and is caught here too. So does truncating
+/// either region list to its first element: U235's nu-bar is a single
+/// interpolation region, so `t.breakpoints.clone()` and `vec![t.breakpoints[0]]`
+/// write the same bytes there. The constructed yield below has TWO regions, of
+/// different widths and different schemes, so a truncation fails and so does a
+/// swap of the two lists.
+///
+/// The three sentinel fields are not physical: a real MF=1/MT=452 total is a
+/// neutron yield, with no precursor, whose emission mode is `Total`. Being
+/// different from every constant the writer might reach for is the whole point
+/// of them, and it is the one thing the evaluations cannot be. The two-region
+/// yield, by contrast, is an ordinary shape the format allows and the vendored
+/// evaluations happen not to use for nu-bar.
+#[test]
+fn total_nu_columns_are_the_products_own_fields_on_every_fission_mt() {
+    // The literal list, not the writer's own constant, so this cannot be
+    // satisfied by narrowing the constant. Pinned so a sixth fission MT has to
+    // arrive in the loop below as well as in the writer.
+    let fission_mts = [18, 19, 20, 21, 38];
+    assert_eq!(yamc_convert::fast_xs::FISSION_MTS, fission_mts);
+
+    for mt in fission_mts {
+        // Two regions: histogram up to the second point, then linear-linear to
+        // the fourth. Nothing vendored has more than one region here.
+        let yield_ = Yield::Tabulated(Tabulated1D::with_regions(
+            vec![1.0e-5, 1.0, 1.0e6, 2.0e7],
+            vec![2.44, 2.45, 3.10, 4.51],
+            vec![2, 4],
+            vec![1, 2],
+        ));
+        let data = constructed_fissile_nuclide(mt, yield_);
+        let dir = scratch();
+        assert!(
+            yamc_convert::fission_nu::write_total_nu(&data, dir.path()).expect("the writer runs"),
+            "the derived total nu-bar is on MT {mt}, which the writer must search"
+        );
+        let batch = section(dir.path(), "total_nu.arrow");
+
+        assert_eq!(
+            str_at(&batch, "particle", 0),
+            SENTINEL_PARTICLE,
+            "particle must be the product's own name, not the constant \"neutron\" (MT {mt})"
+        );
+        assert_eq!(
+            str_at(&batch, "emission_mode", 0),
+            "delayed",
+            "emission_mode must be the product's own mode, not a constant and not \
+             the MT 18 prompt product's (MT {mt})"
+        );
+        assert_eq!(
+            f64_at(&batch, "decay_rate", 0),
+            SENTINEL_DECAY_RATE,
+            "decay_rate must be the product's own rate, not the constant 0.0 (MT {mt})"
+        );
+        assert_i32_slice_eq(
+            "yield_breakpoints",
+            &i32_list(&batch, "yield_breakpoints", 0),
+            &[2, 4],
+        );
+        assert_i32_slice_eq(
+            "yield_interpolation",
+            &i32_list(&batch, "yield_interpolation", 0),
+            &[1, 2],
+        );
+    }
+}
+
+/// The `Yield::Polynomial` arm of `write_total_nu`, which no evaluation reaches.
+///
+/// CONSTRUCTED INPUT. Every derived total-nu product in every vendored fixture
+/// is `Yield::Tabulated` (LNU=2), so `fission_nu.rs:44-50` is dead code against
+/// the fixtures and every defect in it survives both parity tests above: the
+/// arm could label the coefficients "Tabulated1D", give them the Tabulated
+/// arm's `[2, n]` shape, or push a region into columns a polynomial has none
+/// of, and nothing in this repository would notice.
+///
+/// The three coefficients differ from one another in sign and magnitude, so a
+/// reversed or duplicated write fails. There are three of them rather than two
+/// so that a shape carrying the Tabulated arm's leading 2, rather than the
+/// coefficient count, fails as well.
+#[test]
+fn total_nu_polynomial_yield_is_written_as_bare_coefficients() {
+    let coefficients = vec![2.4367, 0.0611, -0.00123];
+    let data =
+        constructed_fissile_nuclide(18, Yield::Polynomial(Polynomial::new(coefficients.clone())));
+
+    let dir = scratch();
+    assert!(
+        yamc_convert::fission_nu::write_total_nu(&data, dir.path()).expect("the writer runs"),
+        "a derived total nu-bar is present, polynomial or not"
+    );
+    let batch = section(dir.path(), "total_nu.arrow");
+
+    assert_eq!(str_at(&batch, "yield_type", 0), "Polynomial");
+    assert_f64_slice_eq(
+        "yield_data",
+        &f64_list(&batch, "yield_data", 0),
+        &coefficients,
+    );
+    assert_i32_slice_eq(
+        "yield_shape",
+        &i32_list(&batch, "yield_shape", 0),
+        &[coefficients.len() as i32],
+    );
+
+    // A polynomial has no interpolation regions, so both list columns are
+    // EMPTY and not null: `int_lists`, not an `or_null` variant. The loader
+    // decodes the two identically (`arrow_helpers.rs:338-344`) and they are
+    // still different files, so this goes to the array.
+    for column in ["yield_breakpoints", "yield_interpolation"] {
+        assert!(!is_null(&batch, column, 0), "{column} is null");
+        assert_eq!(list_len(&batch, column, 0), 0, "{column} is not empty");
+    }
+}
+
+/// A polynomial release term with no coefficients is refused, not written.
+///
+/// CONSTRUCTED INPUT. `FissionEnergyRelease::from_material` cannot build an
+/// empty polynomial out of any vendored evaluation, so the writer's only
+/// defensive path (`fission_nu.rs:145-152`) is unreachable from parsed bytes:
+/// deleting the refusal outright leaves both parity tests above green, and
+/// nothing else in the repository covers it.
+///
+/// What it defends: the reader rejects a polynomial term with no coefficients
+/// at load (`arrow/nuclide_arrow.rs:71-76`), so writing one produces a nuclide
+/// directory that cannot be read at all. Failing the conversion, with the term
+/// named, is the difference between a build error and a library that only
+/// breaks when someone tries to use it.
+///
+/// Both terms are exercised because the check sits inside the loop over them
+/// (`fission_nu.rs:143-152`): a version that validated only the first term
+/// would pass the prompt case and write the delayed one.
+#[test]
+fn a_polynomial_release_term_with_no_coefficients_is_refused() {
+    let empty = || Component::Polynomial(Polynomial::new(Vec::new()));
+    let well_formed = || Component::Polynomial(Polynomial::new(vec![6.33e6, -0.075]));
+
+    for (role, release) in [
+        (
+            "prompt_photons",
+            constructed_release(empty(), well_formed()),
+        ),
+        (
+            "delayed_photons",
+            constructed_release(well_formed(), empty()),
+        ),
+    ] {
+        let dir = scratch();
+        let error = match yamc_convert::fission_nu::write_fission_photon(&release, dir.path()) {
+            Err(error) => error,
+            Ok(()) => panic!("the empty {role} term must be refused, not written"),
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains(role),
+            "the refusal must name the term it refused, got: {message}"
+        );
+        assert!(
+            absent(dir.path(), "fission_photon.arrow"),
+            "{role}: the refusal must leave no half-written section behind"
+        );
+    }
+}

--- a/crates/yamc-convert/tests/section_values_neutron.rs
+++ b/crates/yamc-convert/tests/section_values_neutron.rs
@@ -1,0 +1,1224 @@
+//! `nuclide.arrow`, `urr.arrow` and `reactions.arrow`, column by column,
+//! against the `endf::IncidentNeutron` the writer was handed.
+//!
+//! The writers are called directly rather than through
+//! `entry::convert_neutron_xs`, so these tests hold the identical
+//! `IncidentNeutron` value the writer saw and compare against it rather than
+//! against a second parse of the same bytes.
+//!
+//! Two routes are exercised, because they reach different branches. The ACE
+//! route (`Li6.ace.xz`) carries one temperature, a real 721 point grid and
+//! twelve threshold reactions. The ENDF route
+//! (`n-003_Li_006_trimmed.endf.xz` through `IncidentNeutron::from_endf`) sets
+//! no `k_ts`, no `atomic_weight_ratio` and no nuclide grid, and keys every
+//! cross section at `"0K"`. The unresolved resonance tables come from
+//! `synthetic-urr.ace.xz`, the only vendored input that reaches
+//! `write_urr`'s write branch at all.
+//!
+//! Three of the eleven tests are built from a HAND-CONSTRUCTED
+//! `IncidentNeutron` rather than from a parsed evaluation, and their names all
+//! begin with `constructed_`. They exist because of what the vendored bytes
+//! cannot say: every vendored neutron evaluation carries at most ONE
+//! temperature, and the single one that carries unresolved resonance tables
+//! carries a single row whose scalar columns are all equal to each other or to
+//! a constant. A writer that swapped two of those columns, or that ignored a
+//! parsed field and wrote a literal in its place, passes every test built from
+//! vendored bytes. The constructed inputs give those fields deliberately
+//! DIFFERENT values, which is the only thing that separates them. They are not
+//! evaluation parity and nothing in them should be read as such.
+
+mod section_values;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use arrow_array::RecordBatch;
+use endf::{IncidentNeutron, ProbabilityTables, Reaction, Tabulated1D};
+
+use section_values::*;
+
+// ---------------------------------------------------------------------------
+// Local helpers. Nothing here is shared: the sibling files have their own. The
+// only one that asserts is `written_on_grid`, and it asserts only to turn a
+// slice range panic into a sentence.
+// ---------------------------------------------------------------------------
+
+/// The `energy_temperatures` rule of `nuclide.rs:41-51`, restated.
+///
+/// `data.temperatures()` filtered to the keys `data.energy` holds, in that
+/// order, then whatever else the map holds in its own (BTreeMap, so
+/// lexicographic) order. This is a restatement of the writer rather than an
+/// independent derivation, so on its own it is a wiring check: it pins which
+/// list reached which column, not that the ordering rule is the right one. On
+/// the single temperature Li6 fixture the two phases cannot be told apart at
+/// all, which is why
+/// `constructed_two_temperature_nuclide_separates_the_two_temperature_columns`
+/// spells the expected list out as literals beside this.
+fn expected_energy_temperatures(data: &IncidentNeutron) -> Vec<String> {
+    let temperatures = data.temperatures();
+    let mut out: Vec<String> = temperatures
+        .iter()
+        .filter(|t| data.energy.contains_key(*t))
+        .cloned()
+        .collect();
+    out.extend(
+        data.energy
+            .keys()
+            .filter(|t| !temperatures.contains(t))
+            .cloned(),
+    );
+    out
+}
+
+/// The same two phase rule for one reaction's cross sections
+/// (`reactions.rs:82-87`), which reads `rx.xs` rather than `data.energy`.
+///
+/// A restatement of the writer, with the same caveat: it pins which list
+/// reached which column. The order it encodes is discriminated only in
+/// `constructed_two_temperature_reactions_keep_each_curve_with_its_own_temperature`,
+/// which is the one case in this file where the processed order and the map's
+/// own order differ, and which spells the expected list out as a literal
+/// rather than calling this.
+fn expected_xs_temperatures(data: &IncidentNeutron, rx: &Reaction) -> Vec<String> {
+    let temperatures = data.temperatures();
+    let mut out: Vec<String> = temperatures
+        .iter()
+        .filter(|t| rx.xs.contains_key(*t))
+        .cloned()
+        .collect();
+    out.extend(rx.xs.keys().filter(|t| !temperatures.contains(t)).cloned());
+    out
+}
+
+/// Where each MT sits in a `reactions.arrow` read back as one row space.
+fn rows_by_mt(batch: &RecordBatch) -> BTreeMap<i32, usize> {
+    (0..batch.num_rows())
+        .map(|row| (i32_at(batch, "mt", row), row))
+        .collect()
+}
+
+/// The MT column, in file order.
+fn written_mts(batch: &RecordBatch) -> Vec<i32> {
+    (0..batch.num_rows())
+        .map(|row| i32_at(batch, "mt", row))
+        .collect()
+}
+
+/// One written row's first (and here only) cross section, laid onto an
+/// `n_energy` long zero vector at the threshold index the same row carries.
+///
+/// Deliberately not `synthesis::on_grid`: that is the function the writer used
+/// to build the synthesized rows, so reconstructing with it would restate the
+/// writer instead of checking it. This works only from the file's own two
+/// columns.
+#[track_caller]
+fn written_on_grid(
+    batch: &RecordBatch,
+    mt_rows: &BTreeMap<i32, usize>,
+    mt: i32,
+    n: usize,
+) -> Vec<f64> {
+    let row = mt_rows[&mt];
+    let values = nested_f64_list(batch, "xs_values", row);
+    let threshold = i32_list(batch, "xs_threshold_idx", row)[0] as usize;
+    // Named, because without it the line below panics with "range end index
+    // 722 out of range for slice of length 721", which names neither the MT
+    // nor the column that is wrong. A threshold written one too high is a
+    // defect this file is looking for, so it deserves a sentence.
+    assert!(
+        threshold + values[0].len() <= n,
+        "MT {mt}: threshold {threshold} plus {} written values runs past the {n} point grid",
+        values[0].len()
+    );
+    let mut out = vec![0.0; n];
+    out[threshold..threshold + values[0].len()].copy_from_slice(&values[0]);
+    out
+}
+
+/// `round(x, 6)` the way the URR fixture's generator writes it.
+fn round6(x: f64) -> f64 {
+    (x * 1e6).round() / 1e6
+}
+
+/// The index of the first value that is not zero.
+fn first_nonzero(values: &[f64]) -> Option<usize> {
+    values.iter().position(|&v| v != 0.0)
+}
+
+// ---------------------------------------------------------------------------
+// nuclide.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means nuclide.arrow no longer describes the table it was written
+/// from: the identity the loader keys everything else off, the kT list nothing
+/// in this workspace reads back, or the energy grid every binary search
+/// downstream runs on. `nuclide_section_matches_the_parsed_table` checks name,
+/// Z and A against literals and then only that the grid is non-decreasing, so
+/// a grid of 721 copies of one value, or a grid off by the MeV to eV factor,
+/// passes it today.
+///
+/// What this fixture cannot establish, said here so nobody stops looking:
+/// every list on it has exactly ONE element, so `temperatures` and
+/// `energy_temperatures` both hold `["294K"]` and swapping the two
+/// `string_list` arguments at nuclide.rs:65 and :67 passes everything below.
+/// A one element list has no permutation either, so the kT to temperature
+/// round trip cannot see one. Both are separated in
+/// `constructed_two_temperature_nuclide_separates_the_two_temperature_columns`.
+/// What is independent of the writer HERE is `energy_values` against the raw
+/// ESZ block of the ACE table, and the AWR against the ACE header.
+#[test]
+fn nuclide_columns_are_the_parsed_tables_own_numbers() {
+    let data = li6_ace();
+    let table = ace_table(LI6_ACE);
+    let dir = scratch();
+    yamc_convert::nuclide::write_nuclide(&data, dir.path()).expect("nuclide.arrow is written");
+    let batch = section(dir.path(), "nuclide.arrow");
+
+    assert_eq!(batch.num_rows(), 1, "nuclide.arrow is one row per nuclide");
+
+    // Against the parsed value AND against the literal. Comparing only against
+    // data.name() passes when both sides are wrong the same way.
+    assert_eq!(str_at(&batch, "name", 0), data.name());
+    assert_eq!(str_at(&batch, "name", 0), "Li6");
+    assert_eq!(i32_at(&batch, "Z", 0), data.atomic_number as i32);
+    assert_eq!(i32_at(&batch, "Z", 0), 3);
+    assert_eq!(i32_at(&batch, "A", 0), data.mass_number as i32);
+    assert_eq!(i32_at(&batch, "A", 0), 6);
+
+    // Exact: the AWR is copied from the ACE header with no arithmetic on the
+    // way, so anything but bit equality is a defect rather than rounding.
+    let awr = f64_at(&batch, "atomic_weight_ratio", 0);
+    assert_eq!(
+        awr,
+        data.atomic_weight_ratio
+            .expect("the ACE route sets an atomic weight ratio")
+    );
+    assert_eq!(awr, table.atomic_weight_ratio);
+    assert_eq!(awr, 5.96345);
+
+    let temperatures = str_list(&batch, "temperatures", 0);
+    assert_eq!(temperatures, data.temperatures());
+    assert_eq!(temperatures, vec!["294K".to_string()]);
+
+    // One deterministic multiply on each side, so exact is right here too.
+    let k_ts = f64_list(&batch, "kTs", 0);
+    assert_f64_slice_eq("kTs", &k_ts, &data.k_ts);
+    assert_f64_slice_eq("kTs", &k_ts, &[table.kt * endf::EV_PER_MEV]);
+    // Through temperature_str rather than a reimplementation of its banker's
+    // rounding (crates/endf/src/data.rs:321-328). Nothing in this workspace
+    // reads kTs back, so nothing downstream would ever notice a kT that named
+    // the wrong temperature. On one element this only says the single pair
+    // agrees; the constructed test is where a permutation becomes possible.
+    for (kt, t) in k_ts.iter().zip(&temperatures) {
+        assert_eq!(
+            &endf::data::temperature_str(kt / endf::K_BOLTZMANN),
+            t,
+            "kT {kt} does not name temperature {t}"
+        );
+    }
+
+    let energy_temperatures = str_list(&batch, "energy_temperatures", 0);
+    assert_eq!(energy_temperatures, expected_energy_temperatures(&data));
+    assert_eq!(energy_temperatures, vec!["294K".to_string()]);
+
+    let grids = nested_f64_list(&batch, "energy_values", 0);
+    assert_eq!(
+        grids.len(),
+        energy_temperatures.len(),
+        "one grid per energy temperature"
+    );
+    for (grid, t) in grids.iter().zip(&energy_temperatures) {
+        assert_f64_slice_eq(&format!("energy_values[{t}]"), grid, &data.energy[t]);
+        assert_eq!(grid.len(), 721, "the Li6 ACE grid is 721 points");
+        // Strictly, not the >= the existing test allows: a duplicated point
+        // passes that and breaks every binary search built on the grid.
+        assert!(
+            grid.windows(2).all(|w| w[1] > w[0]),
+            "the grid at {t} is not strictly increasing"
+        );
+    }
+
+    // The one derivation that does not go through the writer at all: the ESZ
+    // block of the raw ACE table, in MeV, times EV_PER_MEV.
+    let base = usize::try_from(table.jxs[1]).expect("JXS(1) locates the ESZ block");
+    let n_energy = usize::try_from(table.nxs[3]).expect("NXS(3) is the grid length");
+    let from_xss: Vec<f64> = (0..n_energy)
+        .map(|k| table.xss[base + k] * endf::EV_PER_MEV)
+        .collect();
+    assert_f64_slice_eq(
+        "energy_values against the raw ESZ block",
+        &grids[0],
+        &from_xss,
+    );
+    assert_eq!(grids[0][0], 9.999999999999999e-6);
+    assert_eq!(grids[0][720], 2e8);
+}
+
+/// A failure means the ENDF branch of `write_nuclide` started inventing a
+/// temperature or an energy grid the evaluation does not carry. It is the only
+/// hermetic case that reaches the `atomic_weight_ratio` fallback, because
+/// `IncidentNeutron::from_endf` never sets `k_ts`, never sets
+/// `atomic_weight_ratio` and leaves `data.energy` empty
+/// (crates/endf/src/incident_neutron.rs:41-43, :106-119).
+///
+/// This doc comment used to claim the test was also "the only hermetic case
+/// that separates temperatures from energy_temperatures". It separates
+/// nothing: on this route BOTH lists are empty, so swapping the two
+/// `string_list` arguments at nuclide.rs:65 and :67 leaves every assertion
+/// here true. That separation is done by
+/// `constructed_two_temperature_nuclide_separates_the_two_temperature_columns`.
+/// What the emptiness assertions below do carry is the other direction: a
+/// writer that invented a temperature, a kT or a grid on this route fails
+/// them, and empty against null is a real difference in the written file.
+#[test]
+fn the_endf_route_writes_no_temperature_and_no_grid_it_was_not_given() {
+    let data = endf_nuclide(LI6_ENDF);
+    let dir = scratch();
+    yamc_convert::nuclide::write_nuclide(&data, dir.path()).expect("nuclide.arrow is written");
+    let batch = section(dir.path(), "nuclide.arrow");
+
+    assert_eq!(batch.num_rows(), 1);
+    assert_eq!(str_at(&batch, "name", 0), "Li6");
+    assert_eq!(i32_at(&batch, "Z", 0), 3);
+    assert_eq!(i32_at(&batch, "A", 0), 6);
+
+    // Pinning the fallback at nuclide.rs:64, so a later change that starts
+    // writing a real AWR on this route is a deliberate edit rather than a
+    // surprise. `from_endf` leaves the field None even though the evaluation's
+    // MF=1 MT=451 does carry AWR = 5.961817.
+    assert_eq!(data.atomic_weight_ratio, None);
+    assert_eq!(f64_at(&batch, "atomic_weight_ratio", 0), 0.0);
+
+    // Empty and PRESENT, not null: string_list and float_list_list at
+    // sections.rs:101-135 always append a row, so an absent temperature is an
+    // empty list here and never a null.
+    for column in [
+        "temperatures",
+        "energy_temperatures",
+        "energy_values",
+        "kTs",
+    ] {
+        assert!(!is_null(&batch, column, 0), "{column} was written as null");
+    }
+    assert!(str_list(&batch, "temperatures", 0).is_empty());
+    assert!(f64_list(&batch, "kTs", 0).is_empty());
+    assert!(str_list(&batch, "energy_temperatures", 0).is_empty());
+    assert_eq!(list_len(&batch, "energy_values", 0), 0);
+}
+
+// ---------------------------------------------------------------------------
+// urr.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means urr.arrow disagrees with `endf::ProbabilityTables` on the
+/// one vendored input that reaches `write_urr` at all. No test in this
+/// repository has ever produced a urr.arrow: the only existing one asserts the
+/// file is ABSENT for Li6 (sections.rs:136-146), so all eight columns and the
+/// `(n_energy, 6, n_band)` ravel are otherwise unexercised.
+///
+/// What this fixture cannot establish, because it is ONE row on which every
+/// scalar column is a constant: `interpolation` is 2, `table_shape` is
+/// `[4, 6, 3]`, `multiply_smooth` is true and `inelastic` and `absorption` are
+/// BOTH -1. A writer that pushed any of those literals instead of reading the
+/// parsed field, or that swapped the `inelastic` and `absorption` arguments at
+/// nuclide.rs:126-127, passes everything below. `multiply_smooth` is the worst
+/// of the four to be blind to, since it flips the physical meaning of every
+/// number in `table_data` from factors on the smooth background to absolute
+/// cross sections, and it is the one this test least deserves credit for. All
+/// four are separated in
+/// `constructed_urr_rows_carry_their_own_scalars_in_processed_order`.
+///
+/// What this test does carry on its own: `table_data` against the generator's
+/// closed form, and the position of `interpolation` in the argument list,
+/// since its neighbour `inelastic` holds a different number.
+///
+/// Two things this deliberately does NOT assert, because the fixture's values
+/// are invented rather than physical: that the q=0 cumulative row ends at 1.0
+/// (it ends at 1.02) and that the total row exceeds the elastic row (it does
+/// not).
+#[test]
+fn urr_columns_are_the_parsed_probability_tables_in_c_order() {
+    let data = ace_nuclide(URR_ACE);
+    let dir = scratch();
+    let wrote = yamc_convert::nuclide::write_urr(&data, dir.path()).expect("no error");
+    assert!(wrote, "synthetic-urr carries unresolved resonance tables");
+    let batch = section(dir.path(), "urr.arrow");
+
+    assert_eq!(batch.num_rows(), data.urr.len());
+    assert_eq!(batch.num_rows(), 1);
+
+    // The row order rule of nuclide.rs:96-105, which is the same shape as the
+    // energy_temperatures rule and equally undiscriminated by a single
+    // temperature fixture.
+    let mut ordered: Vec<String> = data
+        .temperatures()
+        .into_iter()
+        .filter(|t| data.urr.contains_key(t))
+        .collect();
+    ordered.extend(
+        data.urr
+            .keys()
+            .filter(|t| !data.temperatures().contains(t))
+            .cloned(),
+    );
+    let written: Vec<String> = (0..batch.num_rows())
+        .map(|row| str_at(&batch, "temperature", row))
+        .collect();
+    assert_eq!(written, ordered);
+    assert_eq!(written, vec!["294K".to_string()]);
+
+    let tables = &data.urr[&written[0]];
+
+    let energy = f64_list(&batch, "energy", 0);
+    assert_f64_slice_eq("energy", &energy, &tables.energy);
+    assert_f64_slice_eq("energy", &energy, &[1000.0, 2000.0, 3000.0, 4000.0]);
+    assert!(
+        energy.windows(2).all(|w| w[1] > w[0]),
+        "the unresolved energies are not strictly increasing"
+    );
+
+    // The loader defaults n_params to 6 when this list is short
+    // (nuclide_arrow.rs:1862-1866), so a dropped axis is absorbed silently.
+    // The three shape identities that used to follow (shape[1] == 6,
+    // shape[0] == energy.len(), and the flat length as the product) all follow
+    // from the two literals pinned here and above, so they are gone.
+    let shape = i32_list(&batch, "table_shape", 0);
+    assert_i32_slice_eq("table_shape", &shape, &[4, 6, 3]);
+    assert_eq!(
+        shape,
+        tables.shape.iter().map(|&n| n as i32).collect::<Vec<i32>>()
+    );
+
+    let flat = f64_list(&batch, "table_data", 0);
+    assert_eq!(flat.len(), 72);
+
+    let (n_e, n_b) = (shape[0] as usize, shape[2] as usize);
+
+    // The C order identity, exact. Read this for what it is:
+    // `ProbabilityTables::get` computes this same index expression over the
+    // same Vec the writer clones (crates/endf/src/urr.rs:62-70), so it checks
+    // that the copy was not permuted and is NOT independent evidence that the
+    // ravel is C order. The generator oracle below carries that, and so does
+    // the constructed test, which fills its table from an (e, q, b) formula.
+    // The index is also the one the loader uses at nuclide_arrow.rs:1884-1905,
+    // so a ravel that fails here loads as a different set of bands.
+    for e in 0..n_e {
+        for q in 0..6 {
+            for b in 0..n_b {
+                assert_eq!(
+                    flat[(e * 6 + q) * n_b + b],
+                    tables.get(e, q, b).expect("in range"),
+                    "table_data[{e},{q},{b}]"
+                );
+            }
+        }
+    }
+
+    // The independent oracle, and the reason this fixture is worth using:
+    // tools/make_urr_ace.py writes round(1.0 + e + 0.1*q + 0.01*b, 6) with the
+    // q == 5 heating row scaled by EV_PER_MEV. A relative tolerance is right
+    // HERE and only here, because the oracle is a decimal literal
+    // reconstructed in binary (1.0 + 0.01*2 need not be the f64 nearest 1.02)
+    // and not because the converter did any arithmetic. Measured worst on this
+    // fixture is 0.0; the tolerance is headroom for the reconstruction, not
+    // slack for the writer, and the comparison against tables.get above stays
+    // exact.
+    for e in 0..n_e {
+        for q in 0..6 {
+            for b in 0..n_b {
+                let mut want = round6(1.0 + e as f64 + 0.1 * q as f64 + 0.01 * b as f64);
+                if q == 5 {
+                    want *= endf::EV_PER_MEV;
+                }
+                assert_close(
+                    &format!("table_data[{e},{q},{b}] against the generator"),
+                    flat[(e * 6 + q) * n_b + b],
+                    want,
+                    1e-12,
+                );
+            }
+        }
+    }
+
+    // An axis probe that does not reuse the ravel arithmetic above: only the
+    // heating row is scaled by EV_PER_MEV, so it stands about 1.5e6 against
+    // O(1) everywhere else. A transposed ravel moves the large values off that
+    // stride and this fires.
+    for e in 0..n_e {
+        for b in 0..n_b {
+            let heating = flat[(e * 6 + 5) * n_b + b];
+            for q in 0..5 {
+                let other = flat[(e * 6 + q) * n_b + b];
+                assert!(
+                    heating >= 1e3 * other,
+                    "heating at ({e},{b}) is {heating:e}, not above quantity {q} at {other:e}"
+                );
+            }
+        }
+    }
+
+    // The loader maps 5 to log-log and EVERYTHING else to lin-lin
+    // (nuclide_arrow.rs:1849-1852), so a corrupted value degrades silently.
+    assert_eq!(
+        i32_at(&batch, "interpolation", 0),
+        tables.interpolation as i32
+    );
+    assert_eq!(i32_at(&batch, "interpolation", 0), 2);
+
+    assert_eq!(i32_at(&batch, "inelastic", 0), -1);
+    assert_eq!(i32_at(&batch, "absorption", 0), -1);
+    // Also as i64, so the i64 to i32 narrowing at nuclide.rs:112-113 is covered.
+    assert_eq!(
+        i64::from(i32_at(&batch, "inelastic", 0)),
+        tables.inelastic_flag
+    );
+    assert_eq!(
+        i64::from(i32_at(&batch, "absorption", 0)),
+        tables.absorption_flag
+    );
+
+    assert!(bool_at(&batch, "multiply_smooth", 0));
+    assert_eq!(
+        bool_at(&batch, "multiply_smooth", 0),
+        tables.multiply_smooth
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reactions.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means reactions.arrow gained, lost or reordered a reaction, or
+/// gave one a label that is not the format's own name for it. The existing
+/// hermetic test only checks that each label resolves back through
+/// `REACTION_MT`, which accepts any alias: writing "capture" for MT 102
+/// resolves to 102 and passes, and its completeness guard is `checked >= 19`
+/// on a 21 row file.
+#[test]
+fn reaction_rows_are_every_parsed_mt_then_the_synthesized_ones() {
+    let data = li6_ace();
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    // Every batch, fused: reactions.arrow is one RecordBatch per row, so a
+    // first-batch read would check MT 1 alone.
+    let batch = section(dir.path(), "reactions.arrow");
+
+    let mut synthetic: Vec<i32> = yamc_convert::synthesis::SYNTHETIC_MTS
+        .iter()
+        .copied()
+        .filter(|mt| !data.reactions.contains_key(mt))
+        .collect();
+    synthetic.sort_unstable();
+    let mut expected: Vec<i32> = data.reactions.keys().copied().collect();
+    expected.extend(synthetic);
+
+    let mts = written_mts(&batch);
+    assert_eq!(mts, expected);
+    // The literal order too, so the derivation above cannot go wrong the same
+    // way the writer does. Note the tail: the synthesized rows are appended
+    // AFTER the parsed ones, so the file is not globally ascending.
+    assert_eq!(
+        mts,
+        vec![
+            1, 2, 5, 51, 52, 53, 54, 55, 91, 101, 102, 203, 204, 205, 206, 207, 301, 444, 3, 4, 27
+        ]
+    );
+
+    for (row, &mt) in mts.iter().enumerate() {
+        let label = str_at(&batch, "label", row);
+        assert_eq!(
+            label,
+            endf::reaction_name(mt).unwrap_or_else(|| mt.to_string()),
+            "MT {mt} is not labelled with the format's own name for it"
+        );
+        // The round trip the loader does, kept as a second assertion because
+        // it is what a consumer actually runs. It is the weaker of the two:
+        // every alias resolves.
+        assert_eq!(
+            yamc_nuclide::data::REACTION_MT.get(label.as_str()).copied(),
+            Some(mt),
+            "label {label} does not resolve back to MT {mt}"
+        );
+    }
+}
+
+/// A failure means a reaction's Q value or one of its two boolean flags no
+/// longer matches the parser. `center_of_mass` and `redundant` are adjacent
+/// Boolean columns and `RecordBatch::try_new` validates position and type
+/// only, so swapping the two `bools()` arguments at reactions.rs:101-102
+/// writes a valid, loadable, wrong file; `redundant` also drives
+/// `is_fission_mt(mt) && !redundant` in the loader at
+/// nuclide_arrow.rs:503-505.
+#[test]
+fn reaction_flags_are_the_parsed_reactions_own_flags() {
+    let data = li6_ace();
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+
+    // Not a hand transcribed truth table: the two flags disagree on 14 of the
+    // 18 parsed rows (MT 2 is center_of_mass true and redundant false, MT 102
+    // is false and false, MT 203 to 207 are false and true), so comparing each
+    // against the parsed side already fails on a swap, and a second
+    // transcription would only test the transcription.
+    let mut disagree = 0;
+    for (&mt, rx) in &data.reactions {
+        let row = mt_rows[&mt];
+        assert_eq!(
+            f64_at(&batch, "Q_value", row),
+            rx.q_reaction,
+            "MT {mt} Q value"
+        );
+        assert_eq!(
+            bool_at(&batch, "center_of_mass", row),
+            rx.center_of_mass,
+            "MT {mt} center_of_mass"
+        );
+        assert_eq!(
+            bool_at(&batch, "redundant", row),
+            rx.redundant,
+            "MT {mt} redundant"
+        );
+        if rx.center_of_mass != rx.redundant {
+            disagree += 1;
+        }
+    }
+    assert_eq!(
+        disagree, 14,
+        "the two boolean columns no longer disagree often enough for the \
+         per-MT comparison to catch a swap between them"
+    );
+
+    // Two literal pins quoted from the fixture's MTR/LQR block, so a units
+    // regression in the parser is visible without transcribing 21 numbers.
+    assert_eq!(f64_at(&batch, "Q_value", mt_rows[&51]), -2.186e6);
+    assert_eq!(f64_at(&batch, "Q_value", mt_rows[&102]), 7.251091e6);
+
+    // A PIN, not a check. These three rows have no parsed side at all, so this
+    // compares the writer's own literals at reactions.rs:130-132 against a
+    // transcription of them and cannot tell you the literals are right. It
+    // earns its place because `redundant = true` is what keeps a synthesized
+    // row out of the sums (reactions.rs:43-45): changing the literal changes
+    // the arithmetic of every row above it.
+    for mt in [3, 4, 27] {
+        let row = mt_rows[&mt];
+        assert_eq!(f64_at(&batch, "Q_value", row), 0.0, "MT {mt} Q value");
+        assert!(!bool_at(&batch, "center_of_mass", row), "MT {mt}");
+        assert!(bool_at(&batch, "redundant", row), "MT {mt}");
+    }
+}
+
+/// A failure means the cross section a reaction row carries is not the curve
+/// the parser produced, or the threshold index no longer lines the curve up
+/// with the nuclide grid. Inside reactions.arrow alone the threshold is
+/// silent; it becomes loud only when the whole directory loads, because the
+/// loader compares `grid.tail(threshold_idx)` against the cross section length
+/// at nuclide_arrow.rs:485-499. Reproducing that check here is what makes the
+/// section self-sufficient.
+///
+/// `xs_temperatures` is wiring only here: Li6 has one temperature, so the list
+/// is `["294K"]` on every row and `expected_xs_temperatures` restates
+/// reactions.rs:82-87 rather than deriving it. The ordering rule and the
+/// pairing of each curve with its own temperature are discriminated in
+/// `constructed_two_temperature_reactions_keep_each_curve_with_its_own_temperature`.
+#[test]
+fn reaction_cross_sections_are_the_parsed_curves_unshifted() {
+    let data = li6_ace();
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+
+    for (&mt, rx) in &data.reactions {
+        let row = mt_rows[&mt];
+        let temperatures = str_list(&batch, "xs_temperatures", row);
+        assert_eq!(
+            temperatures,
+            expected_xs_temperatures(&data, rx),
+            "MT {mt} xs_temperatures"
+        );
+        assert_eq!(temperatures, vec!["294K".to_string()], "MT {mt}");
+
+        let values = nested_f64_list(&batch, "xs_values", row);
+        let thresholds = i32_list(&batch, "xs_threshold_idx", row);
+        assert_eq!(values.len(), temperatures.len(), "MT {mt} xs_values");
+        assert_eq!(thresholds.len(), temperatures.len(), "MT {mt} thresholds");
+
+        for (i, t) in temperatures.iter().enumerate() {
+            let xs = &rx.xs[t];
+            // Exact: reactions.rs:88-91 clones `.y` with no grid alignment, no
+            // scaling and no filtering, so a tolerance could only hide a
+            // defect.
+            assert_f64_slice_eq(&format!("MT {mt} xs_values[{t}]"), &values[i], &xs.y);
+            assert_eq!(
+                thresholds[i],
+                xs.threshold_idx.unwrap_or(0) as i32,
+                "MT {mt} xs_threshold_idx[{t}]"
+            );
+            // The loader's own invariant, reproduced here.
+            assert_eq!(
+                thresholds[i] as usize + values[i].len(),
+                data.energy[t].len(),
+                "MT {mt} at {t} does not span the grid from its threshold"
+            );
+            assert_eq!(data.energy[t].len(), 721);
+        }
+    }
+
+    // Two pins so a wholesale parser shift is visible.
+    let row = mt_rows[&51];
+    assert_eq!(i32_list(&batch, "xs_threshold_idx", row)[0], 511);
+    assert_eq!(nested_f64_list(&batch, "xs_values", row)[0].len(), 210);
+}
+
+/// A failure means MT 3, 4 or 27 is not the sum of the partials the same file
+/// carries. Calling `synthesis::synthesize` here would prove nothing, so the
+/// reconstruction is done from the file's own partial rows instead.
+///
+/// Every number compared below comes out of the written file, so what this
+/// establishes is internal consistency: each synthesized row is the sum of the
+/// rows beside it in the summation order stated below, and each one starts
+/// where the fixture says it starts. A comparison of written MT 2 plus written
+/// MT 3 against written MT 1 at 1e-6 relative used to sit here and has been
+/// removed: MT 3 is pinned EXACTLY against those same partial rows a few lines
+/// above, so that assertion could only ever fail on a property of the
+/// evaluation's own seven digit ACE columns, never on a converter defect.
+#[test]
+fn the_synthesized_rows_are_the_sum_of_the_rows_beside_them() {
+    let data = li6_ace();
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+    let n = data.energy["294K"].len();
+    assert_eq!(n, 721);
+
+    let written = |mt: i32| nested_f64_list(&batch, "xs_values", mt_rows[&mt])[0].clone();
+    let on_grid = |mt: i32| written_on_grid(&batch, &mt_rows, mt, n);
+
+    // Ascending MT order, which is the order synthesis.rs:170-227 sums in:
+    // inelastic() and absorption() are BTreeSets and non_elastic_scattering
+    // walks the partials BTreeMap. Summing in that order gives bit identical
+    // f64 results, so this is exact; any other order needs a 1e-12 relative
+    // tolerance instead.
+    let sum = |mts: &[i32]| -> Vec<f64> {
+        let mut acc = vec![0.0; n];
+        for &mt in mts {
+            for (a, b) in acc.iter_mut().zip(on_grid(mt)) {
+                *a += b;
+            }
+        }
+        acc
+    };
+
+    for mt in [3, 4, 27] {
+        assert_i32_slice_eq(
+            &format!("MT {mt} xs_threshold_idx"),
+            &i32_list(&batch, "xs_threshold_idx", mt_rows[&mt]),
+            &[0],
+        );
+        assert_eq!(
+            written(mt).len(),
+            n,
+            "MT {mt} is defined on the whole grid, whatever its partials' offsets were"
+        );
+    }
+
+    assert_f64_slice_eq("MT 4", &written(4), &sum(&[51, 52, 53, 54, 55, 91]));
+    assert_f64_slice_eq("MT 27", &written(27), &sum(&[102]));
+    assert_f64_slice_eq("MT 3", &written(3), &sum(&[5, 51, 52, 53, 54, 55, 91, 102]));
+
+    // The first nonzero index is what turns a one index shift loud, since the
+    // written length cannot: it is 721 whatever the offset was. It is also the
+    // only thing here that survives a shift applied to the PARTIAL rows too,
+    // which moves both sides of the equalities above together.
+    assert_eq!(first_nonzero(&written(4)), Some(512));
+    assert_eq!(first_nonzero(&written(3)), Some(0));
+    assert_eq!(first_nonzero(&written(27)), Some(0));
+
+    // The one comparison here that reaches past the writer's own arithmetic.
+    // Li6 carries its OWN MT 101 in the ACE ESZ block, so that row is PARSED,
+    // while MT 27 is synthesized as the sum of MT 102, and on this fixture the
+    // two are bit identical. So this pins the synthesized absorption against a
+    // column the evaluation stored itself. It says nothing about a SYNTHESIZED
+    // MT 101, which nothing in this file reaches: MT 101 is parsed on the ACE
+    // route and empty on the ENDF route. If a future fixture or parser change
+    // breaks the bit equality, 1e-6 relative is the honest fallback rather
+    // than deleting the check.
+    assert_f64_slice_eq("MT 101 against MT 27", &written(101), &written(27));
+}
+
+/// A failure means the writer changed how it handles an evaluation with no
+/// nuclide grid. This is still the only case in this file, vendored or
+/// constructed, where `xs_temperatures` comes from the extras branch at
+/// reactions.rs:87 rather than from the filtered list at :82-86: here
+/// `temperatures()` is empty and the "0K" key comes entirely from `rx.xs`.
+///
+/// It also pins what the writer actually does with the synthesized MTs on this
+/// route, which is NOT "write no row": `n_energy` is 0 at every temperature so
+/// the synthesis loop at reactions.rs:67-74 never runs, but the row loop at
+/// :113-137 is unconditional, so MT 3, 27 and 101 each get a row whose
+/// xs_temperatures, xs_values and xs_threshold_idx are all empty lists.
+///
+/// Those three rows are a SUSPECTED DEFECT, pinned and not endorsed. An
+/// evaluation with no nuclide grid gains three reactions carrying no cross
+/// section at all, and the loader skips its own grid length check in exactly
+/// that situation (nuclide_arrow.rs:496), so they load as three silently empty
+/// reactions rather than as an error. The fix belongs in reactions.rs, not
+/// here. When it lands this test is EXPECTED to fail on the row count, and the
+/// answer then is 38 rows, not a deleted test.
+#[test]
+fn the_endf_route_synthesizes_empty_rows_and_keys_its_cross_sections_at_0k() {
+    let data = endf_nuclide(LI6_ENDF);
+    assert!(
+        data.energy.is_empty(),
+        "the ENDF route carries no nuclide grid"
+    );
+    assert!(
+        data.temperatures().is_empty(),
+        "the ENDF route carries no k_ts"
+    );
+
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+
+    let mut expected: Vec<i32> = data.reactions.keys().copied().collect();
+    assert_eq!(expected.len(), 38);
+    // MT 1 and MT 4 are the evaluation's own, so only these three are appended.
+    expected.extend([3, 27, 101]);
+    assert_eq!(written_mts(&batch), expected);
+
+    for (&mt, rx) in &data.reactions {
+        let row = mt_rows[&mt];
+        assert_eq!(
+            str_list(&batch, "xs_temperatures", row),
+            vec!["0K".to_string()],
+            "MT {mt}"
+        );
+        assert_i32_slice_eq(
+            &format!("MT {mt} xs_threshold_idx"),
+            &i32_list(&batch, "xs_threshold_idx", row),
+            &[0],
+        );
+        let values = nested_f64_list(&batch, "xs_values", row);
+        assert_eq!(values.len(), 1, "MT {mt}");
+        assert_f64_slice_eq(&format!("MT {mt} xs_values"), &values[0], &rx.xs["0K"].y);
+        // Both hard-coded on this route at crates/endf/src/reaction.rs:361-362.
+        assert!(bool_at(&batch, "center_of_mass", row), "MT {mt}");
+        assert!(!bool_at(&batch, "redundant", row), "MT {mt}");
+    }
+
+    // No grid length invariant here: data.energy is empty, and the loader
+    // skips its own check in the same situation (nuclide_arrow.rs:496).
+    for mt in [3, 27, 101] {
+        let row = mt_rows[&mt];
+        assert!(
+            str_list(&batch, "xs_temperatures", row).is_empty(),
+            "MT {mt}"
+        );
+        assert_eq!(list_len(&batch, "xs_values", row), 0, "MT {mt}");
+        assert!(
+            i32_list(&batch, "xs_threshold_idx", row).is_empty(),
+            "MT {mt}"
+        );
+        for column in ["xs_temperatures", "xs_values", "xs_threshold_idx"] {
+            assert!(!is_null(&batch, column, row), "MT {mt} {column} is null");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructed inputs.
+//
+// Everything below this line is built by hand rather than parsed from an
+// evaluation. Each test names the writer branch that no vendored evaluation
+// discriminates and why only a constructed input separates the two columns in
+// question. None of it is parity with any evaluation: the numbers are invented
+// and are chosen to differ from one another, which is the entire point, since
+// two columns that hold the same value cannot show a swap between them.
+// ---------------------------------------------------------------------------
+
+/// kT in eV for a temperature in kelvin, so `temperatures()` names it back.
+fn k_t(kelvin: f64) -> f64 {
+    kelvin * endf::K_BOLTZMANN
+}
+
+/// A hand-built nuclide with TWO temperatures and THREE energy grids.
+///
+/// Parsed from nothing. The shape it exists to produce, which no vendored
+/// fixture has:
+///
+/// * `temperatures()` is `["294K", "1200K"]`, in `k_ts` order, which is NOT
+///   the order a BTreeMap keyed by those names walks: `"0K"` then `"1200K"`
+///   then `"294K"`.
+/// * `energy` holds a grid at a temperature that is not in `temperatures()`,
+///   which is the 0 K PENDF grid the NJOY route adds (nuclide.rs:28-40).
+/// * the three grids have three different lengths and share no value, so a
+///   grid paired with the wrong temperature cannot pass unnoticed.
+fn two_temperature_nuclide() -> IncidentNeutron {
+    let mut data = IncidentNeutron::new(3, 6, 0);
+    data.k_ts = vec![k_t(294.0), k_t(1200.0)];
+    data.energy.insert("294K".to_string(), vec![1.0, 2.0, 3.0]);
+    data.energy
+        .insert("1200K".to_string(), vec![10.0, 20.0, 30.0, 40.0]);
+    data.energy.insert("0K".to_string(), vec![100.0, 200.0]);
+    data
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. `temperatures` and
+/// `energy_temperatures` are different lists here, and the writer must not
+/// confuse them.
+///
+/// No vendored evaluation reaches this: on Li6 ACE both columns hold
+/// `["294K"]` and on the ENDF route both are empty, so swapping the two
+/// `string_list` arguments at nuclide.rs:65 and :67 writes a valid, loadable,
+/// wrong file that every test built from vendored bytes accepts. That is why
+/// the input is built by hand, and it is why nothing below should be read as
+/// agreement with a real evaluation.
+///
+/// The same construction discriminates the two phase ordering rule the
+/// writer's own comment argues for, which a one element list cannot.
+#[test]
+fn constructed_two_temperature_nuclide_separates_the_two_temperature_columns() {
+    let data = two_temperature_nuclide();
+    // The constructed input, restated: if `temperature_str` ever rendered
+    // these kTs differently, everything below would be about another nuclide.
+    assert_eq!(
+        data.temperatures(),
+        vec!["294K".to_string(), "1200K".to_string()]
+    );
+
+    let dir = scratch();
+    yamc_convert::nuclide::write_nuclide(&data, dir.path()).expect("nuclide.arrow is written");
+    let batch = section(dir.path(), "nuclide.arrow");
+
+    let temperatures = str_list(&batch, "temperatures", 0);
+    let energy_temperatures = str_list(&batch, "energy_temperatures", 0);
+    assert_eq!(
+        temperatures,
+        vec!["294K".to_string(), "1200K".to_string()],
+        "temperatures is data.temperatures(), which has no 0 K entry"
+    );
+    // Processed order first, then whatever the energy map holds that the
+    // temperature list does not. Iterating data.energy directly would give
+    // ["0K", "1200K", "294K"]; filtering to the temperature list would drop
+    // the 0 K grid; writing this list into the other column would put a
+    // temperature the nuclide was never processed at into `temperatures`.
+    assert_eq!(
+        energy_temperatures,
+        vec!["294K".to_string(), "1200K".to_string(), "0K".to_string()],
+        "energy_temperatures is the two phase list of nuclide.rs:41-51"
+    );
+    // The restated rule against the literal, on the only input in this file
+    // where the rule's two phases hold different things. This says nothing
+    // about the writer that the literal above has not already said; it keeps
+    // the helper the Li6 test leans on honest.
+    assert_eq!(energy_temperatures, expected_energy_temperatures(&data));
+    let mut seen = BTreeSet::new();
+    for t in &energy_temperatures {
+        assert!(
+            data.energy.contains_key(t),
+            "energy_temperatures lists {t}, which this nuclide has no grid for"
+        );
+        assert!(
+            seen.insert(t.clone()),
+            "energy_temperatures lists {t} twice, which duplicates a whole grid"
+        );
+    }
+
+    // Two distinct kTs, so the positional pairing with `temperatures` is
+    // finally visible: a reversed pair names the wrong temperature.
+    let k_ts = f64_list(&batch, "kTs", 0);
+    assert_f64_slice_eq("kTs", &k_ts, &data.k_ts);
+    for (kt, t) in k_ts.iter().zip(&temperatures) {
+        assert_eq!(
+            &endf::data::temperature_str(kt / endf::K_BOLTZMANN),
+            t,
+            "kT {kt} does not name temperature {t}"
+        );
+    }
+
+    // Three grids of three different lengths: a grid paired with the wrong
+    // temperature fails on the length before it fails on a value.
+    let grids = nested_f64_list(&batch, "energy_values", 0);
+    assert_eq!(
+        grids.len(),
+        energy_temperatures.len(),
+        "one grid per energy temperature"
+    );
+    for (grid, t) in grids.iter().zip(&energy_temperatures) {
+        assert_f64_slice_eq(&format!("energy_values[{t}]"), grid, &data.energy[t]);
+    }
+}
+
+/// The value the constructed probability tables hold at one
+/// (energy, quantity, band), distinct for every triple and every seed.
+fn urr_cell(seed: f64, e: usize, q: usize, b: usize) -> f64 {
+    seed + 100.0 * e as f64 + 10.0 * q as f64 + b as f64
+}
+
+/// A `ProbabilityTables` whose every field differs from every other row's.
+///
+/// `table` is filled from the (energy, quantity, band) triple rather than from
+/// a running index, so the test can compare the written list against
+/// `urr_cell(e, q, b)` instead of against `ProbabilityTables::get`, which
+/// recomputes the writer's own index expression over the same Vec. What is
+/// being checked is still a clone, since the writer reshapes nothing: a
+/// mismatch means the copy was permuted or came from another row. The energies
+/// are half integers so that no energy can collide with a table value.
+fn distinct_tables(
+    seed: f64,
+    shape: [usize; 3],
+    interpolation: i64,
+    inelastic_flag: i64,
+    absorption_flag: i64,
+    multiply_smooth: bool,
+) -> ProbabilityTables {
+    let [n_e, n_q, n_b] = shape;
+    let mut table = Vec::with_capacity(n_e * n_q * n_b);
+    for e in 0..n_e {
+        for q in 0..n_q {
+            for b in 0..n_b {
+                table.push(urr_cell(seed, e, q, b));
+            }
+        }
+    }
+    ProbabilityTables {
+        energy: (0..n_e).map(|e| seed + 0.5 + e as f64).collect(),
+        table,
+        shape,
+        interpolation,
+        inelastic_flag,
+        absorption_flag,
+        multiply_smooth,
+    }
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. Every scalar column of urr.arrow,
+/// told apart, and the row order with it.
+///
+/// No vendored evaluation reaches this: `synthetic-urr.ace.xz` is the only
+/// input in the tree that produces a urr.arrow at all, and it gives ONE row on
+/// which `interpolation` is 2, `table_shape` is `[4, 6, 3]`,
+/// `multiply_smooth` is true and `inelastic` and `absorption` are both -1.
+/// Against that row a writer that pushed a literal instead of reading the
+/// parsed field, or that swapped `inelastic` with `absorption`, is green. So
+/// the input here is built by hand with three rows whose scalars all differ,
+/// including the two flags within a row and `multiply_smooth` across rows.
+/// The numbers are invented and mean nothing physically.
+#[test]
+fn constructed_urr_rows_carry_their_own_scalars_in_processed_order() {
+    // In the order the rows must come out: the processed temperatures first,
+    // then what the map holds and `temperatures()` does not. The map's own
+    // order is ["0K", "1200K", "294K"], so a writer that walked `data.urr`
+    // directly writes these three rows permuted, and one that filtered to
+    // `temperatures()` drops the 0 K row entirely.
+    let expected: Vec<(&str, f64, ProbabilityTables)> = vec![
+        (
+            "294K",
+            1000.0,
+            distinct_tables(1000.0, [2, 6, 3], 2, 4, 102, false),
+        ),
+        (
+            "1200K",
+            2000.0,
+            distinct_tables(2000.0, [3, 6, 4], 5, 18, 27, true),
+        ),
+        (
+            "0K",
+            3000.0,
+            distinct_tables(3000.0, [1, 6, 2], 1, -1, 51, false),
+        ),
+    ];
+
+    let mut data = IncidentNeutron::new(92, 235, 0);
+    data.k_ts = vec![k_t(294.0), k_t(1200.0)];
+    for (t, _, tables) in &expected {
+        data.urr.insert((*t).to_string(), tables.clone());
+    }
+
+    let dir = scratch();
+    let wrote = yamc_convert::nuclide::write_urr(&data, dir.path()).expect("no error");
+    assert!(
+        wrote,
+        "the constructed nuclide has unresolved resonance data"
+    );
+    let batch = section(dir.path(), "urr.arrow");
+    assert_eq!(batch.num_rows(), expected.len());
+
+    let written: Vec<String> = (0..batch.num_rows())
+        .map(|row| str_at(&batch, "temperature", row))
+        .collect();
+    assert_eq!(
+        written,
+        expected
+            .iter()
+            .map(|(t, _, _)| (*t).to_string())
+            .collect::<Vec<String>>(),
+        "the rows are the processed temperatures first, then the map's extras"
+    );
+    let mut seen = BTreeSet::new();
+    for t in &written {
+        assert!(seen.insert(t.clone()), "urr.arrow lists {t} twice");
+    }
+
+    for (row, (t, seed, tables)) in expected.iter().enumerate() {
+        // Each column against its OWN row's field. No two rows share a value
+        // in any of these, so a column filled from a literal, or copied from
+        // the first row, or swapped with its neighbour, fails here.
+        assert_eq!(
+            i32_at(&batch, "interpolation", row),
+            tables.interpolation as i32,
+            "{t} interpolation"
+        );
+        assert_eq!(
+            i64::from(i32_at(&batch, "inelastic", row)),
+            tables.inelastic_flag,
+            "{t} inelastic"
+        );
+        assert_eq!(
+            i64::from(i32_at(&batch, "absorption", row)),
+            tables.absorption_flag,
+            "{t} absorption"
+        );
+        assert_ne!(
+            tables.inelastic_flag, tables.absorption_flag,
+            "{t}: the two flags must differ or the two assertions above cannot \
+             see a swap between the columns"
+        );
+        assert_eq!(
+            bool_at(&batch, "multiply_smooth", row),
+            tables.multiply_smooth,
+            "{t} multiply_smooth"
+        );
+        assert_i32_slice_eq(
+            &format!("{t} table_shape"),
+            &i32_list(&batch, "table_shape", row),
+            &tables.shape.iter().map(|&n| n as i32).collect::<Vec<i32>>(),
+        );
+        assert_f64_slice_eq(
+            &format!("{t} energy"),
+            &f64_list(&batch, "energy", row),
+            &tables.energy,
+        );
+
+        // The ravel, against the formula the table was filled from rather than
+        // against `ProbabilityTables::get`, which would recompute the same
+        // index over the same Vec. Every row has a different `n_energy` and
+        // `n_band`, so a shape taken from another row does not even fit.
+        let [n_e, n_q, n_b] = tables.shape;
+        let flat = f64_list(&batch, "table_data", row);
+        assert_eq!(flat.len(), n_e * n_q * n_b, "{t} table_data length");
+        for e in 0..n_e {
+            for q in 0..n_q {
+                for b in 0..n_b {
+                    assert_eq!(
+                        flat[(e * n_q + q) * n_b + b],
+                        urr_cell(*seed, e, q, b),
+                        "{t} table_data[{e},{q},{b}]"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// One cross section given from its threshold upwards, the way an ACE table
+/// stores a threshold reaction.
+fn partial_xs(x: Vec<f64>, y: Vec<f64>, threshold_idx: usize) -> Tabulated1D {
+    Tabulated1D {
+        threshold_idx: Some(threshold_idx),
+        ..Tabulated1D::new(x, y)
+    }
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. Each temperature's curve stays with
+/// its own temperature, its own threshold and its own grid.
+///
+/// No vendored evaluation reaches this: every vendored neutron evaluation has
+/// exactly one temperature ("294K" on the ACE route, "0K" on the ENDF route),
+/// so `xs_temperatures`, `xs_values` and `xs_threshold_idx` are one element
+/// lists on every row of every other test here and no permutation of them
+/// exists to be caught. The input is built by hand with two temperatures whose
+/// curves have different lengths, different thresholds and no shared value, so
+/// a writer that walked `rx.xs` in the map's own order ("1200K" before "294K")
+/// or that paired a curve with the wrong name fails. Not parity with any
+/// evaluation.
+///
+/// Both branches that build a row are covered, because they iterate different
+/// lists: the parsed row at reactions.rs:82-95 walks `xs_temperatures`, and
+/// the synthesized rows at :117-135 walk `temperatures` instead.
+#[test]
+fn constructed_two_temperature_reactions_keep_each_curve_with_its_own_temperature() {
+    let mut data = two_temperature_nuclide();
+    // The 0 K grid this builder carries is deliberately left in place:
+    // `write_reactions` reads `data.energy` only for each PROCESSED
+    // temperature's grid length (reactions.rs:68) and never iterates its keys,
+    // so no row may gain a third entry from it.
+    let mut elastic = Reaction::new(2);
+    elastic.xs.insert(
+        "294K".to_string(),
+        partial_xs(vec![1.0, 2.0, 3.0], vec![7.0, 8.0, 9.0], 0),
+    );
+    elastic.xs.insert(
+        "1200K".to_string(),
+        partial_xs(vec![30.0, 40.0], vec![70.0, 80.0], 2),
+    );
+    data.reactions.insert(2, elastic);
+
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+
+    let row = mt_rows[&2];
+    let temperatures = str_list(&batch, "xs_temperatures", row);
+    assert_eq!(
+        temperatures,
+        vec!["294K".to_string(), "1200K".to_string()],
+        "MT 2 xs_temperatures is the processed order, not the map's"
+    );
+    let values = nested_f64_list(&batch, "xs_values", row);
+    let thresholds = i32_list(&batch, "xs_threshold_idx", row);
+    assert_f64_slice_eq("MT 2 at 294K", &values[0], &[7.0, 8.0, 9.0]);
+    assert_f64_slice_eq("MT 2 at 1200K", &values[1], &[70.0, 80.0]);
+    assert_i32_slice_eq("MT 2 xs_threshold_idx", &thresholds, &[0, 2]);
+    // The loader's grid span invariant, at each temperature separately. This
+    // is what a mispairing breaks even where the values happen to look
+    // plausible: 0 + 3 is the 294K grid and 2 + 2 is the 1200K grid, and the
+    // two curves exchanged satisfy neither.
+    for (i, t) in temperatures.iter().enumerate() {
+        assert_eq!(
+            thresholds[i] as usize + values[i].len(),
+            data.energy[t].len(),
+            "MT 2 at {t} does not span that temperature's grid from its threshold"
+        );
+    }
+
+    // The synthesized rows come from the other list. MT 2 is the only parsed
+    // reaction, so MT 1 is the elastic curve and nothing else, laid on each
+    // temperature's own grid: three points at 294K, four at 1200K with the
+    // threshold's two leading zeros.
+    let row = mt_rows[&1];
+    assert_eq!(
+        str_list(&batch, "xs_temperatures", row),
+        vec!["294K".to_string(), "1200K".to_string()],
+        "MT 1 xs_temperatures"
+    );
+    let values = nested_f64_list(&batch, "xs_values", row);
+    assert_f64_slice_eq("MT 1 at 294K", &values[0], &[7.0, 8.0, 9.0]);
+    assert_f64_slice_eq("MT 1 at 1200K", &values[1], &[0.0, 0.0, 70.0, 80.0]);
+    assert_i32_slice_eq(
+        "MT 1 xs_threshold_idx",
+        &i32_list(&batch, "xs_threshold_idx", row),
+        &[0, 0],
+    );
+}

--- a/crates/yamc-convert/tests/section_values_photon.rs
+++ b/crates/yamc-convert/tests/section_values_photon.rs
@@ -1,0 +1,1415 @@
+//! Every column of `element.arrow`, `subshells.arrow`, `compton.arrow` and
+//! `bremsstrahlung.arrow`, against the `endf::IncidentPhoton` the writer was
+//! handed.
+//!
+//! `crates/yamc-convert/src/photon.rs` carries no unit tests of its own, and
+//! the two integration tests that run the photon route assert `is_file()` and
+//! nothing else, one of them skipping entirely on a clean checkout. So until
+//! this file no test compared a single value in those four sections against
+//! the evaluation it came from.
+//!
+//! # Why a slot swap is the failure to look for
+//!
+//! `write_section` builds each batch from a positional `Vec<ArrayRef>` and
+//! Arrow validates the data type and the row count, never the meaning.
+//! `element.arrow` declares seventeen consecutive `list<double>` fields, so
+//! any permutation among them is type-valid and writes without complaint.
+//! `read_photon_interaction_from_arrow`
+//! (`crates/yamc-element/src/photon_arrow.rs:53`) does read every one of those
+//! columns back on every load, but it reads them BY NAME and compares them
+//! against nothing, so a permutation loads as wrong physics rather than as an
+//! error.
+//!
+//! # Hermetic
+//!
+//! The hydrogen photoatomic evaluation and its relaxation file are
+//! `include_bytes!` from `crates/endf/fixtures/`. The three auxiliary
+//! tabulations, which are the only way `compton.arrow` and
+//! `bremsstrahlung.arrow` get written at all, are the git-tracked text files
+//! that ship in the wheel under `packages/yamc-core/python/yamc/data`. No
+//! NJOY, no nuclear-data cache, no network.
+//!
+//! # Constructed inputs, and where they begin
+//!
+//! The four tests in the first half of this file convert a vendored
+//! evaluation. The eight below the "A constructed element" divider hand
+//! `yamc_convert::photon::write_photon` an `IncidentPhoton` this file builds,
+//! because hydrogen is Z = 1 with one subshell and one Compton shell and so
+//! cannot discriminate the Z squared divide, the subshell row order, the two
+//! arguments of `compton_subshell_map`, `safe_log`'s floor or the relaxation
+//! cascade layout. Those eight are not evaluation parity and each says so in
+//! its own doc comment.
+
+mod section_values;
+use section_values::*;
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use endf::function::Tabulated1D;
+use endf::incident_photon::{
+    compton_subshell_map, AtomicRelaxation, ComptonProfiles, PhotonReaction, Transitions, SUBSHELLS,
+};
+use endf::{IncidentPhoton, PhotonData};
+
+// ---------------------------------------------------------------------------
+// Running the real conversion.
+// ---------------------------------------------------------------------------
+
+/// The three auxiliary tabulations, parsed once for the whole binary.
+///
+/// `PhotonData::from_files` reads 2.4 MB of text and resamples a 30-column
+/// bremsstrahlung table onto 200 electron energies for all 100 elements.
+/// Measured at about 130 ms in a debug build, so this is memoised for the
+/// parsed side rather than for the writer: `convert_photon` reads the files
+/// itself on every call and cannot be handed a `PhotonData`.
+fn tabulations() -> &'static PhotonData {
+    static ONCE: OnceLock<PhotonData> = OnceLock::new();
+    ONCE.get_or_init(photon_tabulations)
+}
+
+/// One conversion of the hydrogen pair, and the value the writer was handed.
+struct Converted {
+    /// Held so the scratch tree outlives the assertions and still removes
+    /// itself when one of them panics.
+    _scratch: tempfile::TempDir,
+    /// The `H.arrow` directory `convert_photon` returned.
+    dir: PathBuf,
+    /// The same `IncidentPhoton` the writer saw, rebuilt from the same bytes
+    /// through the same public calls `entry::convert_photon` makes.
+    data: IncidentPhoton,
+}
+
+/// Convert the hydrogen photoatomic fixture through `entry::convert_photon`.
+///
+/// `relaxation` decides whether `atom-001_H_000.endf` is supplied, which is
+/// what fills the subshell binding energy and occupancy. `tabulations`
+/// decides whether `compton.arrow` and `bremsstrahlung.arrow` are written at
+/// all: without them `compton_profiles` and `bremsstrahlung` are `None` and
+/// both writers return early having written nothing.
+fn convert(relaxation: bool, tabulations_on: bool) -> Converted {
+    let scratch = scratch();
+    let photoatomic = write_fixture(H_PHOTOAT, scratch.path(), "photoat-001_H_000.endf");
+    let relax = write_fixture(H_ATOM, scratch.path(), "atom-001_H_000.endf");
+
+    let d = photon_tabulation_dir();
+    let (compton, density, brems) = (
+        d.join("compton_profiles_biggs1975.txt"),
+        d.join("density_effect_sternheimer1982.txt"),
+        d.join("bremsstrahlung_seltzer_berger1986.txt"),
+    );
+    assert!(
+        compton.is_file() && density.is_file() && brems.is_file(),
+        "the auxiliary photon tabulations are missing from {}",
+        d.display()
+    );
+    let paths = yamc_convert::entry::PhotonTabulations {
+        compton_profiles: &compton,
+        density_effect: &density,
+        bremsstrahlung: &brems,
+    };
+
+    let out = scratch.path().join("out");
+    let written = yamc_convert::entry::convert_photon(
+        &photoatomic,
+        relaxation.then_some(relax.as_path()),
+        tabulations_on.then_some(&paths),
+        &out,
+        &yamc_convert::entry::Provenance::default(),
+    )
+    .expect("the photon route converts");
+    assert_eq!(
+        written.len(),
+        1,
+        "one element in the file, one directory out"
+    );
+
+    let photoatomic_material = endf_material(H_PHOTOAT);
+    let relax_material = endf_material(H_ATOM);
+    let mut data =
+        IncidentPhoton::from_endf(&photoatomic_material, relaxation.then_some(&relax_material))
+            .expect("the photoatomic evaluation reads");
+    if tabulations_on {
+        data.add_photon_data(tabulations());
+    }
+
+    Converted {
+        _scratch: scratch,
+        dir: written.into_iter().next().unwrap(),
+        data,
+    }
+}
+
+/// The union of every reaction's abscissa, restated from `photon.rs:48-58`.
+///
+/// A restatement, so on its own it checks wiring rather than arithmetic. The
+/// properties that do not depend on the writer's implementation are asserted
+/// beside it: the result is strictly increasing, and every reaction's own
+/// abscissa is a subset of it.
+fn union_grid_expected(data: &IncidentPhoton) -> Vec<f64> {
+    let mut grid: Vec<f64> = data
+        .reactions
+        .values()
+        .filter_map(|rx| rx.xs.as_ref())
+        .flat_map(|xs| xs.x.iter().copied())
+        .collect();
+    grid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    grid.dedup();
+    grid
+}
+
+/// One reaction's cross section evaluated over the union grid.
+fn eval_on(data: &IncidentPhoton, mt: i32, grid: &[f64]) -> Vec<f64> {
+    let f = data
+        .get(mt)
+        .and_then(|rx| rx.xs.as_ref())
+        .unwrap_or_else(|| panic!("MT {mt} has no cross section"));
+    grid.iter().map(|&e| f.eval(e)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// element.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means a photon cross section landed in the wrong slot or on the
+/// wrong grid.
+///
+/// `element.arrow` declares seventeen consecutive `list<double>` fields, so
+/// any permutation among them is type-valid and `RecordBatch::try_new`
+/// accepts it. The grid itself is load-bearing and subtle: MT 501 tabulates
+/// 13.6 eV twice for the K edge and `Vec::dedup` collapses the pair, so the
+/// union of a 2021-point channel is 2020 points.
+///
+/// The five channel comparisons run the same `Tabulated1D::eval` the writer
+/// ran, so they pin WIRING (which MT reached which slot) and not arithmetic.
+///
+/// The literal spot values below are two different things and each one is
+/// marked. FIXTURE means the literal was found in `photoat-001_H_000.endf` by
+/// grepping the decompressed text, so it is an independent read of the
+/// evaluation. GOLDEN means it is not in that file in any form: it is a
+/// capture of the same `eval` the writer ran, at a grid point that falls
+/// between two tabulated ones, so it detects a change to `eval` and does not
+/// independently verify it. Four of the twelve are GOLDEN. Every
+/// interpolation region in this evaluation is scheme 2, lin-lin, so `eval` is
+/// plain arithmetic with no libm call and an exact comparison is portable.
+#[test]
+fn element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid() {
+    let c = convert(true, false);
+    assert_eq!(
+        c.dir.file_name().unwrap(),
+        "H.arrow",
+        "the output directory is named for the element"
+    );
+
+    let batch = section(&c.dir, "element.arrow");
+    assert_schema_is_declared(&batch, "element.arrow");
+    assert_eq!(batch.num_rows(), 1, "element.arrow is one row per element");
+
+    assert_eq!(str_at(&batch, "name", 0), c.data.name());
+    assert_eq!(str_at(&batch, "name", 0), "H");
+    assert_eq!(i32_at(&batch, "Z", 0), c.data.atomic_number as i32);
+    assert_eq!(i32_at(&batch, "Z", 0), 1);
+
+    // The grid, and the two properties of it that hold whatever the writer
+    // does internally.
+    let grid = union_grid_expected(&c.data);
+    assert_eq!(grid.len(), 2020, "the union of the H channels");
+    assert!(
+        grid.windows(2).all(|w| w[1] > w[0]),
+        "the union grid must be strictly increasing"
+    );
+    for (&mt, rx) in &c.data.reactions {
+        let Some(f) = rx.xs.as_ref() else { continue };
+        for &e in &f.x {
+            assert!(
+                grid.binary_search_by(|g| g.partial_cmp(&e).unwrap())
+                    .is_ok(),
+                "MT {mt} tabulates {e:e}, which is not on the union grid"
+            );
+        }
+    }
+    // Where the missing point went: MT 501 carries 2021 abscissae with 13.6
+    // eV twice, once each side of the K edge.
+    let total = &c.data.get(501).unwrap().xs.as_ref().unwrap().x;
+    assert_eq!(total.len(), 2021);
+    assert_eq!(total.iter().filter(|&&e| e == 13.6).count(), 2);
+
+    // ln_energy IS the grid: the raw energy column was retired.
+    let ln_energy = f64_list(&batch, "ln_energy", 0);
+    let expected: Vec<f64> = grid.iter().map(|e| e.ln()).collect();
+    assert_f64_slice_eq("ln_energy", &ln_energy, &expected);
+    assert_eq!(ln_energy.len(), 2020);
+    assert_eq!(grid[0], 1.0);
+    assert_eq!(ln_energy[0], 0.0, "ln(1 eV) is exactly zero");
+    assert_eq!(grid[137], 13.6);
+    assert_eq!(grid[2019], 1.0e11);
+
+    // Each populated channel, against the reaction it names.
+    for (col, mt) in [
+        ("coherent_xs", 502),
+        ("incoherent_xs", 504),
+        ("photoelectric_xs", 522),
+        ("pair_production_nuclear_xs", 517),
+        ("pair_production_electron_xs", 515),
+    ] {
+        let written = f64_list(&batch, col, 0);
+        assert_f64_slice_eq(col, &written, &eval_on(&c.data, mt, &grid));
+        assert_eq!(written.len(), grid.len(), "{col} is on the union grid");
+    }
+
+    // Spot values. Coherent and incoherent are orders of magnitude apart at
+    // the same index, so the pair cannot be swapped undetected. FIXTURE is a
+    // literal grepped out of photoat-001_H_000.endf; GOLDEN is a capture of
+    // the writer's own interpolation between two of them.
+    let coherent = f64_list(&batch, "coherent_xs", 0);
+    assert_eq!(coherent[0], 4.52522e-6); // FIXTURE, MT 502 at 1 eV
+    assert_eq!(coherent[137], 8.943107736147576); // GOLDEN, interpolated
+    assert_eq!(coherent[1000], 1.0422148052673345e-5); // GOLDEN, interpolated
+    assert_eq!(coherent[2019], 4.6282e-16); // FIXTURE, MT 502 at 100 GeV
+
+    let incoherent = f64_list(&batch, "incoherent_xs", 0);
+    assert_eq!(incoherent[0], 9.5623e-8); // FIXTURE
+    assert_eq!(incoherent[137], 1.769349772687295e-5); // GOLDEN, interpolated
+    assert_eq!(incoherent[1000], 0.254789613); // FIXTURE, a tabulated point
+    assert_eq!(incoherent[2019], 1.7042e-5); // FIXTURE
+
+    // Below its threshold the photoelectric curve is CONSTANT at the edge
+    // value, not zero: `Tabulated1D::eval` clamps below x[0]. Asserted
+    // explicitly so nobody rewrites the comparison as zero-below-threshold.
+    let photoelectric = f64_list(&batch, "photoelectric_xs", 0);
+    assert_eq!(photoelectric[0], 6318358.25); // FIXTURE, MT 522 at its edge
+    assert_eq!(photoelectric[137], 6318358.25); // FIXTURE, the same clamp
+    assert!(
+        photoelectric[..=137].iter().all(|&v| v == photoelectric[0]),
+        "eval clamps below the 13.6 eV edge, so the first 138 points are flat"
+    );
+    assert_eq!(photoelectric[1000], 4.724903727980379e-9); // GOLDEN
+    assert_eq!(photoelectric[2019], 7.736e-15); // FIXTURE
+
+    // The two pair-production channels are identically zero over most of the
+    // grid and separate only at the top, so the last point and the threshold
+    // index are what tell them apart; comparing index 0 would leave the swap
+    // invisible below about 1 MeV.
+    let nuclear = f64_list(&batch, "pair_production_nuclear_xs", 0);
+    let electron = f64_list(&batch, "pair_production_electron_xs", 0);
+    assert_eq!(nuclear[2019], 0.009601); // FIXTURE
+    assert_eq!(electron[2019], 0.0111); // FIXTURE
+    let first_nuclear = nuclear.iter().position(|&v| v != 0.0).expect("rises");
+    let first_electron = electron.iter().position(|&v| v != 0.0).expect("rises");
+    assert_eq!(first_nuclear, 1026);
+    assert_eq!(first_electron, 1296);
+    assert!(
+        first_nuclear < first_electron,
+        "the nuclear-field threshold 1.022 MeV is below the electron-field 2.044 MeV"
+    );
+    assert_eq!(
+        c.data.get(517).unwrap().xs.as_ref().unwrap().x[0],
+        1_022_000.0
+    );
+    assert_eq!(
+        c.data.get(515).unwrap().xs.as_ref().unwrap().x[0],
+        2_044_000.0
+    );
+
+    // MT 525 is absent from this evaluation, so heating is an EMPTY list and
+    // not a null and not 2020 zeros. The reader substitutes a zero vector for
+    // the empty case, so a wrongly-empty heating column loads as zero KERMA
+    // without a word.
+    //
+    // Empty is the right answer here, but it is also the ONLY answer the
+    // writer can give: `ELEMENT_MTS` (photon.rs:31) lists 501, which
+    // `take` never asks for, and omits 525, which it does, so the filter at
+    // photon.rs:94 drops the heating reaction before it can be evaluated.
+    // Handing `write_photon` a constructed element with an MT 525 cross
+    // section still writes an empty column, which is pinned as a suspected
+    // defect by `constructed_mt_525_is_dropped_from_the_heating_column`.
+    assert!(!c.data.reactions.contains_key(&525), "H carries no MT 525");
+    assert!(
+        !is_null(&batch, "heating_xs", 0),
+        "heating_xs is written as an empty list, not as a null"
+    );
+    assert_eq!(list_len(&batch, "heating_xs", 0), 0);
+}
+
+/// A failure means a form factor or an anomalous scattering term is in the
+/// wrong slot.
+///
+/// These ten columns are the densest interchangeable block in the format, and
+/// the real and imaginary anomalous terms share the same 297-point abscissa on
+/// this element, so only their first ordinate can tell them apart. The MF=27
+/// MT 505 to imaginary and MT 506 to real mapping is a deliberate crossing at
+/// `crates/endf/src/incident_photon.rs:383-392` and is exactly the kind of
+/// thing a slot swap reproduces.
+///
+/// The `coherent_int_ff_y` comparison rebuilds the writer's own expression, so
+/// it pins the CONSTRUCTION (squared axes, the original region scheme carried
+/// onto them) rather than the quadrature. The independent parts of that column
+/// are the two asserted beside it: it starts at zero and never decreases. The
+/// Z squared divide is NOT among them, because Z is 1 here; it is
+/// discriminated by
+/// `constructed_element_divides_the_integrated_form_factor_by_z_squared`.
+#[test]
+fn element_form_factor_columns_come_from_the_reaction_they_name() {
+    let c = convert(true, false);
+    let batch = section(&c.dir, "element.arrow");
+    let z = c.data.atomic_number as f64;
+
+    let coherent = c.data.get(502).expect("MT 502");
+    let ff = coherent.scattering_factor.as_ref().expect("MF=27 MT=502");
+
+    let ff_x = f64_list(&batch, "coherent_ff_x", 0);
+    let ff_y = f64_list(&batch, "coherent_ff_y", 0);
+    assert_f64_slice_eq("coherent_ff_x", &ff_x, &ff.x);
+    assert_f64_slice_eq("coherent_ff_y", &ff_y, &ff.y);
+    assert_eq!(ff_x.len(), 1253);
+    assert_eq!(ff_x[0], 0.0);
+    assert_eq!(ff_x[1252], 1.0e9);
+    // Both verbatim fixture points. The first is the electron count at zero
+    // momentum transfer, which on Z = 1 is indistinguishable from the literal
+    // 1.0 and is written as the literal so it does not read as a Z check.
+    assert_eq!(ff_y[0], 1.0);
+    assert_eq!(ff_y[1252], 8.1829e-39);
+
+    // The integral runs against the SQUARE of the momentum transfer.
+    let int_x = f64_list(&batch, "coherent_int_ff_x", 0);
+    let squared_x: Vec<f64> = ff.x.iter().map(|v| v * v).collect();
+    assert_f64_slice_eq("coherent_int_ff_x", &int_x, &squared_x);
+    for (i, (&a, &b)) in int_x.iter().zip(&ff_x).enumerate() {
+        assert_eq!(
+            a,
+            b * b,
+            "coherent_int_ff_x[{i}] is not coherent_ff_x[{i}] squared"
+        );
+    }
+    assert_eq!(int_x[0], 0.0);
+    assert_eq!(int_x[1252], 1.0e18);
+
+    // `..ff.clone()` carries the original breakpoints and interpolation onto
+    // the squared axes, which is what decides the quadrature rule per region.
+    assert_eq!(ff.breakpoints, vec![1253]);
+    assert_eq!(ff.interpolation, vec![2]);
+    let squared = Tabulated1D {
+        x: squared_x,
+        y: ff.y.iter().map(|v| v * v / z.powi(2)).collect(),
+        ..ff.clone()
+    };
+    let int_y = f64_list(&batch, "coherent_int_ff_y", 0);
+    assert_f64_slice_eq("coherent_int_ff_y", &int_y, &squared.integral());
+    assert_eq!(int_y[0], 0.0, "a cumulative integral starts at zero");
+    assert!(
+        int_y.windows(2).all(|w| w[1] >= w[0]),
+        "the form factor is non-negative, so its integral cannot decrease"
+    );
+    // Hydrogen is Z = 1, so the divide above is a divide by one: changing
+    // `.powi(2)` to `.powi(5)`, or deleting the divide, leaves this test
+    // green. No vendored photoatomic fixture has Z > 1.
+    assert_eq!(z, 1.0);
+
+    // Real and imaginary anomalous terms. Same abscissa, so y[0] is the only
+    // discriminator on hydrogen.
+    let real = coherent.anomalous_real.as_ref().expect("MF=27 MT=506");
+    let imag = coherent.anomalous_imag.as_ref().expect("MF=27 MT=505");
+    let real_x = f64_list(&batch, "coherent_anomalous_real_x", 0);
+    let real_y = f64_list(&batch, "coherent_anomalous_real_y", 0);
+    let imag_x = f64_list(&batch, "coherent_anomalous_imag_x", 0);
+    let imag_y = f64_list(&batch, "coherent_anomalous_imag_y", 0);
+    assert_f64_slice_eq("coherent_anomalous_real_x", &real_x, &real.x);
+    assert_f64_slice_eq("coherent_anomalous_real_y", &real_y, &real.y);
+    assert_f64_slice_eq("coherent_anomalous_imag_x", &imag_x, &imag.x);
+    assert_f64_slice_eq("coherent_anomalous_imag_y", &imag_y, &imag.y);
+    assert_eq!(real_x.len(), 297);
+    assert_eq!(real_x[0], 1.0);
+    assert_eq!(real_x[296], 1.0e7);
+    assert_eq!(real_y[0], -1.00260813);
+    assert_eq!(imag_y[0], 0.0);
+    // Why only the ordinates are checked: in the EVALUATION the two terms share
+    // one abscissa, so exchanging the two written x slots produces a
+    // byte-identical file. Asserted on the parsed side, not by comparing the
+    // two written columns to each other, which would say nothing. The x slots
+    // are discriminated by
+    // `constructed_anomalous_scattering_columns_keep_their_own_abscissae`.
+    assert_eq!(
+        imag.x, real.x,
+        "MT 505 and MT 506 are tabulated on the same 297 points here"
+    );
+    assert_ne!(
+        real_y, imag_y,
+        "a 505/506 swap is only visible in the ordinates on this element"
+    );
+
+    // The incoherent scattering function rises from zero to Z. It has 398
+    // points against the coherent 1253, so the two length literals are
+    // themselves a slot check.
+    let iff = c
+        .data
+        .get(504)
+        .and_then(|rx| rx.scattering_factor.as_ref())
+        .expect("MF=27 MT=504");
+    let iff_x = f64_list(&batch, "incoherent_ff_x", 0);
+    let iff_y = f64_list(&batch, "incoherent_ff_y", 0);
+    assert_f64_slice_eq("incoherent_ff_x", &iff_x, &iff.x);
+    assert_f64_slice_eq("incoherent_ff_y", &iff_y, &iff.y);
+    assert_eq!(iff_x.len(), 398);
+    assert_eq!(iff_x[0], 0.0);
+    assert_eq!(iff_x[397], 1.0e9);
+    assert_eq!(iff_y[0], 0.0);
+    // Z again, and again a literal: the incoherent scattering function rises
+    // to the electron count, which is 1.0 here.
+    assert_eq!(iff_y[397], 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// subshells.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means the per-shell photoelectric data is offset from the grid or
+/// logged wrongly.
+///
+/// This test does NOT establish the row order, and an earlier name saying it
+/// did was wrong. Hydrogen has exactly one photoionization channel, so
+/// reversing the iteration in `write_subshells` leaves everything here green,
+/// and so does deleting `write_compton`'s refusal to accept out-of-order rows.
+/// Both are discriminated by the constructed tests in the second half of this
+/// file. The `xs` and `ln_xs` comparisons likewise re-run the writer's own
+/// `eval` and `ln`, so they pin which reaction reached the row and that the
+/// log column is the log of the column beside it, not the quadrature or the
+/// logarithm itself.
+///
+/// What is established here. `threshold_idx` is a `searchsorted` port and the
+/// off-by-one it reimplements (side `left` instead of `right`) yields 136, one
+/// point below the edge. `ln_xs`, not `xs`, is what the reader loads as the
+/// sampled cross section. And `transitions_data` is NULL rather than an empty
+/// list, which is byte fidelity with the published files and nothing more: an
+/// earlier version of this comment justified it with a reader failure that
+/// does not exist, since `read_transitions_from_arrow` returns at
+/// `crates/yamc-element/src/photon_arrow.rs:303-305` BEFORE it reads
+/// `transitions_shape` at :307, and `try_get_f64_list` collapses null and
+/// empty to the same `Vec` anyway.
+#[test]
+fn subshell_rows_are_the_relaxation_shells_on_the_thresholded_grid() {
+    let c = convert(true, false);
+    let element = section(&c.dir, "element.arrow");
+    let batch = section(&c.dir, "subshells.arrow");
+    assert_schema_is_declared(&batch, "subshells.arrow");
+
+    // BTreeMap order is ascending MT, which is most-bound-first, and is the
+    // order write_compton refuses to proceed without.
+    let shells: Vec<(i32, &str)> = c
+        .data
+        .reactions
+        .range(534..=572)
+        .filter(|(_, rx)| rx.xs.is_some())
+        .map(|(&mt, rx)| (mt, rx.name().expect("a subshell MT has a name")))
+        .collect();
+    assert_eq!(batch.num_rows(), shells.len());
+    assert_eq!(shells.len(), 1, "hydrogen has one photoionization channel");
+    for (row, &(mt, name)) in shells.iter().enumerate() {
+        assert_eq!(
+            str_at(&batch, "designator", row),
+            name,
+            "row {row} is not MT {mt}"
+        );
+    }
+    assert_eq!(shells[0], (534, "K"));
+
+    let relaxation = c.data.atomic_relaxation.as_ref().expect("MF=28 was read");
+    assert_eq!(
+        f64_at(&batch, "binding_energy", 0),
+        relaxation.binding_energy["K"]
+    );
+    assert_eq!(f64_at(&batch, "binding_energy", 0), 13.6);
+    assert_eq!(
+        f64_at(&batch, "num_electrons", 0),
+        relaxation.num_electrons["K"]
+    );
+    assert_eq!(f64_at(&batch, "num_electrons", 0), 1.0);
+
+    // The zero-default branch, which is what a caller with no relaxation
+    // sublibrary gets, and the reason compton's subshell map comes out empty
+    // there.
+    let bare = convert(false, false);
+    assert!(bare.data.atomic_relaxation.is_none());
+    let bare_batch = section(&bare.dir, "subshells.arrow");
+    assert_eq!(str_at(&bare_batch, "designator", 0), "K");
+    assert_eq!(f64_at(&bare_batch, "binding_energy", 0), 0.0);
+    assert_eq!(f64_at(&bare_batch, "num_electrons", 0), 0.0);
+
+    // The threshold index, and the tight form of it. The doc comment at
+    // photon.rs:191-192 says the stored curve "starts one point before the
+    // edge rather than on it", which is not what happens: the subshell's own
+    // abscissa feeds the union grid, so the threshold is always itself a grid
+    // point and grid[idx] == threshold.
+    let grid = union_grid_expected(&c.data);
+    let k = c
+        .data
+        .get(534)
+        .and_then(|rx| rx.xs.as_ref())
+        .expect("MT 534");
+    let idx = i32_at(&batch, "threshold_idx", 0);
+    assert_eq!(idx, 137);
+    let idx = idx as usize;
+    assert_eq!(grid[idx], k.x[0]);
+    assert_eq!(k.x[0], 13.6);
+    assert!(
+        grid[idx - 1] < k.x[0],
+        "grid[136] is 13.5990191, which is what a side='left' searchsorted would have picked"
+    );
+
+    let xs = f64_list(&batch, "xs", 0);
+    let expected: Vec<f64> = grid[idx..].iter().map(|&e| k.eval(e)).collect();
+    assert_f64_slice_eq("subshells.xs", &xs, &expected);
+    assert_eq!(xs.len(), 1883);
+    assert_eq!(xs[0], 6318358.25);
+    assert_eq!(xs[1882], 7.736e-15);
+    // The invariant the reader relies on when it indexes cross_sections at
+    // threshold + j.
+    assert_eq!(xs.len() + idx, list_len(&element, "ln_energy", 0));
+
+    let ln_xs = f64_list(&batch, "ln_xs", 0);
+    assert!(
+        xs.iter().all(|&v| v > 0.0),
+        "every K-shell value is positive here, so safe_log's 1e-300 floor is \
+         not exercised by any vendored fixture"
+    );
+    let expected_ln: Vec<f64> = xs.iter().map(|v| v.ln()).collect();
+    assert_f64_slice_eq("subshells.ln_xs", &ln_xs, &expected_ln);
+
+    // NTR is zero for hydrogen's only shell, so both cascade columns are null
+    // rather than empty, and they have to be null together.
+    assert!(relaxation.transitions.is_empty());
+    for row in 0..batch.num_rows() {
+        assert!(
+            is_null(&batch, "transitions_data", row),
+            "row {row} has no cascade, so transitions_data is null and not an empty list"
+        );
+        assert_eq!(
+            is_null(&batch, "transitions_data", row),
+            is_null(&batch, "transitions_shape", row),
+            "row {row} disagrees between the two cascade columns, which the reader cannot load"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// compton.arrow and bremsstrahlung.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means the Compton profiles or the bremsstrahlung DCS were
+/// reshaped, transposed or sourced from the wrong table.
+///
+/// The parsed side for these two sections is `endf::PhotonData` and the
+/// `IncidentPhoton` AFTER `add_photon_data`, not the ENDF material, because no
+/// evaluation carries them. Both shape columns are silently reshapeable: a
+/// transposed `[31, 1]` or `[30, 200]` has the same element count and the
+/// reader accepts it, so each shape is asserted element by element rather than
+/// by its product.
+///
+/// `J_data` and `dcs_data` are compared against the parsed tabulation, which
+/// pins the slot and the ravel offset but not the spline that produced the
+/// DCS. `J_cdf_data` is the one column recomputed independently here.
+///
+/// The CSR subshell map is WIRING ONLY on this element and cannot be anything
+/// else. Hydrogen has one Compton shell and one subshell, so both arguments of
+/// `compton_subshell_map` are `[1.0]`, exchanging them changes nothing, and
+/// `[0, 1] / [0] / [1.0]` is the only non-empty triple a one-shell element can
+/// produce, whatever the grouping algorithm. Same for the shell-major ravel of
+/// `J_data`: one row has one order. Both are discriminated by
+/// `constructed_compton_shells_map_onto_the_subshell_rows_by_occupancy`.
+#[test]
+fn compton_and_bremsstrahlung_are_written_from_the_auxiliary_tabulations() {
+    let c = convert(true, true);
+    let subshells = section(&c.dir, "subshells.arrow");
+    let batch = section(&c.dir, "compton.arrow");
+    assert_schema_is_declared(&batch, "compton.arrow");
+    assert_eq!(batch.num_rows(), 1, "compton.arrow is one row per element");
+
+    let profiles = c
+        .data
+        .compton_profiles
+        .as_ref()
+        .expect("add_photon_data attached the Biggs profiles");
+
+    let num_electrons = f64_list(&batch, "num_electrons", 0);
+    assert_f64_slice_eq(
+        "compton.num_electrons",
+        &num_electrons,
+        &profiles.num_electrons,
+    );
+    assert_eq!(num_electrons, vec![1.0]);
+    assert_eq!(num_electrons.len(), profiles.j.len());
+
+    // 13.61 from the Biggs tabulation, against 13.6 from MF=28 and MF=23. The
+    // difference is what makes this a usable discriminator that the column
+    // came from the tabulation and not from subshells.binding_energy.
+    let binding_energy = f64_list(&batch, "binding_energy", 0);
+    assert_f64_slice_eq(
+        "compton.binding_energy",
+        &binding_energy,
+        &profiles.binding_energy,
+    );
+    assert_eq!(binding_energy, vec![13.61]);
+    assert_ne!(
+        binding_energy[0],
+        f64_at(&subshells, "binding_energy", 0),
+        "the Compton binding energy is not the relaxation one"
+    );
+
+    // Only the first shell's abscissa is written, so a ragged upstream would
+    // be dropped without a word. The loop below that would notice runs exactly
+    // once here, and `pz = first.x` against a last-shell source stays
+    // undiscriminated: every row of the Biggs tabulation is built from the
+    // same `data.pz`, so no input this writer can be handed is ragged.
+    let pz = f64_list(&batch, "pz", 0);
+    assert_f64_slice_eq("compton.pz", &pz, &profiles.j[0].x);
+    assert_eq!(pz.len(), 31);
+    assert_eq!(pz[0], 0.0);
+    assert_eq!(pz[30], 100.0);
+    for (s, row) in profiles.j.iter().enumerate() {
+        assert_f64_slice_eq(&format!("the momentum grid of shell {s}"), &row.x, &pz);
+        assert_eq!(row.y.len(), pz.len(), "shell {s} is ragged");
+    }
+
+    let j_data = f64_list(&batch, "J_data", 0);
+    let expected_j: Vec<f64> = profiles
+        .j
+        .iter()
+        .flat_map(|t| t.y.iter().copied())
+        .collect();
+    assert_f64_slice_eq("J_data", &j_data, &expected_j);
+    // Hydrogen has one Compton shell, so the comparison above is one row and
+    // the shell-major ravel ORDER cannot be tested here; the arithmetic is
+    // pinned instead against the literal first three of the Z=1 row of
+    // compton_profiles_biggs1975.txt.
+    assert_f64_slice_eq(
+        "the Z=1 row of the Biggs tabulation",
+        &j_data[..3],
+        &[0.849, 0.842, 0.824],
+    );
+
+    let j_shape = i32_list(&batch, "J_shape", 0);
+    assert_eq!(j_shape.len(), 2);
+    assert_eq!(j_shape[0], profiles.j.len() as i32);
+    assert_eq!(j_shape[1], pz.len() as i32);
+    assert_i32_slice_eq("J_shape", &j_shape, &[1, 31]);
+    assert_eq!((j_shape[0] * j_shape[1]) as usize, j_data.len());
+
+    // The trapezoid, accumulated here rather than by calling
+    // compton_profile_cdfs, which is the function the writer called. The
+    // factors are in the opposite order to the writer's, so the last bit can
+    // differ and this is the one column compared to a relative tolerance.
+    let cdf = f64_list(&batch, "J_cdf_data", 0);
+    let mut expected_cdf: Vec<f64> = Vec::with_capacity(cdf.len());
+    for row in &profiles.j {
+        let mut running = 0.0;
+        expected_cdf.push(0.0);
+        for i in 1..row.y.len() {
+            running += (pz[i] - pz[i - 1]) * (row.y[i - 1] + row.y[i]) / 2.0;
+            expected_cdf.push(running);
+        }
+    }
+    assert_f64_slice_close("J_cdf_data", &cdf, &expected_cdf, 1e-15);
+    assert_eq!(cdf[0], 0.0);
+    assert!(
+        cdf.windows(2).all(|w| w[1] >= w[0]),
+        "a cumulative distribution cannot decrease"
+    );
+    // Deliberately un-normalised: a profile is tabulated for positive momentum
+    // only, so this row ends at 0.5021940797600001 and normalising it to 1.0
+    // would be wrong. No separate assertion, because the element-wise
+    // comparison above is against the un-normalised trapezoid and already
+    // fails if the writer starts normalising.
+    let cdf_shape = i32_list(&batch, "J_cdf_shape", 0);
+    assert_i32_slice_eq(
+        "J_cdf_shape",
+        &cdf_shape,
+        &[profiles.j.len() as i32, profiles.j[0].y.len() as i32],
+    );
+    assert_eq!((cdf_shape[0] * cdf_shape[1]) as usize, cdf.len());
+
+    // The CSR map from Compton shells onto subshell rows.
+    let offsets = i32_list(&batch, "subshell_map_offsets", 0);
+    let indices = i32_list(&batch, "subshell_map_indices", 0);
+    let weights = f64_list(&batch, "subshell_map_weights", 0);
+    assert_eq!(offsets.len(), num_electrons.len() + 1);
+    assert_eq!(offsets[0], 0);
+    assert!(offsets.windows(2).all(|w| w[1] >= w[0]));
+    assert_eq!(*offsets.last().unwrap() as usize, indices.len());
+    assert_eq!(weights.len(), indices.len());
+    assert_i32_slice_eq("subshell_map_offsets", &offsets, &[0, 1]);
+    assert_i32_slice_eq("subshell_map_indices", &indices, &[0]);
+    assert_f64_slice_eq("subshell_map_weights", &weights, &[1.0]);
+    for &i in &indices {
+        assert!(
+            (i as usize) < subshells.num_rows(),
+            "index {i} is not a row of subshells.arrow"
+        );
+    }
+    // Checkable from the two written files alone: each group of subshell rows
+    // has to carry the Compton shell's own occupancy, to the tolerance
+    // compton_subshell_map itself enforces. One iteration here, comparing 1.0
+    // against 1.0; the multi-shell case is in the constructed test.
+    for shell in 0..num_electrons.len() {
+        let (lo, hi) = (offsets[shell] as usize, offsets[shell + 1] as usize);
+        if lo == hi {
+            continue;
+        }
+        let grouped: f64 = indices[lo..hi]
+            .iter()
+            .map(|&i| f64_at(&subshells, "num_electrons", i as usize))
+            .sum();
+        assert_close(
+            &format!("the occupancy of Compton shell {shell}"),
+            grouped,
+            num_electrons[shell],
+            1e-3,
+        );
+        let total: f64 = weights[lo..hi].iter().sum();
+        assert_close(
+            &format!("the weights of Compton shell {shell}"),
+            total,
+            1.0,
+            1e-12,
+        );
+    }
+
+    // The empty branch. Without the relaxation file every subshell occupancy
+    // is 0.0, the tolerance test fails on the first shell and the map is
+    // dropped whole.
+    let bare = convert(false, true);
+    let bare_compton = section(&bare.dir, "compton.arrow");
+    assert_eq!(
+        f64_at(&section(&bare.dir, "subshells.arrow"), "num_electrons", 0),
+        0.0
+    );
+    assert_i32_slice_eq(
+        "subshell_map_offsets with no relaxation",
+        &i32_list(&bare_compton, "subshell_map_offsets", 0),
+        &[0, 0],
+    );
+    assert!(i32_list(&bare_compton, "subshell_map_indices", 0).is_empty());
+    assert!(f64_list(&bare_compton, "subshell_map_weights", 0).is_empty());
+
+    // bremsstrahlung.arrow.
+    let brem_batch = section(&c.dir, "bremsstrahlung.arrow");
+    assert_schema_is_declared(&brem_batch, "bremsstrahlung.arrow");
+    assert_eq!(
+        brem_batch.num_rows(),
+        1,
+        "I is the only non-list column, so the batch is one row"
+    );
+    let brem = c
+        .data
+        .bremsstrahlung
+        .as_ref()
+        .expect("add_photon_data attached the Seltzer-Berger data");
+
+    assert_eq!(f64_at(&brem_batch, "I", 0), brem.i);
+    assert_eq!(f64_at(&brem_batch, "I", 0), 19.2);
+
+    let electron_energy = f64_list(&brem_batch, "electron_energy", 0);
+    assert_f64_slice_eq("electron_energy", &electron_energy, &brem.electron_energy);
+    let expected_ee: Vec<f64> = (0..200)
+        .map(|i| 10f64.powf(3.0 + 6.0 * i as f64 / 199.0))
+        .collect();
+    assert_f64_slice_eq("electron_energy", &electron_energy, &expected_ee);
+    assert_eq!(electron_energy.len(), 200);
+    assert_close("electron_energy[0]", electron_energy[0], 1.0e3, 1e-12);
+    assert_close("electron_energy[199]", electron_energy[199], 1.0e9, 1e-9);
+
+    let photon_energy = f64_list(&brem_batch, "photon_energy", 0);
+    assert_f64_slice_eq("photon_energy", &photon_energy, &brem.photon_energy);
+    assert_eq!(photon_energy.len(), 30);
+
+    // Two adjacent type-identical columns which, on hydrogen, only their
+    // values tell apart.
+    let brem_electrons = f64_list(&brem_batch, "num_electrons", 0);
+    let ionization = f64_list(&brem_batch, "ionization_energy", 0);
+    assert_f64_slice_eq(
+        "bremsstrahlung.num_electrons",
+        &brem_electrons,
+        &brem.num_electrons,
+    );
+    assert_f64_slice_eq("ionization_energy", &ionization, &brem.ionization_energy);
+    assert_eq!(brem_electrons, vec![1.0]);
+    assert_eq!(ionization, vec![13.6]);
+    assert_eq!(ionization.len(), brem_electrons.len());
+
+    let dcs = f64_list(&brem_batch, "dcs_data", 0);
+    assert_eq!(dcs.len(), 200 * 30);
+    for (i, row) in brem.dcs.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            assert_eq!(
+                dcs[i * 30 + j],
+                v,
+                "dcs_data[{i} * 30 + {j}] is not dcs[{i}][{j}]"
+            );
+        }
+    }
+    // The ravel orientation, pinned without recomputing the spline: a
+    // transposed ravel would put dcs[1][0] at flat index 1.
+    assert_eq!(dcs[1], brem.dcs[0][1]);
+    assert_ne!(
+        brem.dcs[0][1], brem.dcs[1][0],
+        "the two candidates for flat index 1 have to differ for this to mean anything"
+    );
+
+    let shape = i32_list(&brem_batch, "dcs_shape", 0);
+    assert_i32_slice_eq("dcs_shape", &shape, &[200, 30]);
+    assert_eq!(shape[0] as usize, electron_energy.len());
+    assert_eq!(shape[1] as usize, photon_energy.len());
+    assert_eq!((shape[0] * shape[1]) as usize, dcs.len());
+}
+
+// ---------------------------------------------------------------------------
+// A constructed element, for the branches hydrogen cannot reach.
+// ---------------------------------------------------------------------------
+
+/// A hand-built `IncidentPhoton`. NOT A PARSED EVALUATION.
+///
+/// `photoat-001_H_000.endf` is the only photoatomic file in the tree and it is
+/// Z = 1 with one subshell and one Compton shell. That leaves five writer
+/// branches undiscriminated however the four tests above are written: the
+/// `(z as f64).powi(2)` divide is a divide by one; the subshell row order is
+/// the order of a single row; both arguments of `compton_subshell_map` are the
+/// same `[1.0]`; `safe_log`'s floor is never reached because every K-shell
+/// value is positive; and NTR is zero, so the relaxation cascade table is
+/// never built. Each was measured to survive a source mutation with every
+/// vendored test still green.
+///
+/// So this element is invented. Nothing asserted against it is agreement with
+/// ENDF. It pins the writer's arithmetic, its column order and its ravel
+/// order, and it is worth nothing at all as evaluation parity.
+///
+/// Every field is given a DISTINCT value, which is the entire point of
+/// building one: two columns that are equal cannot discriminate a swap, and
+/// that is exactly what went wrong on hydrogen.
+///
+/// The layout, chosen so every expected answer below is exact in binary:
+///
+/// * Z = 10, so the form factor divide is by 100 rather than by 1.
+/// * Cross sections tabulated so the union grid is `[1, 5, 10, 20, 50, 100]`.
+/// * Three subshells K, L1 and L2, binding energies 50, 20 and 5 eV,
+///   occupancies 2, 2 and 6 summing to Z, thresholds equal to the binding
+///   energies. The rows are then most-bound-first and every subshell column
+///   changes under a reversal.
+/// * The K-shell cross section is exactly zero at its own threshold, which is
+///   the only way to reach `safe_log`'s floor.
+/// * Two Compton shells, occupancies 2 and 8, grouping onto the three subshell
+///   rows as {K} and {L1, L2}. The two arguments of `compton_subshell_map`
+///   then differ in length as well as in value.
+/// * Two Compton profile rows with different ordinates, so the shell-major
+///   ravel of `J_data` is observable.
+/// * MT 525 carries a cross section, which no vendored photoatomic file does.
+fn constructed_element() -> IncidentPhoton {
+    fn channel(mt: i32, x: &[f64], y: &[f64]) -> PhotonReaction {
+        let mut rx = PhotonReaction::new(mt);
+        rx.xs = Some(Tabulated1D::new(x.to_vec(), y.to_vec()));
+        rx
+    }
+
+    let mut data = IncidentPhoton::new(10);
+
+    let mut coherent = channel(502, &[1.0, 10.0, 100.0], &[2.0, 3.0, 5.0]);
+    // A triangle: Z at zero momentum transfer falling to zero at 2. Squared
+    // and divided by Z^2 that is a line from 1 to 0 over [0, 4], whose area is
+    // exactly 2.
+    coherent.scattering_factor = Some(Tabulated1D::new(vec![0.0, 2.0], vec![10.0, 0.0]));
+    // Different abscissae as well as different ordinates, which hydrogen does
+    // not have: there MT 505 and MT 506 share one 297-point grid.
+    coherent.anomalous_real = Some(Tabulated1D::new(vec![1.0, 2.0], vec![-1.5, -0.5]));
+    coherent.anomalous_imag = Some(Tabulated1D::new(vec![1.0, 3.0], vec![0.25, 0.75]));
+    data.reactions.insert(502, coherent);
+
+    let mut incoherent = channel(504, &[1.0, 10.0, 100.0], &[7.0, 11.0, 13.0]);
+    incoherent.scattering_factor = Some(Tabulated1D::new(vec![0.0, 3.0], vec![0.0, 10.0]));
+    data.reactions.insert(504, incoherent);
+
+    data.reactions
+        .insert(522, channel(522, &[10.0, 100.0], &[17.0, 19.0]));
+    data.reactions
+        .insert(525, channel(525, &[1.0, 10.0, 100.0], &[23.0, 29.0, 31.0]));
+
+    // K is zero at its own threshold, which is what reaches the log floor.
+    data.reactions
+        .insert(534, channel(534, &[50.0, 100.0], &[0.0, 4.0]));
+    data.reactions
+        .insert(535, channel(535, &[20.0, 100.0], &[6.0, 8.0]));
+    data.reactions
+        .insert(536, channel(536, &[5.0, 100.0], &[9.0, 12.0]));
+
+    let mut relaxation = AtomicRelaxation::default();
+    for (shell, binding, electrons) in [("K", 50.0, 2.0), ("L1", 20.0, 2.0), ("L2", 5.0, 6.0)] {
+        relaxation.binding_energy.insert(shell, binding);
+        relaxation.num_electrons.insert(shell, electrons);
+    }
+    // One radiative transition, with no tertiary subshell, and one
+    // non-radiative one that has both. The two rows differ in every column.
+    relaxation.transitions.insert(
+        "K",
+        Transitions {
+            secondary_subshell: vec!["L1", "L2"],
+            tertiary_subshell: vec!["", "L2"],
+            energy: vec![30.0, 40.0],
+            probability: vec![0.4, 0.6],
+        },
+    );
+    data.atomic_relaxation = Some(relaxation);
+
+    data.compton_profiles = Some(ComptonProfiles {
+        num_electrons: vec![2.0, 8.0],
+        // Deliberately not the relaxation binding energies, so a column
+        // sourced from the wrong place is visible.
+        binding_energy: vec![51.0, 6.0],
+        j: vec![
+            Tabulated1D::new(vec![0.0, 1.0, 2.0], vec![0.9, 0.5, 0.1]),
+            Tabulated1D::new(vec![0.0, 1.0, 2.0], vec![0.8, 0.4, 0.2]),
+        ],
+    });
+
+    data
+}
+
+/// The real `write_photon` over a constructed element, into a scratch tree
+/// that removes itself when an assertion panics.
+fn write_constructed(data: &IncidentPhoton) -> (tempfile::TempDir, PathBuf) {
+    let scratch = scratch();
+    let dir = scratch.path().join("Ne.arrow");
+    std::fs::create_dir_all(&dir).expect("the output directory is created");
+    yamc_convert::photon::write_photon(data, &dir).expect("the constructed element writes");
+    (scratch, dir)
+}
+
+/// The union grid of [`constructed_element`], as a fact about the fixture
+/// rather than a restatement of `union_grid`.
+const CONSTRUCTED_GRID: [f64; 6] = [1.0, 5.0, 10.0, 20.0, 50.0, 100.0];
+
+/// A failure means the cumulative coherent form factor lost its Z squared
+/// normalisation.
+///
+/// CONSTRUCTED INPUT, not an evaluation: no vendored photoatomic file has
+/// Z > 1, so on `photoat-001_H_000.endf` the divide at `photon.rs:115` is a
+/// divide by one and `.powi(2)` can be changed to `.powi(5)`, or deleted
+/// outright, with every other test in this file still green.
+///
+/// The expected integral is a closed form and not a rerun of the writer's
+/// expression. The form factor is the straight line from `(0, Z)` to `(2, 0)`,
+/// so the squared and normalised function is the line from `(0, 1)` to
+/// `(4, 0)` and the area under it is exactly 2. With `.powi(5)` it would be
+/// 0.002 and with no divide at all 200.
+#[test]
+fn constructed_element_divides_the_integrated_form_factor_by_z_squared() {
+    let data = constructed_element();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "element.arrow");
+    assert_schema_is_declared(&batch, "element.arrow");
+
+    assert_eq!(str_at(&batch, "name", 0), "Ne");
+    assert_eq!(i32_at(&batch, "Z", 0), 10);
+
+    // The form factor itself is copied through untouched, so the divide has to
+    // show up in the integral and nowhere else.
+    assert_f64_slice_eq(
+        "coherent_ff_x",
+        &f64_list(&batch, "coherent_ff_x", 0),
+        &[0.0, 2.0],
+    );
+    assert_f64_slice_eq(
+        "coherent_ff_y",
+        &f64_list(&batch, "coherent_ff_y", 0),
+        &[10.0, 0.0],
+    );
+
+    assert_f64_slice_eq(
+        "coherent_int_ff_x",
+        &f64_list(&batch, "coherent_int_ff_x", 0),
+        &[0.0, 4.0],
+    );
+    assert_f64_slice_eq(
+        "coherent_int_ff_y",
+        &f64_list(&batch, "coherent_int_ff_y", 0),
+        &[0.0, 2.0],
+    );
+}
+
+/// A failure means the two anomalous scattering terms were crossed.
+///
+/// CONSTRUCTED INPUT, not an evaluation. On hydrogen MT 505 and MT 506 share
+/// one 297-point abscissa, so exchanging the two x slots writes a
+/// byte-identical file and only the ordinates separate them. Here the two
+/// terms are tabulated on different abscissae of different lengths, so all
+/// four slots are independent.
+///
+/// The MT 505 to imaginary and MT 506 to real mapping is a deliberate crossing
+/// at `crates/endf/src/incident_photon.rs:383-392`; this test is downstream of
+/// it and pins the writer's slots, not the parser's crossing.
+#[test]
+fn constructed_anomalous_scattering_columns_keep_their_own_abscissae() {
+    let data = constructed_element();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "element.arrow");
+
+    assert_f64_slice_eq(
+        "coherent_anomalous_real_x",
+        &f64_list(&batch, "coherent_anomalous_real_x", 0),
+        &[1.0, 2.0],
+    );
+    assert_f64_slice_eq(
+        "coherent_anomalous_real_y",
+        &f64_list(&batch, "coherent_anomalous_real_y", 0),
+        &[-1.5, -0.5],
+    );
+    assert_f64_slice_eq(
+        "coherent_anomalous_imag_x",
+        &f64_list(&batch, "coherent_anomalous_imag_x", 0),
+        &[1.0, 3.0],
+    );
+    assert_f64_slice_eq(
+        "coherent_anomalous_imag_y",
+        &f64_list(&batch, "coherent_anomalous_imag_y", 0),
+        &[0.25, 0.75],
+    );
+
+    // The incoherent scattering function is the fifth same-typed neighbour of
+    // those four and is given its own third length here.
+    assert_f64_slice_eq(
+        "incoherent_ff_x",
+        &f64_list(&batch, "incoherent_ff_x", 0),
+        &[0.0, 3.0],
+    );
+    assert_f64_slice_eq(
+        "incoherent_ff_y",
+        &f64_list(&batch, "incoherent_ff_y", 0),
+        &[0.0, 10.0],
+    );
+}
+
+/// PINS A SUSPECTED DEFECT. `element.arrow.heating_xs` can never be populated.
+///
+/// This test does not endorse the behaviour it asserts. `ELEMENT_MTS`
+/// (`photon.rs:31`) is `[501, 502, 504, 515, 517, 522]`: it contains 501,
+/// which `take` at `photon.rs:139` never asks for, and omits 525, which is the
+/// MT named `"heating"` (`crates/endf/src/incident_photon.rs:33`). The filter
+/// at `photon.rs:94` therefore drops the heating reaction before it can be
+/// evaluated and `take("heating")` falls through to `unwrap_or_default`. The
+/// reader substitutes `vec![0.0; n_energy]` for an empty column
+/// (`crates/yamc-element/src/photon_arrow.rs:88-94`), so photon KERMA loads as
+/// identically zero with no error anywhere.
+///
+/// CONSTRUCTED INPUT, not an evaluation: `photoat-001_H_000.endf` has no
+/// MF=23 MT=525 and is the only photoatomic file in the tree, so the branch is
+/// unreachable from vendored bytes. If you have just fixed `ELEMENT_MTS` to
+/// `[502, 504, 515, 517, 522, 525]` then this test is what went red, and the
+/// two assertions below should become a comparison against MT 525 evaluated on
+/// the union grid, the same shape as the five channels in
+/// `element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid`.
+#[test]
+fn constructed_mt_525_is_dropped_from_the_heating_column() {
+    let data = constructed_element();
+    // The input really does carry a heating cross section, under the name the
+    // writer asks for.
+    let heating = data.get(525).expect("the constructed element has MT 525");
+    assert_eq!(heating.name(), Some("heating"));
+    assert_f64_slice_eq(
+        "the MT 525 cross section handed to the writer",
+        &heating.xs.as_ref().expect("MT 525 has a cross section").y,
+        &[23.0, 29.0, 31.0],
+    );
+
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "element.arrow");
+
+    // The channels ELEMENT_MTS does list are on the union grid.
+    assert_eq!(list_len(&batch, "ln_energy", 0), CONSTRUCTED_GRID.len());
+    assert_eq!(list_len(&batch, "coherent_xs", 0), CONSTRUCTED_GRID.len());
+    // Heating is not, and it is an empty list rather than a null.
+    assert!(!is_null(&batch, "heating_xs", 0));
+    assert_eq!(
+        list_len(&batch, "heating_xs", 0),
+        0,
+        "heating_xs is written empty even though MT 525 was supplied; see this \
+         test's doc comment before changing the assertion"
+    );
+}
+
+/// A failure means `subshells.arrow` is no longer written most-bound-first.
+///
+/// CONSTRUCTED INPUT, not an evaluation: hydrogen has one photoionization
+/// channel, so on the vendored fixture the row order is the order of a single
+/// row and replacing the loop at `photon.rs:180` with
+/// `data.reactions.iter().rev()` leaves every other test in this file green.
+/// The order is load bearing twice over: `compton_subshell_map` walks the two
+/// occupancy lists in step, and the reader indexes `subshell_map_indices` into
+/// these rows.
+///
+/// The element is written without Compton profiles on purpose, so that a
+/// reversal is caught by the row assertions here rather than by
+/// `write_compton`'s guard, which is exercised separately in
+/// `constructed_out_of_order_subshell_rows_are_refused_by_write_compton`.
+#[test]
+fn constructed_subshell_rows_are_written_most_bound_first() {
+    let mut data = constructed_element();
+    data.compton_profiles = None;
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "subshells.arrow");
+    assert_schema_is_declared(&batch, "subshells.arrow");
+    assert_eq!(batch.num_rows(), 3);
+
+    let designators: Vec<String> = (0..3).map(|r| str_at(&batch, "designator", r)).collect();
+    assert_eq!(designators, ["K", "L1", "L2"]);
+
+    let binding: Vec<f64> = (0..3)
+        .map(|r| f64_at(&batch, "binding_energy", r))
+        .collect();
+    assert_eq!(binding, [50.0, 20.0, 5.0]);
+    assert!(
+        binding.windows(2).all(|w| w[0] > w[1]),
+        "most-bound-first means the binding energy falls down the rows"
+    );
+
+    let electrons: Vec<f64> = (0..3).map(|r| f64_at(&batch, "num_electrons", r)).collect();
+    assert_eq!(electrons, [2.0, 2.0, 6.0]);
+
+    // The thresholds fall with the binding energies, so the index into the
+    // union grid falls too. Grid: [1, 5, 10, 20, 50, 100].
+    let grid = union_grid_expected(&data);
+    assert_f64_slice_eq("the constructed union grid", &grid, &CONSTRUCTED_GRID);
+    let thresholds: Vec<i32> = (0..3).map(|r| i32_at(&batch, "threshold_idx", r)).collect();
+    assert_eq!(thresholds, [4, 3, 1]);
+
+    // Each row's curve starts at its own threshold, so the three rows have
+    // three different lengths as well as three different first values.
+    assert_f64_slice_eq(
+        "row 0, the K curve",
+        &f64_list(&batch, "xs", 0),
+        &[0.0, 4.0],
+    );
+    assert_f64_slice_eq(
+        "row 1, the L1 curve",
+        &f64_list(&batch, "xs", 1),
+        &[6.0, 6.75, 8.0],
+    );
+    let l2 = f64_list(&batch, "xs", 2);
+    assert_eq!(l2.len(), 5);
+    assert_eq!(l2[0], 9.0);
+    assert_eq!(l2[4], 12.0);
+}
+
+/// A failure means a zero cross section reaches the sampler as an infinity.
+///
+/// CONSTRUCTED INPUT, not an evaluation: every K-shell value in
+/// `photoat-001_H_000.endf` is strictly positive, so `safe_log`'s floor
+/// (`photon.rs:43`) is never taken there and changing `1e-300` to `1e-30`
+/// leaves every other test in this file green. The constructed K-shell cross
+/// section is exactly zero at its own threshold, which is the first point of
+/// its stored curve.
+///
+/// The floor is compared against `1e-300f64.ln()` computed here rather than
+/// against the literal -690.7755278982137, so a runner whose `ln` differs in
+/// the last bit does not fail on the constant. The mutation this catches moves
+/// the value by a factor of ten, not by an ulp.
+#[test]
+fn constructed_zero_cross_section_reaches_the_safe_log_floor() {
+    let data = constructed_element();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "subshells.arrow");
+
+    let xs = f64_list(&batch, "xs", 0);
+    let ln_xs = f64_list(&batch, "ln_xs", 0);
+    assert_eq!(xs[0], 0.0, "the K curve starts at zero, which is the point");
+    assert_eq!(ln_xs.len(), xs.len());
+    assert_eq!(ln_xs[0], 1e-300f64.ln());
+    assert!(
+        ln_xs[0].is_finite(),
+        "an infinity here comes back as a NaN energy several steps later"
+    );
+    // The positive values beside it are the ordinary log, so the floor is a
+    // floor and not a blanket replacement.
+    assert_eq!(ln_xs[1], 4.0f64.ln());
+}
+
+/// A failure means the relaxation cascade is transposed or its subshell
+/// indices are wrong.
+///
+/// CONSTRUCTED INPUT, not an evaluation: `atom-001_H_000.endf` gives hydrogen
+/// one subshell with NTR = 0, and it is the only relaxation file in the tree,
+/// so `transitions_table` (`photon.rs:66-77`) is never called on any vendored
+/// input and both cascade columns are only ever null. The NULL branch is
+/// covered by the vendored test; this is the populated one.
+///
+/// The two subshell columns are indices into
+/// `endf::incident_photon::SUBSHELLS` rather than names, so the whole table
+/// can be one `f64` array. A radiative transition has no tertiary subshell and
+/// is written as index 0, which is the empty name and not `"K"`.
+#[test]
+fn constructed_subshell_cascade_is_a_row_major_table_of_subshell_indices() {
+    let data = constructed_element();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "subshells.arrow");
+
+    // The indices the flat table encodes, so the literals below are legible.
+    assert_eq!(SUBSHELLS[0], "");
+    assert_eq!(SUBSHELLS[2], "L1");
+    assert_eq!(SUBSHELLS[3], "L2");
+
+    // Row 0 is K, which is the only shell given a cascade. Two transitions of
+    // four columns each: secondary, tertiary, energy, probability.
+    assert!(!is_null(&batch, "transitions_data", 0));
+    assert_i32_slice_eq(
+        "K transitions_shape",
+        &i32_list(&batch, "transitions_shape", 0),
+        &[2, 4],
+    );
+    assert_f64_slice_eq(
+        "K transitions_data",
+        &f64_list(&batch, "transitions_data", 0),
+        &[2.0, 0.0, 30.0, 0.4, 3.0, 3.0, 40.0, 0.6],
+    );
+
+    // L1 and L2 have none, so they stay null in a file whose first row does
+    // not.
+    for row in 1..3 {
+        assert!(
+            is_null(&batch, "transitions_data", row),
+            "row {row} has no cascade, so transitions_data is null"
+        );
+        assert!(is_null(&batch, "transitions_shape", row));
+    }
+}
+
+/// A failure means the Compton subshell map groups the wrong way round, or the
+/// profile rows were ravelled in the wrong order.
+///
+/// CONSTRUCTED INPUT, not an evaluation. On hydrogen both arguments of
+/// `compton_subshell_map` (`photon.rs:284`) are `[1.0]`, so exchanging them
+/// changes nothing and the CSR triple can only be `[0, 1] / [0] / [1.0]`,
+/// which is the single answer a one-shell element can give. One Compton shell
+/// also makes every ravel order of `J_data` the same bytes. This element has
+/// two Compton shells over three subshell rows, with different occupancies and
+/// different profile ordinates.
+#[test]
+fn constructed_compton_shells_map_onto_the_subshell_rows_by_occupancy() {
+    let data = constructed_element();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "compton.arrow");
+    let subshells = section(&dir, "subshells.arrow");
+    assert_schema_is_declared(&batch, "compton.arrow");
+
+    assert_f64_slice_eq(
+        "compton.num_electrons",
+        &f64_list(&batch, "num_electrons", 0),
+        &[2.0, 8.0],
+    );
+    assert_f64_slice_eq(
+        "compton.binding_energy",
+        &f64_list(&batch, "binding_energy", 0),
+        &[51.0, 6.0],
+    );
+
+    // Shell-major: row 0 then row 1, not the transpose.
+    assert_f64_slice_eq("compton.pz", &f64_list(&batch, "pz", 0), &[0.0, 1.0, 2.0]);
+    assert_f64_slice_eq(
+        "J_data",
+        &f64_list(&batch, "J_data", 0),
+        &[0.9, 0.5, 0.1, 0.8, 0.4, 0.2],
+    );
+    assert_i32_slice_eq("J_shape", &i32_list(&batch, "J_shape", 0), &[2, 3]);
+
+    // The trapezoid, in closed form: 0.5 * (0.9 + 0.5) * 1 then
+    // 0.5 * (0.5 + 0.1) * 1 on top of it, and the same for the second row.
+    assert_f64_slice_close(
+        "J_cdf_data",
+        &f64_list(&batch, "J_cdf_data", 0),
+        &[0.0, 0.7, 1.0, 0.0, 0.6, 0.9],
+        1e-15,
+    );
+    assert_i32_slice_eq("J_cdf_shape", &i32_list(&batch, "J_cdf_shape", 0), &[2, 3]);
+
+    // Compton shell 0 (2 electrons) is K alone; shell 1 (8 electrons) is
+    // L1 plus L2, weighted 2/8 and 6/8.
+    let offsets = i32_list(&batch, "subshell_map_offsets", 0);
+    assert_i32_slice_eq("subshell_map_offsets", &offsets, &[0, 1, 3]);
+    assert_i32_slice_eq(
+        "subshell_map_indices",
+        &i32_list(&batch, "subshell_map_indices", 0),
+        &[0, 1, 2],
+    );
+    assert_f64_slice_eq(
+        "subshell_map_weights",
+        &f64_list(&batch, "subshell_map_weights", 0),
+        &[1.0, 0.25, 0.75],
+    );
+    assert_eq!(
+        subshells.num_rows(),
+        3,
+        "the indices above are rows of subshells.arrow"
+    );
+
+    // The swap this element exists to catch, stated so the assertions above
+    // are demonstrably not the same under both argument orders. Feeding the
+    // subshell occupancies as the Compton ones yields one offset per subshell
+    // row and stops after the first group.
+    let (swapped, _, _) = compton_subshell_map(&[2.0, 2.0, 6.0], &[2.0, 8.0]);
+    assert_eq!(
+        swapped,
+        vec![0usize, 1, 1, 1],
+        "the two argument orders have to disagree for the CSR triple above to \
+         discriminate between them"
+    );
+}
+
+/// A failure means `write_compton` stopped refusing subshell rows it cannot
+/// map.
+///
+/// CONSTRUCTED INPUT, and a deliberately malformed one. The guard at
+/// `photon.rs:268-278` is unreachable through any parser: `write_subshells`
+/// walks `data.reactions` in `BTreeMap` key order and names each row from
+/// `PhotonReaction::name`, which reads the reaction's own `mt`, and every
+/// constructor in `crates/endf` inserts a reaction under its own MT, so the
+/// designators come out in ascending `SUBSHELLS` order by construction. The
+/// only way to reach the guard is to insert a reaction under a key that is not
+/// its `mt`, which is what this does. Nothing here says a real evaluation can
+/// produce that state; it says the guard fires when it does.
+///
+/// The refusal happens after `element.arrow` and `subshells.arrow` are already
+/// on disk, so a caller that ignores the error is left with a partial tree.
+#[test]
+fn constructed_out_of_order_subshell_rows_are_refused_by_write_compton() {
+    let mut data = IncidentPhoton::new(10);
+
+    let mut l2 = PhotonReaction::new(536);
+    l2.xs = Some(Tabulated1D::new(vec![5.0, 100.0], vec![9.0, 12.0]));
+    let mut k = PhotonReaction::new(534);
+    k.xs = Some(Tabulated1D::new(vec![50.0, 100.0], vec![1.0, 4.0]));
+    // Key 534 holds the reaction that names itself L2, key 535 the one that
+    // names itself K, so the rows come out L2 then K: least bound first.
+    data.reactions.insert(534, l2);
+    data.reactions.insert(535, k);
+    data.compton_profiles = Some(ComptonProfiles {
+        num_electrons: vec![2.0, 8.0],
+        binding_energy: vec![51.0, 6.0],
+        j: vec![
+            Tabulated1D::new(vec![0.0, 1.0, 2.0], vec![0.9, 0.5, 0.1]),
+            Tabulated1D::new(vec![0.0, 1.0, 2.0], vec![0.8, 0.4, 0.2]),
+        ],
+    });
+
+    let scratch = scratch();
+    let dir = scratch.path().join("Ne.arrow");
+    std::fs::create_dir_all(&dir).expect("the output directory is created");
+    let err = yamc_convert::photon::write_photon(&data, &dir)
+        .expect_err("out-of-order subshell rows are refused")
+        .to_string();
+    assert!(
+        err.contains("not in most-bound-first order"),
+        "the refusal came from somewhere else: {err}"
+    );
+    assert!(
+        absent(&dir, "compton.arrow"),
+        "the refusal has to leave compton.arrow unwritten"
+    );
+    assert_eq!(
+        str_at(&section(&dir, "subshells.arrow"), "designator", 0),
+        "L2",
+        "the rows really were out of order, rather than the guard misfiring"
+    );
+}

--- a/crates/yamc-convert/tests/section_values_products.rs
+++ b/crates/yamc-convert/tests/section_values_products.rs
@@ -1,0 +1,2508 @@
+//! Every column of `products.arrow` and `distributions.arrow`, against the
+//! parsed evaluation the writer was handed.
+//!
+//! # Why the writers are called directly
+//!
+//! `entry::convert_neutron_transport` is the only production caller of these
+//! two writers, and it refuses an ACE source outright, so there is no hermetic
+//! route to them through the entry point. Every test here hands
+//! `write_products` and `write_distributions` the same `IncidentNeutron` the
+//! entry point would have built.
+//!
+//! # Which fixture is here for what
+//!
+//! `Li6.ace.xz` is the only vendored input that drives both writers with a full
+//! product set: 18 products, uncorrelated and Kalbach-Mann distributions, ACE
+//! energy laws 2, 3/33 and 4, and both yield forms.
+//! `n-092_U_235_trimmed.endf.xz` is the only source of delayed products with
+//! real decay constants. `n-026_Fe_056_trimmed.endf.xz` is the zero-row
+//! distributions case. `n-003_Li_006_trimmed.endf.xz` drives two of the three
+//! refusals. `synthetic-laws.ace.xz` cannot be read as a nuclide at all, so its
+//! seven laws are decoded per DLW locator and wrapped in a scaffold built here;
+//! that is the only way any vendored bytes reach laws 7, 9, 11, 61 and 66.
+//!
+//! # Four inputs are built here rather than parsed
+//!
+//! `constructed_two_distribution_product`, `constructed_correlated_regions`,
+//! `constructed_kalbach_mann_with_lines` and
+//! `constructed_watt_with_distinct_grids` assemble an `IncidentNeutron` by
+//! hand. Each exists because no vendored evaluation discriminates the column
+//! it covers, each is named in the doc comment of the test that uses it, and
+//! each gives its fields deliberately different values: two columns that hold
+//! the same thing on a real fixture cannot discriminate a swap between them,
+//! which is the only reason to build an input at all. None of the four is
+//! evaluation parity and no number in them is claimed to be physical.
+//!
+//! # No ravel is recomputed by calling the writer's own flattener
+//!
+//! `yamc_convert::univariate_flat::flatten` and `distributions::ravel3` are
+//! what these tests exist to check, so calling either to build an expectation
+//! would restate the writer rather than test it. The `(x, p, c)` triples come
+//! from `expect_flat` and `expect_mu` below, which are written from the
+//! `endf::univariate` and `endf::mf::mf4` types directly.
+
+mod section_values;
+use section_values::*;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use arrow_array::RecordBatch;
+use endf::angle_energy::{
+    AngleEnergy, CorrelatedAngleEnergy, KalbachMann, UncorrelatedAngleEnergy,
+};
+use endf::function::Tabulated1D;
+use endf::mf::mf4::AngleAtEnergy;
+use endf::mf::mf5::EnergyDistribution;
+use endf::product::{Product, Yield};
+use endf::univariate::{Discrete, Interpolation, Mixture, Tabular, Uniform, Univariate};
+use endf::IncidentNeutron;
+
+// ---------------------------------------------------------------------------
+// Writing, and reading a whole column back.
+// ---------------------------------------------------------------------------
+
+fn products_of(data: &IncidentNeutron, dir: &Path) -> RecordBatch {
+    yamc_convert::products::write_products(data, dir).expect("products.arrow is written");
+    section(dir, "products.arrow")
+}
+
+fn distributions_of(data: &IncidentNeutron, dir: &Path) -> RecordBatch {
+    yamc_convert::distributions::write_distributions(data, dir)
+        .expect("distributions.arrow is written");
+    section(dir, "distributions.arrow")
+}
+
+fn i32_column(batch: &RecordBatch, col: &str) -> Vec<i32> {
+    (0..batch.num_rows())
+        .map(|r| i32_at(batch, col, r))
+        .collect()
+}
+
+fn str_column(batch: &RecordBatch, col: &str) -> Vec<String> {
+    (0..batch.num_rows())
+        .map(|r| str_at(batch, col, r))
+        .collect()
+}
+
+/// The `(reaction_mt, product_idx, dist_idx)` key the reader joins on.
+fn triples(batch: &RecordBatch) -> Vec<(i32, i32, i32)> {
+    (0..batch.num_rows())
+        .map(|r| {
+            (
+                i32_at(batch, "reaction_mt", r),
+                i32_at(batch, "product_idx", r),
+                i32_at(batch, "dist_idx", r),
+            )
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The traversal the two files share.
+// ---------------------------------------------------------------------------
+
+/// One entry per `products.arrow` row: MT, product index, product.
+///
+/// A restatement of `products::product_rows`, kept local so the row order the
+/// later tests index by is the one
+/// `product_rows_are_the_reaction_walk_in_mt_order` pins against the file.
+fn product_walk(data: &IncidentNeutron) -> Vec<(i32, usize, &Product)> {
+    let mut out = Vec::new();
+    for (&mt, rx) in &data.reactions {
+        for (idx, product) in rx.products.iter().enumerate() {
+            out.push((mt, idx, product));
+        }
+    }
+    out
+}
+
+/// One entry per `distributions.arrow` row: the key, the distribution and the
+/// applicability that belongs to it.
+type DistRow<'a> = (i32, usize, usize, &'a AngleEnergy, Option<&'a Tabulated1D>);
+
+fn distribution_walk(data: &IncidentNeutron) -> Vec<DistRow<'_>> {
+    let mut out = Vec::new();
+    for (mt, product_idx, product) in product_walk(data) {
+        for (dist_idx, dist) in product.distribution.iter().enumerate() {
+            out.push((
+                mt,
+                product_idx,
+                dist_idx,
+                dist,
+                product.applicability.get(dist_idx),
+            ));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// What a sub-table must be written as, restated from the endf types.
+// ---------------------------------------------------------------------------
+
+/// The interpolation code the format draws its one distinction with.
+fn interp_code(interp: Interpolation) -> i32 {
+    match interp {
+        Interpolation::Histogram => 1,
+        _ => 2,
+    }
+}
+
+/// The CDF the file supplied, which is the one the format must carry.
+///
+/// Panics rather than falling back, because the fallback is the converter's
+/// own trapezoid integration: if it ever fires on a vendored fixture then the
+/// comparisons below stop being a comparison against the file and this helper
+/// has to grow a second branch, which is worth failing over rather than
+/// absorbing.
+fn stored_cdf(what: &str, c: &Option<Vec<f64>>, n: usize) -> Vec<f64> {
+    match c {
+        Some(c) if c.len() == n => c.clone(),
+        _ => panic!(
+            "{what}: the parsed table carries no CDF of its own length, so the writer \
+             integrated one instead and this test is no longer comparing against the file"
+        ),
+    }
+}
+
+/// The `(x, p, c, interp, n_discrete)` one sub-table must be written as.
+///
+/// Written from `endf::univariate::Univariate` and not by calling
+/// `univariate_flat::flatten`, which is the function under test. Two of the
+/// five values are conventions with no counterpart on the parsed side and are
+/// restated here as such: a `Discrete` is always written with interpolation 1
+/// whatever the ACE INTT said, and a `Uniform` likewise, since
+/// `endf::univariate::Uniform` carries no interpolation at all.
+fn expect_flat(u: &Univariate) -> (Vec<f64>, Vec<f64>, Vec<f64>, i32, i32) {
+    match u {
+        Univariate::Tabular(t) => (
+            t.x.clone(),
+            t.p.clone(),
+            stored_cdf("a tabular outgoing table", &t.c, t.x.len()),
+            interp_code(t.interpolation),
+            0,
+        ),
+        Univariate::Discrete(d) => (
+            d.x.clone(),
+            d.p.clone(),
+            stored_cdf("a discrete line set", &d.c, d.x.len()),
+            1,
+            d.x.len() as i32,
+        ),
+        Univariate::Uniform(u) => {
+            assert!(
+                u.b > u.a,
+                "no vendored fixture holds a degenerate Uniform, so the writer's \
+                 zero-density branch is not the one under test here"
+            );
+            let density = 1.0 / (u.b - u.a);
+            (vec![u.a, u.b], vec![density, density], vec![0.0, 1.0], 1, 0)
+        }
+        // The format has no mixture: the parts are concatenated with the
+        // discrete lines in front, because `n_discrete` counts from the front.
+        Univariate::Mixture(m) => {
+            let (mut x, mut p, mut c) = (Vec::new(), Vec::new(), Vec::new());
+            let mut n_discrete = 0;
+            let mut continuous_interp = None;
+            for part in &m.distribution {
+                let (px, pp, pc, part_interp, part_discrete) = expect_flat(part);
+                if part_discrete > 0 {
+                    n_discrete += part_discrete;
+                } else if continuous_interp.is_none() {
+                    continuous_interp = Some(part_interp);
+                }
+                x.extend(px);
+                p.extend(pp);
+                c.extend(pc);
+            }
+            (x, p, c, continuous_interp.unwrap_or(2), n_discrete)
+        }
+    }
+}
+
+/// The same for a cosine table, whose parsed type is a different enum.
+fn expect_mu(mu: &AngleAtEnergy) -> (Vec<f64>, Vec<f64>, Vec<f64>, i32) {
+    match mu {
+        AngleAtEnergy::Tabular(t) => (
+            t.x.clone(),
+            t.p.clone(),
+            stored_cdf("a cosine table", &t.c, t.x.len()),
+            interp_code(t.interpolation),
+        ),
+        AngleAtEnergy::Isotropic(u) => {
+            let density = 1.0 / (u.b - u.a);
+            (vec![u.a, u.b], vec![density, density], vec![0.0, 1.0], 1)
+        }
+        AngleAtEnergy::Tabulated(_) => {
+            panic!("no vendored fixture reaches the MF=4 LTT=2 branch of angle_at_energy")
+        }
+        AngleAtEnergy::Legendre(_) => panic!("the writer refuses Legendre, so this cannot be here"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Comparing a ravel.
+// ---------------------------------------------------------------------------
+
+/// A `(3, total)` C-order ravel, one third at a time.
+///
+/// Compared in thirds rather than as one vector because the failure the module
+/// docstring names is an interleaved layout, and an interleaved write differs
+/// from this one in the first third: naming the third in the message says
+/// which row went wrong instead of giving an index into a flat array of
+/// thousands.
+#[track_caller]
+fn assert_ravel3(what: &str, written: &[f64], x: &[f64], p: &[f64], c: &[f64]) {
+    let total = x.len();
+    assert_eq!(p.len(), total, "{what}: the p row is a different length");
+    assert_eq!(c.len(), total, "{what}: the c row is a different length");
+    assert_eq!(
+        written.len(),
+        3 * total,
+        "{what}: the ravel is (3, {total}), so it holds {} values",
+        3 * total
+    );
+    assert_f64_slice_eq(&format!("{what} x"), &written[..total], x);
+    assert_f64_slice_eq(&format!("{what} p"), &written[total..2 * total], p);
+    assert_f64_slice_eq(&format!("{what} c"), &written[2 * total..], c);
+}
+
+/// The running start of each sub-table.
+fn expect_offsets(lengths: &[usize]) -> Vec<i32> {
+    let mut out = Vec::with_capacity(lengths.len());
+    let mut at = 0i32;
+    for &n in lengths {
+        out.push(at);
+        at += n as i32;
+    }
+    out
+}
+
+/// The offsets, and the four properties the reader depends on.
+///
+/// `stride` is the first dimension of the ravel the offsets index into, and it
+/// is not always 3: `km_data` and `corr_eout_data` are `(5, total)`, so a
+/// closing check that divided by 3 would pass on a file with the wrong number
+/// of rows entirely.
+#[track_caller]
+fn assert_offsets(what: &str, written: &[i32], lengths: &[usize], data_len: usize, stride: usize) {
+    assert_i32_slice_eq(what, written, &expect_offsets(lengths));
+    assert_eq!(written.len(), lengths.len(), "{what}: one offset per table");
+    assert_eq!(written[0], 0, "{what}: the first table starts at zero");
+    assert!(
+        written.windows(2).all(|w| w[0] <= w[1]),
+        "{what}: the offsets are not non-decreasing: {written:?}"
+    );
+    // The reader takes the end of the LAST table as the total point count, so
+    // this is the only one of the four that catches an off-by-one at the end.
+    let last = *written.last().expect("at least one sub-table") as usize;
+    assert_eq!(
+        last + lengths.last().expect("at least one sub-table"),
+        data_len / stride,
+        "{what}: the last table does not end where the ({stride}, total) ravel does"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nullability.
+// ---------------------------------------------------------------------------
+
+/// The nullable scalar columns of `distributions.arrow`.
+///
+/// A row fills the ones its own variant uses and leaves the rest null, and the
+/// reader defaults each null to zero, so a null in the wrong place is a
+/// different physics rather than a missing value: a null `energy_threshold`
+/// opens a threshold reaction at every energy, and a null `nbody_n` is zero
+/// bodies.
+const SCALAR_COLUMNS: [&str; 10] = [
+    "energy_restriction_u",
+    "energy_threshold",
+    "energy_mass_ratio",
+    "energy_primary_flag",
+    "energy_atomic_weight_ratio",
+    "energy_discrete_energy",
+    "nbody_n",
+    "nbody_total_mass",
+    "nbody_atomic_weight_ratio",
+    "nbody_q_value",
+];
+
+/// The columns a Kalbach-Mann row fills, and every other row leaves null.
+const KM_COLUMNS: [&str; 7] = [
+    "km_energies",
+    "km_breakpoints",
+    "km_interpolation",
+    "km_data",
+    "km_offsets",
+    "km_interp",
+    "km_n_discrete",
+];
+
+/// The columns a correlated row fills, and every other row leaves null.
+const CORR_COLUMNS: [&str; 10] = [
+    "corr_energies",
+    "corr_breakpoints",
+    "corr_interpolation",
+    "corr_eout_data",
+    "corr_eout_offsets",
+    "corr_eout_interp",
+    "corr_eout_n_discrete",
+    "corr_mu_data",
+    "corr_mu_offsets",
+    "corr_mu_interp",
+];
+
+/// Every `list<int32>` column of `distributions.arrow`.
+const INT_LIST_COLUMNS: [&str; 21] = [
+    "applicability_shape",
+    "applicability_breakpoints",
+    "applicability_interpolation",
+    "angle_mu_offsets",
+    "angle_mu_interpolation",
+    "energy_dist_interpolation",
+    "energy_dist_offsets",
+    "energy_dist_out_interp",
+    "energy_dist_n_discrete",
+    "corr_breakpoints",
+    "corr_interpolation",
+    "corr_eout_offsets",
+    "corr_eout_interp",
+    "corr_eout_n_discrete",
+    "corr_mu_offsets",
+    "corr_mu_interp",
+    "km_breakpoints",
+    "km_interpolation",
+    "km_offsets",
+    "km_interp",
+    "km_n_discrete",
+];
+
+#[track_caller]
+fn assert_null(batch: &RecordBatch, columns: &[&str], row: usize, what: &str) {
+    for col in columns {
+        assert!(
+            is_null(batch, col, row),
+            "{what}: {col} should be null on row {row}"
+        );
+    }
+}
+
+#[track_caller]
+fn assert_not_null(batch: &RecordBatch, columns: &[&str], row: usize, what: &str) {
+    for col in columns {
+        assert!(
+            !is_null(batch, col, row),
+            "{what}: {col} should not be null on row {row}"
+        );
+    }
+}
+
+/// The scalar columns this row is allowed to fill, and no others.
+///
+/// Both directions matter and no single fixture exercises both on every
+/// column: on Li6 the four `nbody_*` columns are null on every row, so this
+/// sweeps them there only in the null direction. The law-66 row of the laws
+/// fixture is where they are filled.
+#[track_caller]
+fn assert_only_scalars(batch: &RecordBatch, row: usize, filled: &[&str], what: &str) {
+    for col in SCALAR_COLUMNS {
+        let expected_null = !filled.contains(&col);
+        assert_eq!(
+            is_null(batch, col, row),
+            expected_null,
+            "{what}: row {row} has {col} {}, which its variant does not agree with",
+            if expected_null { "filled" } else { "null" }
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The laws fixture, which no parser will take whole.
+// ---------------------------------------------------------------------------
+
+/// Walk the DLW linked list for one reaction.
+///
+/// LDLW is JXS(10) and gives one locator per reaction; DLW is JXS(11) and each
+/// distribution's own first word points at the next one for the same reaction.
+/// This reimplements the crate's own helper at
+/// `crates/endf/src/angle_energy.rs:276-285`, which lives inside a
+/// `#[cfg(test)]` module and so cannot be imported. If the DLW layout ever
+/// changes, this walk breaks in a way that looks like a converter defect and
+/// is not one, which is what that reference is here to say.
+fn dlw_chain(table: &endf::Table, i_reaction: usize) -> Vec<i64> {
+    let (ldlw, dlw) = (table.jxs[10], table.jxs[11]);
+    let mut chain = Vec::new();
+    let mut lnw = table.xss[ldlw as usize + i_reaction - 1] as i64;
+    while lnw > 0 {
+        chain.push(lnw);
+        lnw = table.xss[(dlw + lnw - 1) as usize] as i64;
+    }
+    chain
+}
+
+/// A Q value that cannot have come from anywhere but this call.
+///
+/// Law 66 is the only law that takes its Q from the caller rather than from the
+/// block, and the golden dumper passes 0.0, which would make a dropped field
+/// indistinguishable from a copied one.
+fn law_q(law: i64) -> f64 {
+    -1.0e6 * law as f64 - 0.5
+}
+
+/// The seven laws of `synthetic-laws.ace.xz`, each on a reaction of its own.
+///
+/// The table is a DLW block and nothing else: JXS(1) ESZ, JXS(3) MTR, JXS(6)
+/// LSIG and JXS(7) SIG are all zero, so `IncidentNeutron::from_ace` fails and
+/// no writer can be handed this fixture the ordinary way. Each law is decoded
+/// straight out of the vendored bytes by `endf::AngleEnergy::from_ace`; only
+/// the `Reaction` and `Product` around it are built here. MTs are `1000 + law`
+/// so a failure names the law, and they ascend in law order, which is the order
+/// the `BTreeMap` walk then writes them in.
+fn laws_nuclide() -> (endf::Table, IncidentNeutron, Vec<i64>) {
+    let table = ace_table(LAWS_ACE);
+    let dlw = table.jxs[11];
+    let mut data = IncidentNeutron::new(1, 1, 0);
+    let mut laws = Vec::new();
+    for i_reaction in 1..=(table.nxs[5] as usize) {
+        for lnw in dlw_chain(&table, i_reaction) {
+            // The law number sits one word past the locator, which is where
+            // `AngleEnergy::from_ace` reads it from too.
+            let law = table.xss[(dlw + lnw) as usize] as i64;
+            let dist = AngleEnergy::from_ace(&table, dlw, lnw, Some(law_q(law)))
+                .expect("every law in this table is one the reader knows");
+            let mt = 1000 + law as i32;
+            let mut reaction = endf::Reaction::new(mt);
+            reaction.products.push(Product {
+                name: "neutron".to_string(),
+                distribution: vec![dist],
+                ..Default::default()
+            });
+            data.reactions.insert(mt, reaction);
+            laws.push(law);
+        }
+    }
+    (table, data, laws)
+}
+
+/// The parsed distribution of the one product on MT `1000 + law`.
+fn law_dist(data: &IncidentNeutron, law: i64) -> &AngleEnergy {
+    &data.reactions[&(1000 + law as i32)].products[0].distribution[0]
+}
+
+// ---------------------------------------------------------------------------
+// Inputs built by hand, for the branches no vendored evaluation reaches.
+// ---------------------------------------------------------------------------
+
+/// A tabulated sub-table carrying the CDF an ACE table stores beside it.
+///
+/// The CDF is supplied rather than left `None` so the writer's own trapezoid
+/// integration stays out of the comparison, which is the same rule
+/// `stored_cdf` enforces on the parsed fixtures.
+fn tabular(x: Vec<f64>, p: Vec<f64>, interpolation: Interpolation, c: Vec<f64>) -> Univariate {
+    Univariate::Tabular(Tabular::with_cdf(x, p, interpolation, c))
+}
+
+/// A set of discrete lines carrying its own CDF, for the same reason.
+fn discrete_lines(x: Vec<f64>, p: Vec<f64>, c: Vec<f64>) -> Univariate {
+    Univariate::Discrete(Discrete { x, p, c: Some(c) })
+}
+
+/// One reaction holding one neutron product, and nothing else at all.
+fn one_product_nuclide(
+    mt: i32,
+    distribution: Vec<AngleEnergy>,
+    applicability: Vec<Tabulated1D>,
+) -> IncidentNeutron {
+    let mut data = IncidentNeutron::new(3, 6, 0);
+    let mut reaction = endf::Reaction::new(mt);
+    reaction.products.push(Product {
+        name: "neutron".to_string(),
+        distribution,
+        applicability,
+        ..Default::default()
+    });
+    data.reactions.insert(mt, reaction);
+    data
+}
+
+/// A product with TWO distributions, and a different applicability for each.
+///
+/// CONSTRUCTED INPUT. Nothing here was parsed from an evaluation and nothing
+/// here is evaluation parity: the only claim it can support is about how the
+/// writer indexes. It exists because every product of Li6, U235, Fe56 and the
+/// laws scaffold carries exactly one distribution, so `dist_idx` is 0 on every
+/// row those fixtures produce and so is the index into `product.applicability`.
+/// Replacing `dist_idx: dist_idx as i32` with `dist_idx: 0`, or
+/// `product.applicability.get(dist_idx)` with `.get(0)`, leaves every
+/// vendored-fixture assertion in this file green.
+///
+/// The two distributions differ in both of their scalars and the two
+/// applicability tabulations differ in y, deliberately: equal rows cannot
+/// discriminate an index that never advances.
+fn constructed_two_distribution_product() -> IncidentNeutron {
+    let level = |threshold: f64, mass_ratio: f64| {
+        AngleEnergy::Uncorrelated(UncorrelatedAngleEnergy {
+            angle: None,
+            energy: Some(EnergyDistribution::LevelInelastic {
+                threshold,
+                mass_ratio,
+            }),
+        })
+    };
+    one_product_nuclide(
+        16,
+        vec![level(1.5e6, 0.75), level(7.25e6, 0.25)],
+        vec![
+            Tabulated1D::new(vec![1.0e3, 2.0e7], vec![1.0, 0.0]),
+            Tabulated1D::new(vec![1.0e3, 2.0e7], vec![0.0, 1.0]),
+        ],
+    )
+}
+
+/// A correlated distribution whose two region columns disagree and whose
+/// outgoing tables hold different numbers of discrete lines.
+///
+/// CONSTRUCTED INPUT, and not evaluation parity: the values below are not from
+/// any evaluation. Law 61 of `synthetic-laws.ace.xz` is the only vendored
+/// correlated distribution in the tree, and on it `corr_breakpoints` and
+/// `corr_interpolation` are both `[1, 2]` while `corr_eout_n_discrete` is
+/// `[0, 0]`. Swapping the two writer assignments, or pushing a literal 0 for
+/// the line count, therefore produces a byte-identical file. Here the
+/// breakpoints are `[1, 3]` against interpolation `[2, 1]`, which differ at
+/// every position, and the three outgoing tables hold 0, 1 and 2 lines.
+fn constructed_correlated_regions() -> IncidentNeutron {
+    let isotropic = || Univariate::Uniform(Uniform::new(-1.0, 1.0));
+    let mu_table = || {
+        tabular(
+            vec![-1.0, 1.0],
+            vec![0.25, 0.75],
+            Interpolation::LinearLinear,
+            vec![0.0, 1.0],
+        )
+    };
+    let c = CorrelatedAngleEnergy {
+        breakpoints: vec![1, 3],
+        interpolation: vec![2, 1],
+        energy: vec![1.0e3, 1.0e6, 2.0e7],
+        energy_out: vec![
+            tabular(
+                vec![1.0e5, 5.0e5],
+                vec![1.5e-6, 5.0e-7],
+                Interpolation::LinearLinear,
+                vec![0.0, 1.0],
+            ),
+            Univariate::Mixture(Mixture::new(
+                vec![0.4, 0.6],
+                vec![
+                    discrete_lines(vec![2.0e5], vec![0.4], vec![0.4]),
+                    tabular(
+                        vec![3.0e5, 9.0e5],
+                        vec![1.0e-6, 5.0e-7],
+                        Interpolation::Histogram,
+                        vec![0.7, 1.0],
+                    ),
+                ],
+            )),
+            discrete_lines(vec![1.1e6, 1.3e6], vec![0.25, 0.75], vec![0.25, 1.0]),
+        ],
+        // One cosine table per outgoing POINT: two, then three, then two, so
+        // the writer's missing-mu fallback does not fire here either.
+        mu: vec![
+            vec![isotropic(), mu_table()],
+            vec![isotropic(), mu_table(), isotropic()],
+            vec![mu_table(), isotropic()],
+        ],
+    };
+    one_product_nuclide(22, vec![AngleEnergy::Correlated(c)], Vec::new())
+}
+
+/// A Kalbach-Mann distribution with discrete lines in one outgoing table.
+///
+/// CONSTRUCTED INPUT, and not evaluation parity. Li6 is the only vendored
+/// source of the variant and every outgoing table of both its Kalbach-Mann
+/// rows is a pure `Tabular`, so `km_n_discrete` is all zeros there and
+/// `n_discrete.push(0)` in `write_kalbach_mann` writes the same file. One
+/// mixture is enough to tell those apart. The precompound and slope
+/// tabulations are as long as their flattened tables, matching what
+/// `KalbachMann::from_ace` produces, so the writer's zero-padding branch stays
+/// out of this.
+fn constructed_kalbach_mann_with_lines() -> IncidentNeutron {
+    let k = KalbachMann {
+        breakpoints: vec![2],
+        interpolation: vec![1],
+        energy: vec![1.0e6, 1.4e7],
+        energy_out: vec![
+            tabular(
+                vec![1.0e5, 9.0e5],
+                vec![1.5e-6, 5.0e-7],
+                Interpolation::LinearLinear,
+                vec![0.0, 1.0],
+            ),
+            Univariate::Mixture(Mixture::new(
+                vec![0.3, 0.7],
+                vec![
+                    discrete_lines(vec![2.0e5, 4.0e5], vec![0.1, 0.2], vec![0.1, 0.3]),
+                    tabular(
+                        vec![5.0e5, 1.5e6],
+                        vec![1.0e-6, 4.0e-7],
+                        Interpolation::Histogram,
+                        vec![0.6, 1.0],
+                    ),
+                ],
+            )),
+        ],
+        precompound: vec![
+            Tabulated1D::new(vec![1.0e5, 9.0e5], vec![0.11, 0.12]),
+            Tabulated1D::new(
+                vec![2.0e5, 4.0e5, 5.0e5, 1.5e6],
+                vec![0.21, 0.22, 0.23, 0.24],
+            ),
+        ],
+        slope: vec![
+            Tabulated1D::new(vec![1.0e5, 9.0e5], vec![0.51, 0.52]),
+            Tabulated1D::new(
+                vec![2.0e5, 4.0e5, 5.0e5, 1.5e6],
+                vec![0.61, 0.62, 0.63, 0.64],
+            ),
+        ],
+    };
+    one_product_nuclide(28, vec![AngleEnergy::KalbachMann(k)], Vec::new())
+}
+
+/// A Watt spectrum whose two tabulated parameters sit on DIFFERENT grids.
+///
+/// CONSTRUCTED INPUT, and not evaluation parity. Law 11 of
+/// `synthetic-laws.ace.xz` is the only Watt spectrum any vendored bytes
+/// produce, and it gives `a` and `b` the same x, `[1.0, 2.0e7]`, so writing
+/// `a.x` into `energy_param2_x` (the copy-paste a four-assignment block
+/// invites) produces a byte-identical file. The two y vectors there differ by
+/// eleven orders of magnitude, so the pair as a whole is discriminated and
+/// only the two grids are not. These two differ in length as well as in value.
+fn constructed_watt_with_distinct_grids() -> IncidentNeutron {
+    let watt = AngleEnergy::Uncorrelated(UncorrelatedAngleEnergy {
+        angle: None,
+        energy: Some(EnergyDistribution::WattEnergy {
+            u: 1.25e6,
+            a: Tabulated1D::new(vec![1.0e3, 2.0e7], vec![9.0e5, 1.1e6]),
+            b: Tabulated1D::new(vec![2.0e3, 5.0e6, 1.9e7], vec![3.0e-6, 3.2e-6, 3.4e-6]),
+        }),
+    });
+    one_product_nuclide(18, vec![watt], Vec::new())
+}
+
+// ---------------------------------------------------------------------------
+// products.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means `products.arrow` and `distributions.arrow` stopped being
+/// written from one traversal, which is the contract `products.rs:4-8` states
+/// and nothing checks. The reader joins the two files on
+/// `(reaction_mt, product_idx, dist_idx)` and builds a `HashMap` keyed on it,
+/// so a duplicate triple silently drops a distribution and a gap in `dist_idx`
+/// leaves a product whose secondary energy is sampled from nothing.
+///
+/// Li6 pins two thirds of that key and cannot pin the third. All 18 of its
+/// products carry exactly one distribution, so `dist_idx` is 0 on every row it
+/// produces, and so it is on every row of every other vendored fixture in this
+/// file: writing a literal 0 satisfies all of them. The constructed
+/// two-distribution product at the end is the only thing here that says
+/// `dist_idx` counts, and its helper says why it is built rather than parsed.
+#[test]
+fn product_rows_are_the_reaction_walk_in_mt_order() {
+    let data = li6_ace();
+    let walk = product_walk(&data);
+    let tmp = scratch();
+    let products = products_of(&data, tmp.path());
+    let distributions = distributions_of(&data, tmp.path());
+    assert_schema_is_declared(&products, "products.arrow");
+
+    assert_eq!(
+        products.num_rows(),
+        walk.len(),
+        "one row per parsed product"
+    );
+
+    let written_mt = i32_column(&products, "reaction_mt");
+    let expected_mt: Vec<i32> = walk.iter().map(|&(mt, _, _)| mt).collect();
+    assert_i32_slice_eq("products.arrow reaction_mt", &written_mt, &expected_mt);
+    // The literal too, so the traversal itself is pinned rather than merely
+    // restated: a walk that dropped MT 55's third and fourth photons would
+    // agree with the expression above and not with this.
+    assert_i32_slice_eq(
+        "products.arrow reaction_mt against the Li6 product set",
+        &written_mt,
+        &[
+            2, 5, 5, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 55, 55, 91, 91, 102,
+        ],
+    );
+
+    let written_idx = i32_column(&products, "product_idx");
+    let expected_idx: Vec<i32> = walk.iter().map(|&(_, idx, _)| idx as i32).collect();
+    assert_i32_slice_eq("products.arrow product_idx", &written_idx, &expected_idx);
+    assert_i32_slice_eq(
+        "products.arrow product_idx against the Li6 product set",
+        &written_idx,
+        &[0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 0, 1, 0],
+    );
+
+    let written_n = i32_column(&products, "n_distribution");
+    let expected_n: Vec<i32> = walk
+        .iter()
+        .map(|&(_, _, p)| p.distribution.len() as i32)
+        .collect();
+    assert_i32_slice_eq("products.arrow n_distribution", &written_n, &expected_n);
+
+    // The join invariant: exactly the triples n_distribution promises, once
+    // each, and nothing else.
+    let mut expected_triples = Vec::new();
+    for (row, &(mt, idx, _)) in walk.iter().enumerate() {
+        for d in 0..written_n[row] {
+            expected_triples.push((mt, idx as i32, d));
+        }
+    }
+    // `expected_triples` holds no duplicate, because `(mt, idx)` is unique per
+    // product and `d` ascends within it, so the equality is also the check
+    // that no triple appears twice.
+    let written_triples = triples(&distributions);
+    assert_eq!(
+        written_triples, expected_triples,
+        "the distribution rows are not products.arrow expanded by n_distribution"
+    );
+
+    // The dist_idx third of the key, on a CONSTRUCTED input: see
+    // `constructed_two_distribution_product`. Everything above passes with the
+    // column hard-coded to zero, because no vendored product has a second
+    // distribution.
+    let two = constructed_two_distribution_product();
+    let two_tmp = scratch();
+    let two_products = products_of(&two, two_tmp.path());
+    let two_distributions = distributions_of(&two, two_tmp.path());
+    assert_i32_slice_eq(
+        "the constructed product's n_distribution",
+        &i32_column(&two_products, "n_distribution"),
+        &[2],
+    );
+    assert_eq!(
+        triples(&two_distributions),
+        vec![(16, 0, 0), (16, 0, 1)],
+        "n_distribution promises two rows, numbered by dist_idx and not both zero"
+    );
+}
+
+/// A failure means a product's particle type, emission mode or decay constant
+/// is no longer the one the evaluation gave. `decay_rate` is the one that
+/// cannot be told from a default on an ACE fixture, which is why the fissile
+/// ENDF evaluation is here: its six delayed groups carry real decay constants
+/// from MF=1 MT=455, and a writer that dropped the field would still pass on
+/// Li6, where every value is 0.0.
+#[test]
+fn product_identity_columns_are_the_parsed_products_own_fields() {
+    let data = li6_ace();
+    let walk = product_walk(&data);
+    let tmp = scratch();
+    let products = products_of(&data, tmp.path());
+
+    let mut names: BTreeMap<&str, usize> = BTreeMap::new();
+    for (row, &(mt, idx, product)) in walk.iter().enumerate() {
+        let what = format!("Li6 MT {mt} product {idx}");
+        assert_eq!(
+            str_at(&products, "particle", row),
+            product.name,
+            "{what}: particle"
+        );
+        assert_eq!(
+            str_at(&products, "emission_mode", row),
+            product.emission_mode.name(),
+            "{what}: emission_mode"
+        );
+        // The literal beside the call, so a rename on either side is visible
+        // rather than agreeing with itself.
+        assert_eq!(
+            str_at(&products, "emission_mode", row),
+            "prompt",
+            "{what}: every Li6 product is prompt"
+        );
+        assert_eq!(
+            f64_at(&products, "decay_rate", row),
+            product.decay_rate,
+            "{what}: decay_rate"
+        );
+        assert_eq!(f64_at(&products, "decay_rate", row), 0.0, "{what}: prompt");
+        *names.entry(product.name.as_str()).or_insert(0) += 1;
+    }
+    assert_eq!(
+        names,
+        BTreeMap::from([("neutron", 8), ("photon", 10)]),
+        "Li6 gives 8 neutron products from the DLW and elastic chains and 10 photons from MTRP"
+    );
+
+    // The delayed groups, which no ACE fixture in the tree carries.
+    let u235 = endf_nuclide(U235_ENDF);
+    let u_walk = product_walk(&u235);
+    let u_tmp = scratch();
+    let u_products = products_of(&u235, u_tmp.path());
+    assert_eq!(
+        u_products.num_rows(),
+        7,
+        "one prompt and six delayed groups"
+    );
+
+    let mut delayed = 0;
+    for (row, &(mt, idx, product)) in u_walk.iter().enumerate() {
+        let what = format!("U235 MT {mt} product {idx}");
+        assert_eq!(str_at(&u_products, "particle", row), product.name, "{what}");
+        assert_eq!(
+            str_at(&u_products, "emission_mode", row),
+            product.emission_mode.name(),
+            "{what}: emission_mode"
+        );
+        assert_eq!(
+            f64_at(&u_products, "decay_rate", row),
+            product.decay_rate,
+            "{what}: decay_rate"
+        );
+        if product.emission_mode == endf::EmissionMode::Delayed {
+            delayed += 1;
+            assert!(
+                f64_at(&u_products, "decay_rate", row) > 0.0,
+                "{what}: a delayed group's decay constant cannot be the prompt default"
+            );
+        }
+    }
+    assert_eq!(delayed, 6, "MF=1 MT=455 gives six precursor groups");
+    assert_eq!(
+        str_column(&u_products, "emission_mode"),
+        vec!["prompt", "delayed", "delayed", "delayed", "delayed", "delayed", "delayed"],
+        "the literal names endf::EmissionMode::name produces"
+    );
+
+    // The one-row photon case.
+    let fe56 = endf_nuclide(FE56_ENDF);
+    let fe_tmp = scratch();
+    let fe_products = products_of(&fe56, fe_tmp.path());
+    assert_eq!(fe_products.num_rows(), 1);
+    assert_eq!(
+        str_at(&fe_products, "particle", 0),
+        product_walk(&fe56)[0].2.name
+    );
+    assert_eq!(str_at(&fe_products, "particle", 0), "photon");
+}
+
+/// A failure means a multiplicity was reshaped on the way out. `yield_shape` is
+/// the column `products.rs:48-53` warns about: the reader splits on `shape[1]`,
+/// so a transposed `[n, 2]` loads without error and turns Li6's 32-point MT 5
+/// yield into a 2-point one. `yield_breakpoints` and `yield_interpolation` are
+/// adjacent `list<int32>` columns filled from adjacent lines and the yamc
+/// loader never reads either, so nothing but a direct comparison can catch a
+/// swap.
+#[test]
+fn product_yield_columns_round_trip_both_yield_forms() {
+    let mut polynomial = 0;
+    let mut tabulated = 0;
+
+    for (label, data) in [
+        ("Li6", li6_ace()),
+        ("U235", endf_nuclide(U235_ENDF)),
+        ("Fe56", endf_nuclide(FE56_ENDF)),
+    ] {
+        let walk = product_walk(&data);
+        let tmp = scratch();
+        let products = products_of(&data, tmp.path());
+
+        for (row, &(mt, idx, product)) in walk.iter().enumerate() {
+            let what = format!("{label} MT {mt} product {idx}");
+            let written = f64_list(&products, "yield_data", row);
+            let shape = i32_list(&products, "yield_shape", row);
+            let breakpoints = i32_list(&products, "yield_breakpoints", row);
+            let interpolation = i32_list(&products, "yield_interpolation", row);
+
+            match &product.yield_ {
+                Yield::Polynomial(p) => {
+                    polynomial += 1;
+                    assert_eq!(str_at(&products, "yield_type", row), "Polynomial", "{what}");
+                    assert_f64_slice_eq(&format!("{what} yield_data"), &written, &p.coefficients);
+                    assert_eq!(shape.len(), 1, "{what}: a polynomial's shape is [n]");
+                    assert_eq!(shape[0] as usize, written.len(), "{what}: shape[0]");
+                    // Empty and not null: products.arrow uses sections::int_lists
+                    // where every list column in distributions.arrow uses the
+                    // or_null variant, and the reader cannot tell the two apart.
+                    assert_not_null(
+                        &products,
+                        &["yield_breakpoints", "yield_interpolation"],
+                        row,
+                        &what,
+                    );
+                    assert!(breakpoints.is_empty(), "{what}: yield_breakpoints");
+                    assert!(interpolation.is_empty(), "{what}: yield_interpolation");
+                }
+                Yield::Tabulated(t) => {
+                    tabulated += 1;
+                    let n = t.x.len();
+                    assert_eq!(
+                        str_at(&products, "yield_type", row),
+                        "Tabulated1D",
+                        "{what}"
+                    );
+                    assert_eq!(written.len(), 2 * n, "{what}: x and y end to end");
+                    // Bit-exact: no arithmetic happens here, the eV conversion
+                    // was done in the parser at function.rs:198-202.
+                    assert_f64_slice_eq(&format!("{what} yield x"), &written[..n], &t.x);
+                    assert_f64_slice_eq(&format!("{what} yield y"), &written[n..], &t.y);
+                    // `[2, n]` and not `[n, 2]`. The reader splits the data
+                    // column at `shape[1]`, so the transposed shape loads and
+                    // turns Li6's 32-point MT 5 yield into a 2-point one; this
+                    // one comparison is the whole defence, and n is 32 there,
+                    // so the two shapes are distinguishable.
+                    assert_i32_slice_eq(&format!("{what} yield_shape"), &shape, &[2, n as i32]);
+                    assert_i32_slice_eq(
+                        &format!("{what} yield_breakpoints"),
+                        &breakpoints,
+                        &t.breakpoints,
+                    );
+                    assert_i32_slice_eq(
+                        &format!("{what} yield_interpolation"),
+                        &interpolation,
+                        &t.interpolation,
+                    );
+                    assert!(
+                        !breakpoints.is_empty(),
+                        "{what}: Tabulated1D::from_ace falls back to vec![n_pairs], so a \
+                         tabulated yield always has a region"
+                    );
+                    assert_eq!(
+                        breakpoints.len(),
+                        interpolation.len(),
+                        "{what}: one interpolation code per region"
+                    );
+                }
+            }
+        }
+    }
+
+    // Neither form is covered by accident: Li6 alone gives 7 polynomial and 11
+    // tabulated yields, and the two ENDF fixtures add 8 more tabulated.
+    assert_eq!(polynomial, 7, "the polynomial branch was exercised");
+    assert_eq!(tabulated, 19, "the tabulated branch was exercised");
+}
+
+// ---------------------------------------------------------------------------
+// distributions.arrow
+// ---------------------------------------------------------------------------
+
+/// A failure means the distribution table no longer lines up with the product
+/// table. The zero-row case matters as much as the populated one: Fe56's single
+/// photon product has an empty distribution vector, and "a distributions.arrow
+/// with no rows" and "no distributions.arrow" are different answers to the
+/// loader.
+///
+/// What the Li6 half of this cannot say, stated so nobody reads more into it.
+/// The expectation is rebuilt by reading `products.arrow` rather than the
+/// parsed evaluation, so a defect that dropped the same product from BOTH
+/// writers agrees with itself here; only
+/// `product_rows_are_the_reaction_walk_in_mt_order`, which walks the parsed
+/// side, catches that. And every Li6 product holds one distribution, so the
+/// no-gap sweep over `dist_idx` is satisfied by a column of zeros. The
+/// CONSTRUCTED two-distribution product at the end is what makes `dist_idx`
+/// mean something, and it is the only part of this test that checks a row
+/// against the distribution it claims to be.
+#[test]
+fn distribution_rows_join_products_one_for_one() {
+    let data = li6_ace();
+    let tmp = scratch();
+    let products = products_of(&data, tmp.path());
+    let distributions = distributions_of(&data, tmp.path());
+    assert_schema_is_declared(&distributions, "distributions.arrow");
+    assert_eq!(distributions.num_rows(), 18, "Li6 has 18 distributions");
+
+    let written = triples(&distributions);
+    let mut expected = Vec::new();
+    for row in 0..products.num_rows() {
+        let mt = i32_at(&products, "reaction_mt", row);
+        let idx = i32_at(&products, "product_idx", row);
+        for d in 0..i32_at(&products, "n_distribution", row) {
+            expected.push((mt, idx, d));
+        }
+    }
+    assert_eq!(
+        written, expected,
+        "the two files must be in the same row order, not merely hold the same keys"
+    );
+
+    // Per product the dist_idx values ascend from zero with no gaps: the reader
+    // loops `for di in 0..n_dist` and skips a missing one silently.
+    let mut seen: BTreeMap<(i32, i32), Vec<i32>> = BTreeMap::new();
+    for &(mt, idx, dist) in &written {
+        seen.entry((mt, idx)).or_default().push(dist);
+    }
+    for ((mt, idx), dists) in &seen {
+        let expected: Vec<i32> = (0..dists.len() as i32).collect();
+        assert_eq!(dists, &expected, "MT {mt} product {idx}: dist_idx");
+    }
+    let unique: BTreeSet<_> = written.iter().collect();
+    assert_eq!(unique.len(), written.len(), "no triple appears twice");
+
+    // Row d against distribution d, on a CONSTRUCTED input: see
+    // `constructed_two_distribution_product`. `write_distributions` picks the
+    // applicability with `product.applicability.get(dist_idx)`, and with one
+    // distribution per product `.get(0)` is the same call.
+    let two = constructed_two_distribution_product();
+    let two_tmp = scratch();
+    let two_batch = distributions_of(&two, two_tmp.path());
+    assert_eq!(two_batch.num_rows(), 2);
+    let product = &two.reactions[&16].products[0];
+    for (row, dist) in product.distribution.iter().enumerate() {
+        let what = format!("the constructed product's distribution {row}");
+        let AngleEnergy::Uncorrelated(u) = dist else {
+            panic!("{what}: built as uncorrelated");
+        };
+        let Some(EnergyDistribution::LevelInelastic {
+            threshold,
+            mass_ratio,
+        }) = &u.energy
+        else {
+            panic!("{what}: built as a level law");
+        };
+        assert_eq!(i32_at(&two_batch, "dist_idx", row), row as i32, "{what}");
+        assert_eq!(
+            f64_at(&two_batch, "energy_threshold", row),
+            *threshold,
+            "{what}: the row holds the OTHER distribution's threshold"
+        );
+        assert_eq!(
+            f64_at(&two_batch, "energy_mass_ratio", row),
+            *mass_ratio,
+            "{what}: energy_mass_ratio"
+        );
+
+        let app = &product.applicability[row];
+        let n = app.x.len();
+        let written = f64_list(&two_batch, "applicability_data", row);
+        assert_eq!(written.len(), 2 * n, "{what}: applicability x and y");
+        assert_f64_slice_eq(&format!("{what} applicability x"), &written[..n], &app.x);
+        assert_f64_slice_eq(&format!("{what} applicability y"), &written[n..], &app.y);
+    }
+    // And the two rows do differ, which is what makes the pairing above
+    // checkable rather than a comparison of two copies of one thing.
+    assert_ne!(
+        f64_list(&two_batch, "applicability_data", 0),
+        f64_list(&two_batch, "applicability_data", 1),
+        "the constructed applicabilities are built distinct on purpose"
+    );
+
+    // Written, and empty. Fe56's one photon product carries no distribution.
+    let fe56 = endf_nuclide(FE56_ENDF);
+    let fe_tmp = scratch();
+    let fe_distributions = distributions_of(&fe56, fe_tmp.path());
+    assert!(
+        !absent(fe_tmp.path(), "distributions.arrow"),
+        "an absent file and an empty one are different answers to the loader"
+    );
+    assert_eq!(fe_distributions.num_rows(), 0);
+    let fe_products = products_of(&fe56, fe_tmp.path());
+    assert_eq!(i32_at(&fe_products, "n_distribution", 0), 0);
+}
+
+/// A failure means the angular tables or the scalar energy-law parameters were
+/// reshaped, interleaved or dropped. The interleaved `(x, p, c)` layout is the
+/// failure `distributions.rs:24-26` names: it loads, and then samples densities
+/// out of the cosine column. The null-versus-empty distinction is part of the
+/// format here and invisible at load, because the reader's `try_get_f64_list`
+/// maps both to an empty `Vec`.
+///
+/// Two of these columns are pinned on Li6 and not discriminated by it.
+/// `energy_primary_flag` is 0 on all seven of its discrete-photon rows, so the
+/// comparison below cannot tell the column from a literal 0; the one vendored
+/// row that carries 1 is the law-2 row of `synthetic-laws.ace.xz`, asserted in
+/// `the_laws_only_an_assembled_table_can_reach_are_written_from_the_parsed_blocks`.
+/// And the four `nbody_*` columns are null on every Li6 row, so
+/// `assert_only_scalars` sweeps them here in the null direction only.
+#[test]
+fn an_uncorrelated_distribution_is_the_parsed_angle_and_energy_tables() {
+    let table = ace_table(LI6_ACE);
+    let data = li6_ace();
+    let walk = distribution_walk(&data);
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+
+    let mut types: BTreeMap<String, usize> = BTreeMap::new();
+    let mut energy_types: BTreeMap<String, usize> = BTreeMap::new();
+    let mut applicable = 0;
+    let mut angle_interp_seen: BTreeSet<i32> = BTreeSet::new();
+    let mut angle_grids: Vec<usize> = Vec::new();
+
+    for (row, &(mt, product_idx, dist_idx, dist, applicability)) in walk.iter().enumerate() {
+        let what = format!("Li6 MT {mt} product {product_idx} distribution {dist_idx}");
+
+        let ty = str_at(&batch, "type", row);
+        let expected_ty = match dist {
+            AngleEnergy::Uncorrelated(_) => "uncorrelated",
+            AngleEnergy::Correlated(_) => "correlated",
+            AngleEnergy::KalbachMann(_) => "kalbach-mann",
+            AngleEnergy::NBodyPhaseSpace(_) => "nbody",
+        };
+        assert_eq!(ty, expected_ty, "{what}: type");
+        *types.entry(ty).or_insert(0) += 1;
+
+        // Nothing in Li6 is correlated or N-body, and no row may pretend to
+        // be: the N-body columns are swept by assert_only_scalars below.
+        assert_null(&batch, &CORR_COLUMNS, row, &what);
+
+        let applicability_columns = [
+            "applicability_data",
+            "applicability_shape",
+            "applicability_breakpoints",
+            "applicability_interpolation",
+        ];
+        match applicability {
+            Some(app) => {
+                applicable += 1;
+                assert_not_null(&batch, &applicability_columns, row, &what);
+                let n = app.x.len();
+                let written = f64_list(&batch, "applicability_data", row);
+                assert_eq!(written.len(), 2 * n, "{what}: applicability x and y");
+                assert_f64_slice_eq(&format!("{what} applicability x"), &written[..n], &app.x);
+                assert_f64_slice_eq(&format!("{what} applicability y"), &written[n..], &app.y);
+                assert_i32_slice_eq(
+                    &format!("{what} applicability_shape"),
+                    &i32_list(&batch, "applicability_shape", row),
+                    &[2, n as i32],
+                );
+                let breakpoints = i32_list(&batch, "applicability_breakpoints", row);
+                let interpolation = i32_list(&batch, "applicability_interpolation", row);
+                assert_i32_slice_eq(
+                    &format!("{what} applicability_breakpoints"),
+                    &breakpoints,
+                    &app.breakpoints,
+                );
+                assert_i32_slice_eq(
+                    &format!("{what} applicability_interpolation"),
+                    &interpolation,
+                    &app.interpolation,
+                );
+                assert!(!breakpoints.is_empty(), "{what}: at least one region");
+                assert_eq!(
+                    breakpoints.len(),
+                    interpolation.len(),
+                    "{what}: one per region"
+                );
+            }
+            // Null, not an empty list. `float_lists_or_null` writes null and the
+            // published files hold null; an empty list loads identically and is
+            // not the same file.
+            None => assert_null(&batch, &applicability_columns, row, &what),
+        }
+
+        let angle_columns = [
+            "angle_energies",
+            "angle_mu_data",
+            "angle_mu_offsets",
+            "angle_mu_interpolation",
+        ];
+        let angle = match dist {
+            AngleEnergy::Uncorrelated(u) => u.angle.as_ref().filter(|a| !a.energy.is_empty()),
+            _ => None,
+        };
+        match angle {
+            Some(angle) => {
+                assert_not_null(&batch, &angle_columns, row, &what);
+                assert_f64_slice_eq(
+                    &format!("{what} angle_energies"),
+                    &f64_list(&batch, "angle_energies", row),
+                    &angle.energy,
+                );
+                // write_angle takes the energies from angle.energy and the
+                // tables from angle.mu and never checks the two agree, while
+                // the reader indexes the offsets by the energy index.
+                assert_eq!(
+                    list_len(&batch, "angle_energies", row),
+                    angle.mu.len(),
+                    "{what}: one cosine table per incident energy"
+                );
+
+                let (mut x, mut p, mut c, mut lengths, mut interp) =
+                    (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new());
+                for mu in &angle.mu {
+                    let (mx, mp, mc, mi) = expect_mu(mu);
+                    lengths.push(mx.len());
+                    x.extend(mx);
+                    p.extend(mp);
+                    c.extend(mc);
+                    interp.push(mi);
+                }
+                let data_col = f64_list(&batch, "angle_mu_data", row);
+                assert_ravel3(&format!("{what} angle_mu_data"), &data_col, &x, &p, &c);
+                assert_offsets(
+                    &format!("{what} angle_mu_offsets"),
+                    &i32_list(&batch, "angle_mu_offsets", row),
+                    &lengths,
+                    data_col.len(),
+                    3,
+                );
+                // Li6's cosine tables parse as LinearLinear, so a neutron row is
+                // all 2s; the photon rows are Isotropic, which the converter
+                // writes as 1 by convention (univariate_flat.rs:102-113) because
+                // endf's Uniform carries no interpolation to copy.
+                assert_i32_slice_eq(
+                    &format!("{what} angle_mu_interpolation"),
+                    &i32_list(&batch, "angle_mu_interpolation", row),
+                    &interp,
+                );
+                angle_interp_seen.extend(interp);
+                angle_grids.push(angle.energy.len());
+            }
+            None => assert_null(&batch, &angle_columns, row, &what),
+        }
+
+        let energy = match dist {
+            AngleEnergy::Uncorrelated(u) => u.energy.as_ref(),
+            _ => None,
+        };
+        match energy {
+            None => assert!(
+                is_null(&batch, "energy_dist_type", row),
+                "{what}: energy_dist_type must be null where there is no energy distribution"
+            ),
+            Some(energy) => {
+                let written = str_at(&batch, "energy_dist_type", row);
+                let expected = match energy {
+                    EnergyDistribution::ContinuousTabular { .. } => "continuous",
+                    EnergyDistribution::LevelInelastic { .. } => "level",
+                    EnergyDistribution::DiscretePhoton { .. } => "discrete_photon",
+                    other => panic!("{what}: Li6 does not hold {other:?}"),
+                };
+                assert_eq!(written, expected, "{what}: energy_dist_type");
+                *energy_types.entry(written).or_insert(0) += 1;
+            }
+        }
+
+        match energy {
+            Some(EnergyDistribution::LevelInelastic {
+                threshold,
+                mass_ratio,
+            }) => {
+                assert_only_scalars(
+                    &batch,
+                    row,
+                    &["energy_threshold", "energy_mass_ratio"],
+                    &what,
+                );
+                assert_eq!(
+                    f64_at(&batch, "energy_threshold", row),
+                    *threshold,
+                    "{what}: energy_threshold"
+                );
+                assert_eq!(
+                    f64_at(&batch, "energy_mass_ratio", row),
+                    *mass_ratio,
+                    "{what}: energy_mass_ratio"
+                );
+                // Two adjacent Float64 columns filled from two adjacent lines.
+                // A transposition is unmistakable only because the two differ
+                // by six orders of magnitude on this fixture.
+                assert!(
+                    f64_at(&batch, "energy_threshold", row) > 1.0e5,
+                    "{what}: the laboratory threshold is an energy in eV"
+                );
+                assert!(
+                    f64_at(&batch, "energy_mass_ratio", row) < 1.0,
+                    "{what}: (A / (A + 1))^2 is below one"
+                );
+            }
+            Some(EnergyDistribution::DiscretePhoton {
+                primary_flag,
+                energy,
+                atomic_weight_ratio,
+            }) => {
+                assert_only_scalars(
+                    &batch,
+                    row,
+                    &[
+                        "energy_primary_flag",
+                        "energy_atomic_weight_ratio",
+                        "energy_discrete_energy",
+                    ],
+                    &what,
+                );
+                assert_eq!(
+                    i32_at(&batch, "energy_primary_flag", row),
+                    *primary_flag as i32,
+                    "{what}: energy_primary_flag decides whether the energy is the photon's \
+                     or a binding energy"
+                );
+                assert_eq!(
+                    f64_at(&batch, "energy_discrete_energy", row),
+                    *energy,
+                    "{what}: energy_discrete_energy in eV"
+                );
+                assert_eq!(
+                    f64_at(&batch, "energy_atomic_weight_ratio", row),
+                    *atomic_weight_ratio,
+                    "{what}: energy_atomic_weight_ratio"
+                );
+                // The parser takes it from the ACE header, not from the block.
+                assert_eq!(
+                    f64_at(&batch, "energy_atomic_weight_ratio", row),
+                    table.atomic_weight_ratio,
+                    "{what}: and the header is where it came from"
+                );
+                assert_eq!(
+                    f64_at(&batch, "energy_atomic_weight_ratio", row),
+                    5.96345,
+                    "{what}: Li6's atomic weight ratio"
+                );
+            }
+            // The continuous rows fill no scalar column at all, and neither
+            // does the elastic row with no energy distribution or either
+            // Kalbach-Mann row.
+            _ => assert_only_scalars(&batch, row, &[], &what),
+        }
+    }
+
+    assert_eq!(
+        types,
+        BTreeMap::from([
+            ("kalbach-mann".to_string(), 2),
+            ("uncorrelated".to_string(), 16)
+        ]),
+        "Li6 gives 16 uncorrelated distributions and 2 Kalbach-Mann"
+    );
+    assert_eq!(
+        energy_types,
+        BTreeMap::from([
+            ("continuous".to_string(), 3),
+            ("discrete_photon".to_string(), 7),
+            ("level".to_string(), 5),
+        ]),
+        "ACE laws 4, 2 and 3/33, with the elastic row leaving energy_dist_type null"
+    );
+    assert_eq!(
+        applicable, 7,
+        "one applicability per DLW chain entry, and NXS(5) is 7"
+    );
+    // The literal grid sizes, so a fixture that quietly lost its angular
+    // detail could not leave the comparisons above passing on nothing: the
+    // elastic row is 51 energies, the MT 51 to 55 neutrons run 28, 24, 21, 19
+    // and 18, and every photon is the two-point isotropic pair.
+    assert_eq!(
+        angle_grids,
+        vec![51, 2, 28, 2, 24, 2, 21, 2, 19, 2, 18, 2, 2, 2, 2, 2],
+        "the angular grids Li6 holds, in row order, with the two Kalbach-Mann rows absent"
+    );
+    assert_eq!(
+        angle_interp_seen,
+        BTreeSet::from([1, 2]),
+        "both interpolation codes appear, so the column is not a constant that happens to fit"
+    );
+}
+
+/// Every column of one continuous-tabular row, against the law it came from.
+///
+/// Returns the interpolation codes and discrete-line counts it derived, so a
+/// caller can pin the ones a literal makes sharper.
+#[track_caller]
+fn check_continuous_row(
+    batch: &RecordBatch,
+    row: usize,
+    what: &str,
+    breakpoints: &[i32],
+    interpolation: &[i32],
+    energy: &[f64],
+    energy_out: &[Univariate],
+) -> (Vec<i32>, Vec<i32>) {
+    assert_not_null(batch, &CONTINUOUS_COLUMNS, row, what);
+
+    // Already eV: ace_incident_grid converted them at mf5.rs:315-318.
+    assert_f64_slice_eq(
+        &format!("{what} energy_dist_energies"),
+        &f64_list(batch, "energy_dist_energies", row),
+        energy,
+    );
+    assert_eq!(
+        energy.len(),
+        energy_out.len(),
+        "{what}: one outgoing table per incident energy"
+    );
+
+    // The two ENDF fields share one column, breakpoints first. The reader
+    // splits at len / 2, so both halves have to be there and in that order.
+    let concatenated: Vec<i32> = breakpoints.iter().chain(interpolation).copied().collect();
+    let written_interp = i32_list(batch, "energy_dist_interpolation", row);
+    assert_i32_slice_eq(
+        &format!("{what} energy_dist_interpolation"),
+        &written_interp,
+        &concatenated,
+    );
+    assert_eq!(written_interp.len() % 2, 0, "{what}: an even length");
+    assert_eq!(
+        breakpoints.len(),
+        interpolation.len(),
+        "{what}: one interpolation code per region"
+    );
+    let half = written_interp.len() / 2;
+    assert_i32_slice_eq(
+        &format!("{what} the interpolation half the reader takes"),
+        &written_interp[half..],
+        interpolation,
+    );
+
+    let (mut x, mut p, mut c, mut lengths, mut interp, mut n_discrete) = (
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut leading_discrete: Vec<Vec<f64>> = Vec::new();
+    for out in energy_out {
+        let (ox, op, oc, oi, on) = expect_flat(out);
+        lengths.push(ox.len());
+        leading_discrete.push(ox[..on as usize].to_vec());
+        x.extend(ox);
+        p.extend(op);
+        c.extend(oc);
+        interp.push(oi);
+        n_discrete.push(on);
+    }
+
+    let data_col = f64_list(batch, "energy_dist_data", row);
+    assert_ravel3(&format!("{what} energy_dist_data"), &data_col, &x, &p, &c);
+    let offsets = i32_list(batch, "energy_dist_offsets", row);
+    assert_offsets(
+        &format!("{what} energy_dist_offsets"),
+        &offsets,
+        &lengths,
+        data_col.len(),
+        3,
+    );
+    // A Discrete gives 1 always, hard-coded at univariate_flat.rs:98 whatever
+    // the ACE INTT said, which is a convention with no counterpart in
+    // endf::univariate::Discrete; a Mixture takes the code of its first
+    // continuous part.
+    let written_out_interp = i32_list(batch, "energy_dist_out_interp", row);
+    assert_i32_slice_eq(
+        &format!("{what} energy_dist_out_interp"),
+        &written_out_interp,
+        &interp,
+    );
+    let written_discrete = i32_list(batch, "energy_dist_n_discrete", row);
+    assert_i32_slice_eq(
+        &format!("{what} energy_dist_n_discrete"),
+        &written_discrete,
+        &n_discrete,
+    );
+
+    for (i, &n) in written_discrete.iter().enumerate() {
+        assert!(
+            (n as usize) <= lengths[i],
+            "{what}: sub-table {i} labels {n} of its {} points as discrete lines",
+            lengths[i]
+        );
+        // The part a load cannot see: the leading n_discrete points of the
+        // written table must be the parsed Discrete component's own energies,
+        // which is what makes "discrete lines come first" true rather than
+        // merely counted.
+        let start = offsets[i] as usize;
+        assert_f64_slice_eq(
+            &format!("{what} sub-table {i} discrete lines"),
+            &data_col[start..start + n as usize],
+            &leading_discrete[i],
+        );
+    }
+
+    (written_out_interp, written_discrete)
+}
+
+/// The columns a continuous-tabular row fills, and every other row leaves null.
+const CONTINUOUS_COLUMNS: [&str; 6] = [
+    "energy_dist_energies",
+    "energy_dist_interpolation",
+    "energy_dist_data",
+    "energy_dist_offsets",
+    "energy_dist_out_interp",
+    "energy_dist_n_discrete",
+];
+
+/// The parsed pieces of a continuous-tabular law, where the row holds one.
+type Continuous<'a> = (&'a [i32], &'a [i32], &'a [f64], &'a [Univariate]);
+
+fn as_continuous(dist: &AngleEnergy) -> Option<Continuous<'_>> {
+    match dist {
+        AngleEnergy::Uncorrelated(u) => match &u.energy {
+            Some(EnergyDistribution::ContinuousTabular {
+                breakpoints,
+                interpolation,
+                energy,
+                energy_out,
+            }) => Some((breakpoints, interpolation, energy, energy_out)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A failure means an outgoing-energy table was raveled wrongly, its region
+/// boundaries were written in the wrong half of the concatenated interpolation
+/// column, or its discrete-line count no longer matches the points it labels.
+/// Writing the interpolation before the breakpoints loads fine and inverts the
+/// histogram decision at `nuclide_arrow.rs:1288-1290`, which issue #499 already
+/// cost once, and a wrong `n_discrete` loads cleanly and samples a plausible
+/// spectrum with the wrong shape, which is what `univariate_flat.rs:8-20` says.
+///
+/// Li6 is the fixture for the values and the synthetic law 4 is the fixture for
+/// the two interpolation and discrete-line codes: every one of Li6's 67
+/// outgoing tables is histogram-interpolated, so its `energy_dist_out_interp`
+/// is a column of 1s that a writer could hard-code and still pass. The
+/// synthetic row's scaffold is built by hand, as
+/// `the_laws_only_an_assembled_table_can_reach_are_written_from_the_parsed_blocks`
+/// explains, but the three outgoing tables in it are parsed out of the
+/// vendored bytes.
+#[test]
+fn a_continuous_tabular_energy_distribution_keeps_its_discrete_lines_first() {
+    let data = li6_ace();
+    let walk = distribution_walk(&data);
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+
+    let mut incident_grids: Vec<usize> = Vec::new();
+    let mut discrete_lines = 0;
+    for (row, &(mt, product_idx, dist_idx, dist, _)) in walk.iter().enumerate() {
+        let what = format!("Li6 MT {mt} product {product_idx} distribution {dist_idx}");
+        let Some((breakpoints, interpolation, energy, energy_out)) = as_continuous(dist) else {
+            assert_null(&batch, &CONTINUOUS_COLUMNS, row, &what);
+            continue;
+        };
+        incident_grids.push(energy.len());
+        let (_, n_discrete) = check_continuous_row(
+            &batch,
+            row,
+            &what,
+            breakpoints,
+            interpolation,
+            energy,
+            energy_out,
+        );
+        discrete_lines += n_discrete.iter().sum::<i32>() as usize;
+    }
+
+    assert_eq!(
+        incident_grids,
+        vec![16, 8, 43],
+        "Li6's three law-4 products, in row order: the MT 5 photon, the MT 91 photon and MT 102"
+    );
+    // Not a vacuous column on this fixture: the MT 91 photon carries 56
+    // discrete lines at each of 8 incident energies and MT 102 carries 35 at
+    // each of 43, while the MT 5 photon's 16 tables are pure continuum.
+    assert_eq!(
+        discrete_lines,
+        8 * 56 + 43 * 35,
+        "the discrete-line counts Li6's mixtures hold"
+    );
+
+    // The same columns on the synthetic law 4, whose three outgoing tables are
+    // a plain continuum, a pure set of discrete lines and a mixture of the two.
+    // Li6 cannot discriminate `energy_dist_out_interp`, because every one of
+    // its 67 outgoing tables is histogram-interpolated and so writes a 1, and
+    // it holds no `Univariate::Discrete` at all.
+    let (_, laws, _) = laws_nuclide();
+    let laws_tmp = scratch();
+    let laws_batch = distributions_of(&laws, laws_tmp.path());
+    let row = (0..laws_batch.num_rows())
+        .find(|&r| i32_at(&laws_batch, "reaction_mt", r) == 1004)
+        .expect("the law 4 row");
+    let (breakpoints, interpolation, energy, energy_out) =
+        as_continuous(law_dist(&laws, 4)).expect("law 4 is a continuous tabulation");
+    let (out_interp, n_discrete) = check_continuous_row(
+        &laws_batch,
+        row,
+        "law 4",
+        breakpoints,
+        interpolation,
+        energy,
+        energy_out,
+    );
+    // The middle table is written with INTT=2 in the file and must still come
+    // out as 1, because a discrete line is sampled by its own rule; the third
+    // is a mixture whose continuous part is a histogram.
+    assert_i32_slice_eq("law 4 energy_dist_out_interp", &out_interp, &[2, 1, 1]);
+    assert_i32_slice_eq("law 4 energy_dist_n_discrete", &n_discrete, &[0, 2, 1]);
+}
+
+/// A failure means the two Kalbach parameters were dropped, padded or raveled
+/// at the wrong stride. `km_data` is a `(5, total)` ravel while `angle_mu_data`
+/// and `energy_dist_data` are `(3, total)`, so an offset check that divided by
+/// 3 would be wrong here and this test states the divisor.
+///
+/// `km_n_discrete` is all zeros on Li6, because every outgoing table of both
+/// its Kalbach-Mann rows is a pure `Tabular`, so nothing in the loop below can
+/// tell that column from a literal zero. The CONSTRUCTED row at the end of
+/// this test is here for that one column, and its helper says why it is built
+/// rather than parsed.
+#[test]
+fn a_kalbach_mann_distribution_carries_its_precompound_and_slope_rows() {
+    let data = li6_ace();
+    let walk = distribution_walk(&data);
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+
+    let mut incident_grids: Vec<usize> = Vec::new();
+    for (row, &(mt, product_idx, dist_idx, dist, _)) in walk.iter().enumerate() {
+        let what = format!("Li6 MT {mt} product {product_idx} distribution {dist_idx}");
+        let AngleEnergy::KalbachMann(k) = dist else {
+            assert_null(&batch, &KM_COLUMNS, row, &what);
+            continue;
+        };
+        incident_grids.push(k.energy.len());
+        assert_not_null(&batch, &KM_COLUMNS, row, &what);
+
+        assert_f64_slice_eq(
+            &format!("{what} km_energies"),
+            &f64_list(&batch, "km_energies", row),
+            &k.energy,
+        );
+        assert_eq!(
+            k.energy.len(),
+            k.energy_out.len(),
+            "{what}: one outgoing table per incident energy"
+        );
+
+        // Separate columns here, where the continuous-tabular case puts the
+        // same two ENDF fields end to end in one. Both shapes are asserted so a
+        // future unification cannot quietly change one of them.
+        let breakpoints = i32_list(&batch, "km_breakpoints", row);
+        let interpolation = i32_list(&batch, "km_interpolation", row);
+        assert_i32_slice_eq(
+            &format!("{what} km_breakpoints"),
+            &breakpoints,
+            &k.breakpoints,
+        );
+        assert_i32_slice_eq(
+            &format!("{what} km_interpolation"),
+            &interpolation,
+            &k.interpolation,
+        );
+        assert!(
+            !breakpoints.is_empty(),
+            "{what}: ace_incident_grid falls back to vec![n_energy_in], so this is never empty"
+        );
+        assert_eq!(
+            breakpoints.len(),
+            interpolation.len(),
+            "{what}: one per region"
+        );
+
+        let (mut x, mut p, mut c, mut lengths, mut interp, mut n_discrete) = (
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        for out in &k.energy_out {
+            let (ox, op, oc, oi, on) = expect_flat(out);
+            lengths.push(ox.len());
+            x.extend(ox);
+            p.extend(op);
+            c.extend(oc);
+            interp.push(oi);
+            n_discrete.push(on);
+        }
+        let total: usize = lengths.iter().sum();
+
+        let data_col = f64_list(&batch, "km_data", row);
+        assert_eq!(
+            data_col.len(),
+            5 * total,
+            "{what}: km_data is (5, {total}), not (3, {total})"
+        );
+        assert_ravel3(
+            &format!("{what} km_data rows 0 to 2"),
+            &data_col[..3 * total],
+            &x,
+            &p,
+            &c,
+        );
+
+        // r and a are tabulated against the same outgoing energies. The
+        // writer's zero-padding branch at distributions.rs:411-418 cannot fire
+        // on ACE data, because KalbachMann::from_ace builds both from
+        // out.data[3] and out.data[4], which are as long as the table itself.
+        let mut precompound = Vec::new();
+        let mut slope = Vec::new();
+        for (i, &n) in lengths.iter().enumerate() {
+            assert_eq!(
+                k.precompound[i].y.len(),
+                n,
+                "{what}: the precompound fraction is one value per outgoing point, so the \
+                 writer never pads"
+            );
+            assert_eq!(k.slope[i].y.len(), n, "{what}: and so is the slope");
+            precompound.extend_from_slice(&k.precompound[i].y);
+            slope.extend_from_slice(&k.slope[i].y);
+        }
+        assert_f64_slice_eq(
+            &format!("{what} km_data row 3, the precompound fraction"),
+            &data_col[3 * total..4 * total],
+            &precompound,
+        );
+        assert_f64_slice_eq(
+            &format!("{what} km_data row 4, the slope"),
+            &data_col[4 * total..],
+            &slope,
+        );
+
+        assert_offsets(
+            &format!("{what} km_offsets"),
+            &i32_list(&batch, "km_offsets", row),
+            &lengths,
+            data_col.len(),
+            5,
+        );
+        assert_i32_slice_eq(
+            &format!("{what} km_interp"),
+            &i32_list(&batch, "km_interp", row),
+            &interp,
+        );
+        assert_i32_slice_eq(
+            &format!("{what} km_n_discrete"),
+            &i32_list(&batch, "km_n_discrete", row),
+            &n_discrete,
+        );
+    }
+    assert_eq!(
+        incident_grids,
+        vec![16, 2],
+        "Li6's two Kalbach-Mann products: the MT 5 neutron and the MT 91 neutron"
+    );
+
+    // The other half of the shape claim above, read off the MT 5 photon, whose
+    // law-4 distribution concatenates the same two fields into one column.
+    let continuous_row = walk
+        .iter()
+        .position(|&(mt, idx, _, _, _)| mt == 5 && idx == 1)
+        .expect("the MT 5 photon");
+    let AngleEnergy::Uncorrelated(u) = walk[continuous_row].3 else {
+        panic!("the MT 5 photon is uncorrelated");
+    };
+    let Some(EnergyDistribution::ContinuousTabular {
+        breakpoints,
+        interpolation,
+        ..
+    }) = &u.energy
+    else {
+        panic!("the MT 5 photon is a law-4 continuous tabulation");
+    };
+    assert_eq!(
+        list_len(&batch, "energy_dist_interpolation", continuous_row),
+        breakpoints.len() + interpolation.len(),
+        "the continuous case writes both fields into one column"
+    );
+
+    // `km_n_discrete`, on a CONSTRUCTED input: see
+    // `constructed_kalbach_mann_with_lines`. The loop above passes with the
+    // column hard-coded to zero, because Li6 holds no Kalbach-Mann mixture.
+    let built = constructed_kalbach_mann_with_lines();
+    let built_tmp = scratch();
+    let built_batch = distributions_of(&built, built_tmp.path());
+    assert_eq!(built_batch.num_rows(), 1);
+    let AngleEnergy::KalbachMann(k) = &built.reactions[&28].products[0].distribution[0] else {
+        panic!("the constructed row is Kalbach-Mann");
+    };
+    let (mut n_discrete, mut leading_lines) = (Vec::new(), Vec::new());
+    for out in &k.energy_out {
+        let (ox, _, _, _, on) = expect_flat(out);
+        leading_lines.push(ox[..on as usize].to_vec());
+        n_discrete.push(on);
+    }
+    let written_discrete = i32_list(&built_batch, "km_n_discrete", 0);
+    assert_i32_slice_eq(
+        "the constructed km_n_discrete",
+        &written_discrete,
+        &n_discrete,
+    );
+    assert_i32_slice_eq(
+        "the constructed km_n_discrete, whose two tables differ so neither a \
+         hard-coded count nor a copied one can pass",
+        &written_discrete,
+        &[0, 2],
+    );
+    // And the points the count labels are the mixture's own lines, which is
+    // what makes it "lines first" rather than a number beside the table.
+    let built_data = f64_list(&built_batch, "km_data", 0);
+    let built_offsets = i32_list(&built_batch, "km_offsets", 0);
+    for (i, &n) in written_discrete.iter().enumerate() {
+        let start = built_offsets[i] as usize;
+        assert_f64_slice_eq(
+            &format!("the constructed km sub-table {i} discrete lines"),
+            &built_data[start..start + n as usize],
+            &leading_lines[i],
+        );
+    }
+}
+
+/// A failure means one of the five laws no vendored nuclide reaches was written
+/// wrongly. `synthetic-laws.ace.xz` cannot be read as an `IncidentNeutron` (its
+/// JXS(1) ESZ, JXS(3) MTR, JXS(6) LSIG and JXS(7) SIG are all zero, so
+/// `IncidentNeutron::from_ace` fails), so the scaffold around the distributions
+/// is SYNTHETIC while the distributions themselves come out of
+/// `endf::AngleEnergy::from_ace` reading the vendored bytes. The comparison is
+/// still file against parser; only the enclosing `Reaction` and `Product` are
+/// built by hand.
+///
+/// Three things here are pinned rather than discriminated, and are worth
+/// reading as such. `corr_eout_n_discrete` is `[0, 0]`, because both outgoing
+/// tables of law 61 are pure `Tabular`. `corr_breakpoints` and
+/// `corr_interpolation` both hold `[1, 2]` on that same row, so this test
+/// cannot tell the two columns apart and stays green with the writer's two
+/// assignments swapped. Those two gaps are closed by
+/// `correlated_region_columns_and_line_counts_come_from_the_distribution`, on
+/// an input built by hand rather than parsed. The third is not closable at
+/// all: the choice between writing an interpolation VALUE and an index into
+/// `corr_mu_interp` in row 3 of `corr_eout_data` cannot be resolved by any
+/// test, so the convention `distributions.rs:327-334` describes is what is
+/// asserted.
+#[test]
+fn the_laws_only_an_assembled_table_can_reach_are_written_from_the_parsed_blocks() {
+    let (table, data, laws) = laws_nuclide();
+    assert_eq!(
+        laws,
+        vec![2, 4, 7, 9, 11, 61, 66],
+        "the seven laws tools/make_laws_ace.py writes"
+    );
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+    assert_schema_is_declared(&batch, "distributions.arrow");
+    assert_eq!(batch.num_rows(), 7, "one row per law");
+    assert_i32_slice_eq(
+        "the scaffold's MTs, which are 1000 + the law number",
+        &i32_column(&batch, "reaction_mt"),
+        &[1002, 1004, 1007, 1009, 1011, 1061, 1066],
+    );
+
+    let row_of = |law: i64| -> usize {
+        (0..batch.num_rows())
+            .find(|&r| i32_at(&batch, "reaction_mt", r) == 1000 + law as i32)
+            .expect("every law has a row")
+    };
+
+    // -- law 2: the only discrete photon in the tree with a set flag ---------
+    //
+    // Li6 has seven discrete-photon rows and every one carries
+    // `primary_flag = 0`, so the uncorrelated test cannot tell that column
+    // from a literal zero. This row carries 1, which is the difference between
+    // the stored energy being the photon's own and it being a binding energy
+    // the sampler subtracts.
+    {
+        let row = row_of(2);
+        let what = "law 2";
+        let (primary_flag, photon_energy, awr) = match law_dist(&data, 2) {
+            AngleEnergy::Uncorrelated(unc) => match &unc.energy {
+                Some(EnergyDistribution::DiscretePhoton {
+                    primary_flag,
+                    energy,
+                    atomic_weight_ratio,
+                }) => (primary_flag, energy, atomic_weight_ratio),
+                other => panic!("{what}: parsed as {other:?}"),
+            },
+            other => panic!("{what}: parsed as {other:?}"),
+        };
+        assert_eq!(str_at(&batch, "type", row), "uncorrelated", "{what}");
+        assert_eq!(
+            str_at(&batch, "energy_dist_type", row),
+            "discrete_photon",
+            "{what}"
+        );
+        assert_only_scalars(
+            &batch,
+            row,
+            &[
+                "energy_primary_flag",
+                "energy_atomic_weight_ratio",
+                "energy_discrete_energy",
+            ],
+            what,
+        );
+        assert_eq!(
+            i32_at(&batch, "energy_primary_flag", row),
+            *primary_flag as i32,
+            "{what}: energy_primary_flag"
+        );
+        assert_eq!(
+            i32_at(&batch, "energy_primary_flag", row),
+            1,
+            "{what}: the one vendored row where the flag is not zero, which is what \
+             stops the column from being indistinguishable from a hard-coded 0"
+        );
+        assert_eq!(
+            f64_at(&batch, "energy_discrete_energy", row),
+            *photon_energy,
+            "{what}: energy_discrete_energy in eV"
+        );
+        assert_eq!(
+            f64_at(&batch, "energy_atomic_weight_ratio", row),
+            *awr,
+            "{what}: energy_atomic_weight_ratio"
+        );
+        assert_eq!(
+            f64_at(&batch, "energy_atomic_weight_ratio", row),
+            table.atomic_weight_ratio,
+            "{what}: which the parser took from the ACE header"
+        );
+    }
+
+    // -- laws 7 and 9: one tabulated parameter and a restriction energy ------
+    for law in [7, 9] {
+        let row = row_of(law);
+        let what = format!("law {law}");
+        let (name, u, theta) = match law_dist(&data, law) {
+            AngleEnergy::Uncorrelated(unc) => match &unc.energy {
+                Some(EnergyDistribution::MaxwellEnergy { u, theta }) => ("maxwell", u, theta),
+                Some(EnergyDistribution::Evaporation { u, theta }) => ("evaporation", u, theta),
+                other => panic!("{what}: parsed as {other:?}"),
+            },
+            other => panic!("{what}: parsed as {other:?}"),
+        };
+        assert_eq!(str_at(&batch, "type", row), "uncorrelated", "{what}");
+        assert_eq!(str_at(&batch, "energy_dist_type", row), name, "{what}");
+        assert_f64_slice_eq(
+            &format!("{what} energy_param_x"),
+            &f64_list(&batch, "energy_param_x", row),
+            &theta.x,
+        );
+        assert_f64_slice_eq(
+            &format!("{what} energy_param_y"),
+            &f64_list(&batch, "energy_param_y", row),
+            &theta.y,
+        );
+        assert_only_scalars(&batch, row, &["energy_restriction_u"], &what);
+        assert_eq!(
+            f64_at(&batch, "energy_restriction_u", row),
+            *u,
+            "{what}: the reader defaults a null restriction energy to zero, which is a \
+             different spectrum"
+        );
+        assert_null(&batch, &["energy_param2_x", "energy_param2_y"], row, &what);
+
+        // The deliberate loss, asserted rather than left to be discovered: the
+        // parsed Tabulated1D has regions and the format has nowhere to put
+        // them, so the reader reconstructs it with none.
+        assert!(
+            !theta.breakpoints.is_empty(),
+            "{what}: the parsed side does carry region boundaries"
+        );
+        assert_null(&batch, &INT_LIST_COLUMNS, row, &what);
+    }
+
+    // -- law 11: the only row that can tell param from param2 ----------------
+    {
+        let row = row_of(11);
+        let what = "law 11";
+        let (u, a, b) = match law_dist(&data, 11) {
+            AngleEnergy::Uncorrelated(unc) => match &unc.energy {
+                Some(EnergyDistribution::WattEnergy { u, a, b }) => (u, a, b),
+                other => panic!("{what}: parsed as {other:?}"),
+            },
+            other => panic!("{what}: parsed as {other:?}"),
+        };
+        assert_eq!(str_at(&batch, "type", row), "uncorrelated");
+        assert_eq!(str_at(&batch, "energy_dist_type", row), "watt");
+        assert_f64_slice_eq(
+            "law 11 energy_param_x",
+            &f64_list(&batch, "energy_param_x", row),
+            &a.x,
+        );
+        assert_f64_slice_eq(
+            "law 11 energy_param_y",
+            &f64_list(&batch, "energy_param_y", row),
+            &a.y,
+        );
+        assert_f64_slice_eq(
+            "law 11 energy_param2_x",
+            &f64_list(&batch, "energy_param2_x", row),
+            &b.x,
+        );
+        assert_f64_slice_eq(
+            "law 11 energy_param2_y",
+            &f64_list(&batch, "energy_param2_y", row),
+            &b.y,
+        );
+        assert_only_scalars(&batch, row, &["energy_restriction_u"], what);
+        assert_eq!(f64_at(&batch, "energy_restriction_u", row), *u);
+        // a and b differ by more than eleven orders of magnitude in this
+        // fixture (9.0e5 against 3.0e-6), so a swap of the two pairs is
+        // unmistakable rather than merely unequal.
+        assert!(
+            a.y.iter().all(|&v| v > 1.0e5) && b.y.iter().all(|&v| v < 1.0e-3),
+            "law 11: the fixture's a and b are far apart, which is what makes the swap visible"
+        );
+        assert_null(&batch, &INT_LIST_COLUMNS, row, what);
+    }
+
+    // -- law 61: correlated angle and energy ---------------------------------
+    {
+        let row = row_of(61);
+        let what = "law 61";
+        let AngleEnergy::Correlated(c) = law_dist(&data, 61) else {
+            panic!("{what}: parsed as something else");
+        };
+        assert_eq!(str_at(&batch, "type", row), "correlated");
+        assert!(
+            is_null(&batch, "energy_dist_type", row),
+            "{what}: a correlated law fills no energy_dist_type"
+        );
+        assert_f64_slice_eq(
+            "law 61 corr_energies",
+            &f64_list(&batch, "corr_energies", row),
+            &c.energy,
+        );
+        let breakpoints = i32_list(&batch, "corr_breakpoints", row);
+        let interpolation = i32_list(&batch, "corr_interpolation", row);
+        assert_i32_slice_eq("law 61 corr_breakpoints", &breakpoints, &c.breakpoints);
+        assert_i32_slice_eq(
+            "law 61 corr_interpolation",
+            &interpolation,
+            &c.interpolation,
+        );
+        // Two regions, which is what separates the correlated law's two
+        // columns from the continuous law's single concatenated one: a
+        // concatenated write would be four values long. It does NOT separate
+        // the two columns from each other, because both hold [1, 2] here, and
+        // that takes the constructed row in
+        // correlated_region_columns_and_line_counts_come_from_the_distribution.
+        assert_eq!(breakpoints, vec![1, 2], "law 61 is deliberately two-region");
+        assert_eq!(interpolation, vec![1, 2]);
+
+        let (mut x, mut p, mut cdf, mut lengths, mut interp, mut n_discrete) = (
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        for out in &c.energy_out {
+            let (ox, op, oc, oi, on) = expect_flat(out);
+            lengths.push(ox.len());
+            x.extend(ox);
+            p.extend(op);
+            cdf.extend(oc);
+            interp.push(oi);
+            n_discrete.push(on);
+        }
+        let total: usize = lengths.iter().sum();
+
+        // One cosine table per outgoing POINT, in row-major (incident,
+        // outgoing) order. The writer's missing-mu fallback at
+        // distributions.rs:317-324 cannot fire, because
+        // CorrelatedAngleEnergy::from_ace fills mu[i] to the point count.
+        let (mut mx, mut mp, mut mc, mut mu_lengths, mut mu_interp) =
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        for (i, &n) in lengths.iter().enumerate() {
+            assert_eq!(
+                c.mu[i].len(),
+                n,
+                "{what}: one cosine table per outgoing energy of incident energy {i}"
+            );
+            for mu in &c.mu[i] {
+                let (ux, up, uc, ui, un) = expect_flat(mu);
+                assert_eq!(un, 0, "{what}: a cosine table holds no discrete lines");
+                mu_lengths.push(ux.len());
+                mx.extend(ux);
+                mp.extend(up);
+                mc.extend(uc);
+                mu_interp.push(ui);
+            }
+        }
+
+        let eout = f64_list(&batch, "corr_eout_data", row);
+        assert_eq!(
+            eout.len(),
+            5 * total,
+            "{what}: corr_eout_data is (5, {total})"
+        );
+        assert_ravel3(
+            "law 61 corr_eout_data rows 0 to 2",
+            &eout[..3 * total],
+            &x,
+            &p,
+            &cdf,
+        );
+        assert_offsets(
+            "law 61 corr_eout_offsets",
+            &i32_list(&batch, "corr_eout_offsets", row),
+            &lengths,
+            eout.len(),
+            5,
+        );
+        assert_eq!(
+            i32_list(&batch, "corr_eout_offsets", row),
+            vec![0, 2],
+            "a two-point table then a three-point one"
+        );
+        // Deliberately non-constant, so a writer that hard-coded 2 is caught.
+        assert_i32_slice_eq(
+            "law 61 corr_eout_interp",
+            &i32_list(&batch, "corr_eout_interp", row),
+            &interp,
+        );
+        assert_eq!(i32_list(&batch, "corr_eout_interp", row), vec![2, 1]);
+        assert_i32_slice_eq(
+            "law 61 corr_eout_n_discrete",
+            &i32_list(&batch, "corr_eout_n_discrete", row),
+            &n_discrete,
+        );
+
+        let mu_data = f64_list(&batch, "corr_mu_data", row);
+        assert_ravel3("law 61 corr_mu_data", &mu_data, &mx, &mp, &mc);
+        let mu_offsets = i32_list(&batch, "corr_mu_offsets", row);
+        assert_offsets(
+            "law 61 corr_mu_offsets",
+            &mu_offsets,
+            &mu_lengths,
+            mu_data.len(),
+            3,
+        );
+        // Global across incident energies, not restarting per energy: the
+        // second incident energy's first table does not begin at zero.
+        assert_eq!(
+            mu_offsets[lengths[0]],
+            mu_lengths[..lengths[0]].iter().sum::<usize>() as i32
+        );
+        assert!(mu_offsets[lengths[0]] > 0, "{what}: the offsets are global");
+
+        let written_mu_interp = i32_list(&batch, "corr_mu_interp", row);
+        assert_i32_slice_eq("law 61 corr_mu_interp", &written_mu_interp, &mu_interp);
+        assert_eq!(
+            written_mu_interp,
+            vec![1, 2, 2, 1, 2],
+            "isotropic cosines flatten to 1 and lin-lin tabulations to 2, so this column is \
+             deliberately not uniform"
+        );
+
+        // Rows 3 and 4 of the outgoing ravel are not data: they repeat the
+        // per-point cosine interpolation and offset as f64, and the reader's
+        // legacy fallback depends on the two agreeing.
+        for k in 0..total {
+            assert_eq!(
+                eout[3 * total + k],
+                written_mu_interp[k] as f64,
+                "{what}: corr_eout_data row 3 point {k} against corr_mu_interp"
+            );
+            assert_eq!(
+                eout[4 * total + k],
+                mu_offsets[k] as f64,
+                "{what}: corr_eout_data row 4 point {k} against corr_mu_offsets"
+            );
+        }
+    }
+
+    // -- law 66: N-body phase space ------------------------------------------
+    {
+        let row = row_of(66);
+        let what = "law 66";
+        let AngleEnergy::NBodyPhaseSpace(n) = law_dist(&data, 66) else {
+            panic!("{what}: parsed as something else");
+        };
+        assert_eq!(str_at(&batch, "type", row), "nbody");
+        assert_only_scalars(
+            &batch,
+            row,
+            &[
+                "nbody_n",
+                "nbody_total_mass",
+                "nbody_atomic_weight_ratio",
+                "nbody_q_value",
+            ],
+            what,
+        );
+        // Non-null is half the assertion: the reader does unwrap_or(0) and zero
+        // bodies is a kinematically impossible distribution that loads without
+        // complaint.
+        assert_eq!(i32_at(&batch, "nbody_n", row), n.n_particles as i32);
+        assert_eq!(i32_at(&batch, "nbody_n", row), 4);
+        assert_eq!(f64_at(&batch, "nbody_total_mass", row), n.total_mass);
+        assert_eq!(f64_at(&batch, "nbody_total_mass", row), 3.98);
+        // Asserted against the ACE header rather than the parsed struct: that
+        // is the provenance the parser chose at angle_energy.rs:247, and it is
+        // the one field here not read out of the distribution block.
+        assert_eq!(
+            f64_at(&batch, "nbody_atomic_weight_ratio", row),
+            table.atomic_weight_ratio
+        );
+        assert_eq!(f64_at(&batch, "nbody_atomic_weight_ratio", row), 0.999167);
+        assert_eq!(f64_at(&batch, "nbody_q_value", row), n.q_value);
+        assert_eq!(
+            f64_at(&batch, "nbody_q_value", row),
+            law_q(66),
+            "the Q comes from the caller, so a dropped field is only visible against a \
+             distinctive one"
+        );
+    }
+
+    // A row fills the columns its own discriminant names and no others, which
+    // is what lets the reader switch on `type` and read nothing else.
+    for row in 0..batch.num_rows() {
+        let ty = str_at(&batch, "type", row);
+        let what = format!("the {ty} row");
+        if ty != "nbody" {
+            assert_null(
+                &batch,
+                &[
+                    "nbody_n",
+                    "nbody_total_mass",
+                    "nbody_atomic_weight_ratio",
+                    "nbody_q_value",
+                ],
+                row,
+                &what,
+            );
+        }
+        if ty != "correlated" {
+            assert_null(&batch, &CORR_COLUMNS, row, &what);
+        } else {
+            assert_null(&batch, &CONTINUOUS_COLUMNS, row, &what);
+        }
+        // Nothing in this fixture is Kalbach-Mann, and no row may pretend to be.
+        assert_null(&batch, &KM_COLUMNS, row, &what);
+    }
+
+    // -- the two discriminants, across both fixtures -------------------------
+    let li6 = li6_ace();
+    let li6_tmp = scratch();
+    let li6_batch = distributions_of(&li6, li6_tmp.path());
+
+    let mut types: BTreeSet<String> = BTreeSet::new();
+    let mut energy_types: BTreeSet<String> = BTreeSet::new();
+    for b in [&batch, &li6_batch] {
+        for row in 0..b.num_rows() {
+            types.insert(str_at(b, "type", row));
+            if !is_null(b, "energy_dist_type", row) {
+                energy_types.insert(str_at(b, "energy_dist_type", row));
+            }
+        }
+    }
+    // The reader refuses an unknown discriminant, so a fifth endf::AngleEnergy
+    // variant must not be able to slip through as an unwritten row.
+    assert_eq!(
+        types,
+        ["correlated", "kalbach-mann", "nbody", "uncorrelated"]
+            .map(String::from)
+            .into(),
+        "the four the reader accepts at nuclide_arrow.rs:1134-1137"
+    );
+    assert_eq!(
+        energy_types,
+        [
+            "continuous",
+            "discrete_photon",
+            "evaporation",
+            "level",
+            "maxwell",
+            "watt"
+        ]
+        .map(String::from)
+        .into(),
+        "the six the reader accepts at nuclide_arrow.rs:1442-1452"
+    );
+}
+
+/// A failure means a correlated row's region boundaries, its interpolation
+/// codes or its discrete-line counts came from somewhere other than the
+/// distribution they belong to.
+///
+/// The input is CONSTRUCTED and not parsed, and
+/// `constructed_correlated_regions` says why. Law 61 of
+/// `synthetic-laws.ace.xz` is the only correlated distribution any vendored
+/// bytes produce, and on it `corr_breakpoints` and `corr_interpolation` both
+/// hold `[1, 2]` while `corr_eout_n_discrete` is `[0, 0]`, so two real writer
+/// defects (the two region assignments swapped, and a hard-coded line count)
+/// leave every other test in this file green. Nothing here is evaluation
+/// parity: the values in a correlated row are checked against parsed bytes in
+/// `the_laws_only_an_assembled_table_can_reach_are_written_from_the_parsed_blocks`,
+/// and this test checks only that the writer copies the right field.
+#[test]
+fn correlated_region_columns_and_line_counts_come_from_the_distribution() {
+    let data = constructed_correlated_regions();
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+    assert_eq!(batch.num_rows(), 1);
+    let AngleEnergy::Correlated(c) = &data.reactions[&22].products[0].distribution[0] else {
+        panic!("the constructed row is correlated");
+    };
+    assert_eq!(str_at(&batch, "type", 0), "correlated");
+    assert_f64_slice_eq(
+        "the constructed corr_energies",
+        &f64_list(&batch, "corr_energies", 0),
+        &c.energy,
+    );
+
+    let breakpoints = i32_list(&batch, "corr_breakpoints", 0);
+    let interpolation = i32_list(&batch, "corr_interpolation", 0);
+    assert_i32_slice_eq(
+        "the constructed corr_breakpoints",
+        &breakpoints,
+        &c.breakpoints,
+    );
+    assert_i32_slice_eq(
+        "the constructed corr_interpolation",
+        &interpolation,
+        &c.interpolation,
+    );
+    // The literals as well, because the two comparisons above are what a swap
+    // has to get past and they only bite while the two disagree. These are
+    // built to disagree at every position.
+    assert_i32_slice_eq("the constructed corr_breakpoints", &breakpoints, &[1, 3]);
+    assert_i32_slice_eq(
+        "the constructed corr_interpolation",
+        &interpolation,
+        &[2, 1],
+    );
+
+    let (mut interp, mut n_discrete, mut leading_lines) = (Vec::new(), Vec::new(), Vec::new());
+    for out in &c.energy_out {
+        let (ox, _, _, oi, on) = expect_flat(out);
+        leading_lines.push(ox[..on as usize].to_vec());
+        interp.push(oi);
+        n_discrete.push(on);
+    }
+    let written_discrete = i32_list(&batch, "corr_eout_n_discrete", 0);
+    assert_i32_slice_eq(
+        "the constructed corr_eout_n_discrete",
+        &written_discrete,
+        &n_discrete,
+    );
+    assert_i32_slice_eq(
+        "the constructed corr_eout_n_discrete, three tables with three different \
+         counts so neither a hard-coded nor a copied count can pass",
+        &written_discrete,
+        &[0, 1, 2],
+    );
+    assert_i32_slice_eq(
+        "the constructed corr_eout_interp",
+        &i32_list(&batch, "corr_eout_interp", 0),
+        &interp,
+    );
+
+    // The points those counts label are the mixture's and the discrete table's
+    // own energies, so the count means "these leading points are lines" rather
+    // than being a number beside the table. `corr_eout_data` is a (5, total)
+    // ravel and the offsets index its first row, which is where the energies
+    // are.
+    let eout = f64_list(&batch, "corr_eout_data", 0);
+    let offsets = i32_list(&batch, "corr_eout_offsets", 0);
+    for (i, &n) in written_discrete.iter().enumerate() {
+        let start = offsets[i] as usize;
+        assert_f64_slice_eq(
+            &format!("the constructed corr sub-table {i} discrete lines"),
+            &eout[start..start + n as usize],
+            &leading_lines[i],
+        );
+    }
+}
+
+/// A failure means a Watt spectrum's second parameter was paired with the
+/// first one's energy grid.
+///
+/// The input is CONSTRUCTED and not parsed, and
+/// `constructed_watt_with_distinct_grids` says why: on law 11, the only Watt
+/// spectrum in the tree, `a.x` and `b.x` are the same two numbers, so
+/// `energy_param2_x = a.x.clone()` writes a file identical to the correct one
+/// and every other test here stays green. This is not evaluation parity; law
+/// 11 in
+/// `the_laws_only_an_assembled_table_can_reach_are_written_from_the_parsed_blocks`
+/// is what checks Watt against parsed bytes.
+#[test]
+fn a_watt_spectrum_pairs_each_parameter_with_its_own_energy_grid() {
+    let data = constructed_watt_with_distinct_grids();
+    let tmp = scratch();
+    let batch = distributions_of(&data, tmp.path());
+    assert_eq!(batch.num_rows(), 1);
+    let AngleEnergy::Uncorrelated(unc) = &data.reactions[&18].products[0].distribution[0] else {
+        panic!("the constructed row is uncorrelated");
+    };
+    let Some(EnergyDistribution::WattEnergy { u, a, b }) = &unc.energy else {
+        panic!("the constructed row is a Watt spectrum");
+    };
+    assert_eq!(str_at(&batch, "energy_dist_type", 0), "watt");
+    // The grids are built to differ in length and in value, which is the whole
+    // reason this test exists.
+    assert_ne!(a.x, b.x, "the two parameters are on different grids here");
+
+    assert_f64_slice_eq(
+        "the constructed energy_param_x",
+        &f64_list(&batch, "energy_param_x", 0),
+        &a.x,
+    );
+    assert_f64_slice_eq(
+        "the constructed energy_param_y",
+        &f64_list(&batch, "energy_param_y", 0),
+        &a.y,
+    );
+    assert_f64_slice_eq(
+        "the constructed energy_param2_x",
+        &f64_list(&batch, "energy_param2_x", 0),
+        &b.x,
+    );
+    assert_f64_slice_eq(
+        "the constructed energy_param2_y",
+        &f64_list(&batch, "energy_param2_y", 0),
+        &b.y,
+    );
+    assert_only_scalars(
+        &batch,
+        0,
+        &["energy_restriction_u"],
+        "the constructed watt row",
+    );
+    assert_eq!(f64_at(&batch, "energy_restriction_u", 0), *u);
+}
+
+/// A failure means a refusal turned into invented data. The three errors are
+/// deliberate: the format holds neutrons and photons only, it holds tabulated
+/// angular distributions only, and it holds the processed ACE energy laws only.
+/// Silently converting any of them would be inventing a tabulation the
+/// evaluation did not give, which is what the messages say.
+#[test]
+fn the_writers_refuse_what_the_format_cannot_hold() {
+    let tmp = scratch();
+
+    // A recoil product the format has no column for.
+    let li6 = endf_nuclide(LI6_ENDF);
+    let err = yamc_convert::products::write_products(&li6, tmp.path())
+        .expect_err("MT 105 emits H3 and He4")
+        .to_string();
+    assert!(
+        err.contains("MT 105"),
+        "the message names the reaction: {err}"
+    );
+    assert!(err.contains("H3"), "and the particle: {err}");
+
+    // Legendre coefficients, which cannot become a tabulation without
+    // inventing one.
+    let err = yamc_convert::distributions::write_distributions(&li6, tmp.path())
+        .expect_err("the raw evaluation gives MT 2 as Legendre coefficients")
+        .to_string();
+    assert!(
+        err.contains("MT 2"),
+        "the message names the reaction: {err}"
+    );
+    assert!(err.contains("Legendre"), "and the representation: {err}");
+
+    // An unprocessed energy law. The LF=5 general evaporation belongs to
+    // MF=5 MT=455, and the delayed products it describes hang off reaction
+    // MT 18, which is the MT the message names: U235 carries no MF=5 MT=18.
+    let u235 = endf_nuclide(U235_ENDF);
+    let err = yamc_convert::distributions::write_distributions(&u235, tmp.path())
+        .expect_err("the delayed products on MT 18 are LF=5")
+        .to_string();
+    assert!(
+        err.contains("MT 18"),
+        "the message names the reaction: {err}"
+    );
+    assert!(
+        err.contains("LF=5") || err.contains("general evaporation"),
+        "and the law: {err}"
+    );
+}


### PR DESCRIPTION
Fixes fusion-neutronics/core-aug-31#550.

The converters write twelve Arrow sections and almost nothing checked the
numbers in them. The gap is not "no tests": `sections.rs` is thorough about
STRUCTURE, and `reactions_section_matches_the_published_file` states the
missing half outright, that "the cross sections cannot be compared value for
value". The retired Python converter's `verify.py` was the only thing in either
language that compared a written directory against the evaluation it came from,
and retiring it took that checklist with it.

This is the checklist in Rust, against `crates/endf` rather than a second
implementation of the format. 47 tests over five files plus a shared helper
module, 7,206 lines.

| File | Sections | Tests |
| --- | --- | --- |
| `section_values_neutron.rs` | `nuclide`, `urr`, `reactions` | 11 |
| `section_values_products.rs` | `products`, `distributions` | 11 |
| `section_values_fast_xs.rs` | `fast_xs` | 8 |
| `section_values_photon.rs` | `element`, `subshells`, `compton`, `bremsstrahlung` | 12 |
| `section_values_fission.rs` | `total_nu`, `fission_photon` | 5 |

## Hermetic, and that is half the point

Every input is `include_bytes!` from `crates/endf/fixtures/`, plus the three
git-tracked photon tabulations that ship in the wheel. No NJOY, no
nuclear-data cache, no network, and no early-return skip anywhere.

That matters because the strongest existing tests are CI-inert:
`a_transport_conversion_loads_under_a_full_scope`,
`a_nuclide_with_fission_partials_still_gets_its_total_nu` and
`the_photon_route_writes_every_section` all need an ENDF tree and an njoy
binary that no job fetches, so they report green by not running. Nothing added
here can do that. Verified by running all five files with `YAMC_CACHE_DIR`
pointed at a directory that does not exist; all 47 pass.

## Every test was mutation-tested

For each test the defect it claims to catch was introduced in the writer, the
test confirmed red, and the writer restored. That pass is also why the doc
comments are worded the way they are: it proved several first-draft claims
false, and those were corrected rather than left flattering.

Where a vendored evaluation cannot discriminate a defect the input is
hand-constructed with deliberately distinct field values, and the doc comment
says so. Li6 is not fissile, so absorption-including-fission (the wrong answer
`fast_xs.rs:18-20` warns about) survived every test until a constructed fissile
nuclide was added. Hydrogen has Z = 1 and one subshell, so the Z-squared divide
in the integrated form factor, most-bound-first row order and the Compton
occupancy map were all undiscriminated. No vendored neutron evaluation carries
more than one temperature, so the two-phase ordering rule shared by
`nuclide.rs`, `reactions.rs` and the URR writer could not be separated.

Where a defect survives even after that, the doc comment says which assertions
are wiring only rather than letting them read as value checks.

## Three suspected converter defects, pinned and not fixed

Kept out so the fix is a separate change and this one stays a test change. Each
is pinned by a test whose doc comment says it is recording a suspected defect,
not endorsing it.

1. **`element.arrow` `heating_xs` can never be populated.** MT 525 is
   `"heating"` (`endf/src/incident_photon.rs:33`) and is not in `ELEMENT_MTS`
   (`photon.rs:31`), so the reaction is dropped before evaluation and
   `take("heating")` falls through to an empty column. The published
   `element.arrow` files carry it empty too, so this is a dead column in the
   format rather than a regression in the port. Related: MT 501 **is** in
   `ELEMENT_MTS`, so it is evaluated over the whole union grid and then never
   read.
2. **`write_fast_xs` accepts a degenerate energy grid.** It refuses an empty
   grid but not an all-zero one: `synthetic-urr.ace.xz` gives a 294 K grid of
   four zeros, and the writer returns `Ok` with `log_e_min = -inf` and
   `inv_log_delta = NaN`. Nothing downstream catches it (the loader's index
   check only tests in-range and non-decreasing, which all 8001 entries
   satisfy), and a NaN cast to `usize` saturates to zero, so every lookup would
   silently take bin 0's bracket.
3. **`write_reactions` writes empty synthetic rows.** The guard at
   `reactions.rs:67-74` skips building the `synthesized` map but the row loop is
   unconditional, so an evaluation with no energy grid gains MT 3, 27 and 101
   rows with empty `xs_values`. Measured on
   `IncidentNeutron::from_endf(n-003_Li_006_trimmed)`: 41 rows, not 38.

## What is still not covered

Stated so nobody reads 47 green tests as full coverage.

- **No vendored fixture reaches these at all**: MT 901 heating (needs a HEATR
  tape), the covariance NC-only columns, `EmissionMode::Total`, ENDF MF=4 LTT=2
  tabulated angles on a success path, and a fissile ACE table.
- **Only constructed input reaches these**: multi-temperature ordering, every
  URR scalar, the fission/absorption split, and every multi-subshell photon
  path. Those tests establish what the writer does with a given value; they say
  nothing about how a real evaluation presents itself, so parser coverage still
  rests on the vendored routes.
- **Undecidable with vendored bytes**: a swap between two columns that hold
  equal values on the only fixture that reaches them.
- **`nuclide.arrow` `kTs` and five `total_nu.arrow` columns are read back by
  nothing in the workspace**, so no loader test can ever fail on them. The
  direct comparisons here are the only line of defence.