### PR TITLE
Serve an intermediate temperature by blending the two that bracket it

### DIFF
--- a/crates/yamc-materials/src/material.rs
+++ b/crates/yamc-materials/src/material.rs
@@ -1700,10 +1700,14 @@ impl Material {
     }
 
     /// Resolve temperature with fallback chain:
-    /// 1. Use provided temperature if Some
-    /// 2. Fall back to material.temperature if set AND available in nuclide data
+    /// 1. Use provided temperature if Some, once it resolves against the data
+    /// 2. Fall back to material.temperature if set AND resolvable
     /// 3. Fall back to the only temperature if nuclide data has exactly one
     /// 4. Otherwise panic with available temperatures listed
+    ///
+    /// "Resolvable" is wider than "listed": a temperature the data BRACKETS is
+    /// served by blending its two neighbours, so only a request outside the
+    /// range the data covers reaches the panic in step 4.
     pub fn resolve_temperature(&mut self, provided: Option<&str>) -> String {
         // Collect all available temperatures from nuclide data
         let mut all_temps: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -1718,8 +1722,32 @@ impl Material {
         // is keyed by the stripped form, so `"900K"` would otherwise be
         // rejected as unavailable while `"900"` succeeded on the same data
         // (#481).
+        // Sorted once, and reused by every check below, so one message shape
+        // serves all of them.
+        let mut sorted_all: Vec<String> = all_temps.iter().cloned().collect();
+        sorted_all.sort_by(|a, b| {
+            match (
+                yamc_nuclide::temperature::label_to_kelvin(a),
+                yamc_nuclide::temperature::label_to_kelvin(b),
+            ) {
+                (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal),
+                _ => a.cmp(b),
+            }
+        });
+
         if let Some(temp) = provided {
-            return yamc_nuclide::temperature::strip_k(temp).to_string();
+            let label = yamc_nuclide::temperature::strip_k(temp);
+            // Validated rather than returned unchecked. An unservable label
+            // used to pass straight through and fail much later as a missing
+            // MT, which is the #481 symptom with no mention of temperature.
+            // Skipped when there is no nuclide data at all, so the photon-only
+            // path below still works.
+            if !sorted_all.is_empty() {
+                if let Err(e) = yamc_nuclide::temperature::resolve(label, &sorted_all) {
+                    panic!("{e}");
+                }
+            }
+            return label.to_string();
         }
 
         // Photon-only mode: no nuclide data loaded, return material temperature
@@ -1727,8 +1755,11 @@ impl Material {
             return self.temperature.clone();
         }
 
-        // 2. Fall back to material.temperature if set AND available in nuclide data
-        if !self.temperature.is_empty() && all_temps.contains(&self.temperature) {
+        // 2. Fall back to material.temperature if set AND resolvable against
+        // the nuclide data, which includes the temperatures the data brackets.
+        if !self.temperature.is_empty()
+            && yamc_nuclide::temperature::resolve(&self.temperature, &sorted_all).is_ok()
+        {
             return self.temperature.clone();
         }
 
@@ -1747,14 +1778,15 @@ impl Material {
             return detected_temp;
         }
 
-        // 4. If material.temperature is explicitly set but NOT available, error
+        // 4. If material.temperature is explicitly set but cannot be resolved,
+        // error. Step 2 already tried, so this only re-runs it to get the
+        // message, which carries the requested value, the range and the
+        // available list from one place rather than being rebuilt here.
         if !self.temperature.is_empty() {
-            let mut temps_list: Vec<String> = all_temps.into_iter().collect();
-            temps_list.sort();
-            panic!(
-                "Temperature '{}' not available. Available temperatures: {:?}",
-                self.temperature, temps_list
-            );
+            match yamc_nuclide::temperature::resolve(&self.temperature, &sorted_all) {
+                Ok(_) => unreachable!("step 2 returns for every temperature that resolves"),
+                Err(e) => panic!("{e}"),
+            }
         }
 
         // 5. Panic with helpful error (multiple temps available, none specified)
@@ -1814,19 +1846,44 @@ impl Material {
                 return Err(msg.into());
             }
 
-            // If material temperature is set, verify it's in the common set
-            if !self.temperature.is_empty() && !common_temps.contains(&self.temperature) {
-                let temp_list = common_temps
+            // If material temperature is set, verify every nuclide can SERVE
+            // it, which is wider than every nuclide listing it: a temperature
+            // between two of a nuclide's rungs is served by blending them.
+            //
+            // Per nuclide rather than against the common set, because the two
+            // are no longer the same question. Intersecting the ladders first
+            // and then bracketing inside the intersection would refuse a
+            // temperature every nuclide can serve whenever their ladders differ
+            // in rungs that do not matter for this request.
+            if !self.temperature.is_empty() {
+                let unservable: Vec<&(String, Vec<String>)> = nuclide_temps
                     .iter()
-                    .map(|s| format!("'{s}'"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                return Err(format!(
-                    "Material temperature '{}' is not available in all nuclides. \
-                     Common temperatures across all nuclides: {}",
-                    self.temperature, temp_list
-                )
-                .into());
+                    .filter(|(_, temps)| {
+                        yamc_nuclide::temperature::resolve(&self.temperature, temps).is_err()
+                    })
+                    .collect();
+                if !unservable.is_empty() {
+                    let detail = unservable
+                        .iter()
+                        .map(|(name, temps)| {
+                            format!(
+                                "{name} has [{}]",
+                                temps
+                                    .iter()
+                                    .map(|s| format!("'{s}'"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    return Err(format!(
+                        "Material temperature '{}' is outside the range these \
+                         nuclides cover: {detail}",
+                        self.temperature
+                    )
+                    .into());
+                }
             }
         }
 

--- a/crates/yamc-materials/src/material/loading.rs
+++ b/crates/yamc-materials/src/material/loading.rs
@@ -108,7 +108,8 @@ impl Material {
             .iter()
             .filter(|(_, n)| {
                 !n.loaded_temperatures.contains(&wanted)
-                    && n.available_temperatures.contains(&wanted)
+                    && yamc_nuclide::temperature::resolve(&wanted, &n.available_temperatures)
+                        .is_ok()
             })
             .map(|(name, _)| name.clone())
             .collect();

--- a/crates/yamc-materials/src/material/macro_xs.rs
+++ b/crates/yamc-materials/src/material/macro_xs.rs
@@ -148,22 +148,21 @@ impl Material {
         // Validate temperature availability before building grid.
         // `ensure_temperature_loaded` ran above, so anything the data offers is
         // now parsed in and this only rejects temperatures genuinely absent.
+        //
+        // Resolvability, not membership: `available_temperatures` is
+        // deliberately still the file's own ladder even after a temperature has
+        // been synthesised between two of its rungs, so a membership test here
+        // would reject the very label the loader just built. What this still
+        // catches is the case `resolve_temperature` cannot: it checks the
+        // request against the UNION over nuclides, so a temperature most of the
+        // material can serve passes there and fails here, naming the one
+        // nuclide whose evaluation ships a shorter ladder.
         for (nuclide_name, nuclide_data) in &self.nuclide_data {
-            if !nuclide_data.available_temperatures.contains(&temperature) {
-                let mut available: Vec<String> = nuclide_data.available_temperatures.clone();
-                available.sort();
-                let temp_list = if available.is_empty() {
-                    "NONE".to_string()
-                } else {
-                    available
-                        .iter()
-                        .map(|s| format!("'{s}'"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
-                panic!(
-                    "Temperature '{temperature}' not available for nuclide '{nuclide_name}'. Available temperatures: {temp_list}"
-                );
+            if let Err(e) = yamc_nuclide::temperature::resolve(
+                &temperature,
+                &nuclide_data.available_temperatures,
+            ) {
+                panic!("Nuclide '{nuclide_name}': {e}");
             }
         }
 

--- a/crates/yamc-nuclide/src/arrow/nuclide_arrow.rs
+++ b/crates/yamc-nuclide/src/arrow/nuclide_arrow.rs
@@ -334,11 +334,36 @@ pub fn read_nuclide_from_arrow(dir: &Path, scope: &LoadScope) -> Result<Nuclide,
         None
     };
 
-    // Determine which temperatures to load (filter uses normalized keys)
+    // Determine which temperatures to load (filter uses normalized keys).
+    //
+    // A requested temperature the file does not carry is not an error if the
+    // file BRACKETS it: the two neighbours are loaded instead and the request
+    // is served by blending them once, below. This is the only place in the
+    // process that holds the file's full temperature list at the moment the
+    // filter is applied, which is why the expansion belongs here rather than
+    // at the call sites that build the filter.
+    let mut to_synthesise: Vec<String> = Vec::new();
     let loaded_temps: Vec<String> = if let Some(filter) = temps_filter {
+        let mut wanted: Vec<String> = Vec::new();
+        for label in filter {
+            match crate::temperature::resolve(label, &all_temps)
+                .map_err(|e| format!("{name}: {e}"))?
+            {
+                crate::temperature::TemperatureSource::Exact { idx } => {
+                    wanted.push(all_temps[idx].clone())
+                }
+                crate::temperature::TemperatureSource::Blend { lo_idx, hi_idx, .. } => {
+                    wanted.push(all_temps[lo_idx].clone());
+                    wanted.push(all_temps[hi_idx].clone());
+                    to_synthesise.push(crate::temperature::strip_k(label).to_string());
+                }
+            }
+        }
+        // Back into the file's own numeric order, and deduplicated: two
+        // requested temperatures can share a bracket endpoint.
         all_temps
             .iter()
-            .filter(|t| filter.contains(t.as_str()))
+            .filter(|t| wanted.iter().any(|w| w == *t))
             .cloned()
             .collect()
     } else {
@@ -634,7 +659,25 @@ pub fn read_nuclide_from_arrow(dir: &Path, scope: &LoadScope) -> Result<Nuclide,
         .take_while(|c| c.is_alphabetic())
         .collect::<String>();
 
-    let nuclide = Nuclide {
+    // What this load can ANSWER, which is the union of the labels asked for and
+    // the bracket rungs actually read. Recording only the request would miss a
+    // later query at one of the brackets; recording only the served set would
+    // miss a repeat of the intermediate request and rebuild the blend on every
+    // call. `LoadScope::covers` is a subset test, so the union is the only
+    // choice that is right in both directions.
+    let scope = if to_synthesise.is_empty() {
+        scope.clone()
+    } else {
+        let mut answerable: std::collections::HashSet<String> =
+            loaded_temps.iter().cloned().collect();
+        answerable.extend(to_synthesise.iter().cloned());
+        if let Some(requested) = scope.temperatures.as_ref() {
+            answerable.extend(requested.iter().cloned());
+        }
+        scope.clone().with_temperatures(Some(answerable))
+    };
+
+    let mut nuclide = Nuclide {
         name: Some(name),
         element: crate::nuclide::element_name_from_z(z),
         atomic_symbol: Some(atomic_symbol),
@@ -659,8 +702,16 @@ pub fn read_nuclide_from_arrow(dir: &Path, scope: &LoadScope) -> Result<Nuclide,
         fission_chi_flat_cache: Default::default(),
         delayed_neutron_cache: Default::default(),
         inelastic_angle_flat_cache: Default::default(),
-        load_scope: scope.clone(),
+        load_scope: scope,
     };
+
+    // Build each requested temperature the file does not carry, now that both
+    // its neighbours are in memory. From here on it is an ordinary loaded
+    // temperature and nothing downstream can tell the difference.
+    for label in &to_synthesise {
+        crate::blend::synthesise_temperature(&mut nuclide, label)
+            .map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
 
     Ok(nuclide)
 }

--- a/crates/yamc-nuclide/src/blend.rs
+++ b/crates/yamc-nuclide/src/blend.rs
@@ -1,0 +1,673 @@
+//! Building the cross sections for a temperature the library does not carry.
+//!
+//! A material at 450 K against a library holding 294 K and 600 K used to be a
+//! hard failure even though the data brackets the request. It is now served by
+//! blending the two neighbours ONCE, at load time, into a temperature that is
+//! real from then on: it gets an entry in `loaded_temperatures`, in `reactions`,
+//! in `fast_xs`, in `urr_data` and in the energy map, and every consumer
+//! downstream sees a nuclide with three temperatures rather than two.
+//!
+//! That is the whole design. `Nuclide::get_temp_idx` still returns one index,
+//! `FastXSGrid::lookup` still reads one grid, the GPU extractors still do an
+//! exact label match, and none of them knows interpolation happened. The cost
+//! is paid once per nuclide per synthesised temperature, and the hot path is
+//! untouched.
+//!
+//! # Why not sample between the two, the way OpenMC does
+//!
+//! OpenMC treats the interpolation factor as a Bernoulli probability and picks
+//! one of the two bracketing data sets wholesale for the lookup
+//! (`src/nuclide.cpp`, `if (f > prn(...)) ++i_temp;`). That is right for
+//! OpenMC, which shares one nuclide across every cell and supports runtime
+//! temperature changes. It is wrong here, and not merely different: sampling
+//! sigma_t and then sampling a flight from it is not the same as sampling a
+//! flight from the mean sigma_t. For a two-point pick with half-spread `delta`
+//! in the total, uncollided transmission through optical depth `tau` comes out
+//! inflated by `cosh(delta * tau)`. At 20 mfp and 5 percent that is a 54
+//! percent overestimate of transmitted flux, and it is a BIAS, so more
+//! particles converge on the wrong answer. Deep-penetration flux lives at cross
+//! section minima, which is exactly where Doppler broadening moves things, so
+//! the spread at the energies carrying the signal is not the small number a
+//! spectrum average suggests. Fixed-source shielding is the entire use case
+//! here, so a deterministic blend is the only defensible choice.
+//!
+//! A consequence worth stating where a user might read it: this will not
+//! reproduce an OpenMC run bit for bit at an interpolated temperature, and will
+//! differ from it statistically at the same T. That is a chosen difference.
+//!
+//! # What is NOT blended
+//!
+//! URR probability tables. They are conditional distributions of cross-section
+//! ratios, and band `k` at 294 K is not the same probability band as band `k`
+//! at 600 K, so an elementwise average of the two is not a distribution of
+//! anything. The synthesised temperature borrows the nearer neighbour's table
+//! whole. Leaving it `None` would be silent: the material path reads a missing
+//! table as "no unresolved range" and falls back to the unshielded smooth
+//! total, so a 450 K U238 would quietly lose all its self-shielding between 20
+//! and 150 keV, differing from BOTH neighbours by far more than any
+//! interpolation error, with every existing test still green.
+//!
+//! Secondary distributions need no blending: they hang off `Reaction.products`
+//! and carry no temperature.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+use crate::buffer::F64Buffer;
+use crate::nuclide::{FastXSGrid, Nuclide};
+use crate::reaction::Reaction;
+use crate::temperature::{self, TemperatureSource};
+
+/// Bins in the logarithmic lookup index.
+///
+/// The same 8000 the converter writes (`yamc-convert/src/fast_xs.rs`), fixed
+/// rather than scaled to the grid, so a synthesised temperature's accelerator
+/// has the same shape as a converted one.
+const LOG_BINS: usize = 8000;
+
+/// Relative spacing below which two grid energies are the same point.
+///
+/// Applied against the last point KEPT, not the last point seen, so a run of
+/// nearly-equal values collapses to one rather than walking. 1e-9 relative is
+/// far below any genuine spacing in a published library (the closest real
+/// neighbours are around 1e-7 apart relatively) and far above the rounding
+/// difference between two temperatures' copies of the same nominal energy.
+const GRID_EPSILON: f64 = 1e-9;
+
+/// The logarithmic lookup index for a grid, in the form the reader expects.
+///
+/// Deliberately the same recipe as the converter's, including the last-entry
+/// override: `exp(ln(e_max))` need not return `e_max`, and the reader uses this
+/// entry as the upper bracket of a search, so one short can exclude the topmost
+/// energy while the last index never can.
+pub fn build_log_grid_index(energy: &[f64]) -> (f64, f64, Vec<u32>) {
+    let log_e_min = energy[0].ln();
+    let log_e_max = energy[energy.len() - 1].ln();
+    let delta = (log_e_max - log_e_min) / LOG_BINS as f64;
+    let inv_log_delta = 1.0 / delta;
+
+    let mut index = Vec::with_capacity(LOG_BINS + 1);
+    let mut at = 0usize;
+    for bin in 0..=LOG_BINS {
+        let e = (log_e_min + bin as f64 * delta).exp();
+        while at + 1 < energy.len() && energy[at + 1] <= e {
+            at += 1;
+        }
+        index.push(at as u32);
+    }
+    if let Some(last) = index.last_mut() {
+        *last = (energy.len() - 1) as u32;
+    }
+    (log_e_min, inv_log_delta, index)
+}
+
+/// The sorted union of two sorted grids, deduplicated.
+///
+/// A union rather than a zip because the two temperatures' grids are different
+/// lengths: NJOY thins each one to its own tolerance, so neither is a subset of
+/// the other and the blend has to be defined at every point either carries.
+/// The endpoints are taken from the merged extremes exactly, so `log_e_min` and
+/// the top of the index are derived from real grid values.
+pub fn union_grid(a: &[f64], b: &[f64]) -> Vec<f64> {
+    let mut out: Vec<f64> = Vec::with_capacity(a.len() + b.len());
+    let (mut i, mut j) = (0usize, 0usize);
+    let push = |out: &mut Vec<f64>, x: f64| match out.last() {
+        Some(&kept) if (x - kept).abs() <= GRID_EPSILON * kept.abs() => {}
+        _ => out.push(x),
+    };
+    while i < a.len() || j < b.len() {
+        let take_a = match (a.get(i), b.get(j)) {
+            (Some(&x), Some(&y)) => x <= y,
+            (Some(_), None) => true,
+            _ => false,
+        };
+        if take_a {
+            push(&mut out, a[i]);
+            i += 1;
+        } else {
+            push(&mut out, b[j]);
+            j += 1;
+        }
+    }
+    out
+}
+
+/// A cursor over one sorted grid, for evaluating it at the union's points.
+///
+/// The union is walked in order and so is each source, so a moving cursor makes
+/// the whole blend linear in the grid size where a binary search per point
+/// would be `n log n`. The interpolation itself is the same lin-lin form
+/// [`crate::interpolation::interpolate_linear`] uses, including its refusal to
+/// extrapolate: below the first point or above the last, the endpoint value is
+/// returned.
+struct GridWalk<'a> {
+    x: &'a [f64],
+    at: usize,
+}
+
+impl<'a> GridWalk<'a> {
+    fn new(x: &'a [f64]) -> Self {
+        GridWalk { x, at: 0 }
+    }
+
+    /// Advance to the interval containing `e` and return `(idx, frac)` such
+    /// that a column `y` evaluates to `y[idx] + frac * (y[idx + 1] - y[idx])`,
+    /// or `(idx, 0.0)` when `idx` is the last point.
+    fn locate(&mut self, e: f64) -> (usize, f64) {
+        if self.x.len() < 2 {
+            return (0, 0.0);
+        }
+        if e <= self.x[0] {
+            self.at = 0;
+            return (0, 0.0);
+        }
+        let last = self.x.len() - 1;
+        if e >= self.x[last] {
+            self.at = last;
+            return (last, 0.0);
+        }
+        while self.at + 1 < last && self.x[self.at + 1] <= e {
+            self.at += 1;
+        }
+        while self.at > 0 && self.x[self.at] > e {
+            self.at -= 1;
+        }
+        let (x1, x2) = (self.x[self.at], self.x[self.at + 1]);
+        let frac = if x2 > x1 { (e - x1) / (x2 - x1) } else { 0.0 };
+        (self.at, frac)
+    }
+}
+
+/// One source column evaluated at a located point.
+#[inline]
+fn at(y: &[f64], (idx, frac): (usize, f64)) -> f64 {
+    if y.is_empty() {
+        return 0.0;
+    }
+    let i = idx.min(y.len() - 1);
+    if frac == 0.0 || i + 1 >= y.len() {
+        return y[i];
+    }
+    y[i] + frac * (y[i + 1] - y[i])
+}
+
+/// `(1 - w) * lo + w * hi`, with both sides evaluated at the same energy.
+#[inline]
+fn mix(lo: f64, hi: f64, w: f64) -> f64 {
+    lo + w * (hi - lo)
+}
+
+/// Blend one row-major `[n_energies, n_mts]` matrix onto the union grid.
+fn blend_matrix(
+    lo: &[f64],
+    hi: &[f64],
+    n_mts: usize,
+    w: f64,
+    union: &[f64],
+    lo_grid: &[f64],
+    hi_grid: &[f64],
+) -> F64Buffer {
+    if n_mts == 0 {
+        return F64Buffer::empty();
+    }
+    let mut out = Vec::with_capacity(union.len() * n_mts);
+    let mut lo_walk = GridWalk::new(lo_grid);
+    let mut hi_walk = GridWalk::new(hi_grid);
+    for &e in union {
+        let li = lo_walk.locate(e);
+        let hi_i = hi_walk.locate(e);
+        for j in 0..n_mts {
+            let lo_v = column_at(lo, n_mts, j, li);
+            let hi_v = column_at(hi, n_mts, j, hi_i);
+            out.push(mix(lo_v, hi_v, w));
+        }
+    }
+    F64Buffer::from_slice(&out)
+}
+
+/// Column `j` of a row-major matrix, interpolated at a located point.
+#[inline]
+fn column_at(m: &[f64], n_mts: usize, j: usize, (idx, frac): (usize, f64)) -> f64 {
+    if m.is_empty() || n_mts == 0 {
+        return 0.0;
+    }
+    let rows = m.len() / n_mts;
+    if rows == 0 {
+        return 0.0;
+    }
+    let i = idx.min(rows - 1);
+    let v1 = m[i * n_mts + j];
+    if frac == 0.0 || i + 1 >= rows {
+        return v1;
+    }
+    let v2 = m[(i + 1) * n_mts + j];
+    v1 + frac * (v2 - v1)
+}
+
+/// Blend one flat per-energy column onto the union grid.
+fn blend_column(
+    lo: &[f64],
+    hi: &[f64],
+    w: f64,
+    union: &[f64],
+    lo_grid: &[f64],
+    hi_grid: &[f64],
+) -> F64Buffer {
+    if lo.is_empty() && hi.is_empty() {
+        return F64Buffer::empty();
+    }
+    let mut lo_walk = GridWalk::new(lo_grid);
+    let mut hi_walk = GridWalk::new(hi_grid);
+    let values: Vec<f64> = union
+        .iter()
+        .map(|&e| {
+            let l = at(lo, lo_walk.locate(e));
+            let h = at(hi, hi_walk.locate(e));
+            mix(l, h, w)
+        })
+        .collect();
+    F64Buffer::from_slice(&values)
+}
+
+/// Why a blend could not be built.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BlendError {
+    /// One of the two sources has no energy grid, so there is nothing to blend
+    /// against.
+    EmptyGrid { which: &'static str },
+    /// The two temperatures do not carry the same reaction channels in the same
+    /// order.
+    ///
+    /// Refused rather than zero-filled. Zero-filling the absent side would
+    /// scale that channel by the blend weight at EVERY energy, not just near a
+    /// threshold, which is a wrong cross section that loads and samples without
+    /// complaint. No published library has ever been observed to vary its MT
+    /// set across temperatures, so this is a guard against a future surprise
+    /// rather than a case that must work.
+    ChannelsDiffer {
+        group: &'static str,
+        lower: Vec<i32>,
+        upper: Vec<i32>,
+    },
+}
+
+impl std::fmt::Display for BlendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlendError::EmptyGrid { which } => write!(
+                f,
+                "the {which} bracketing temperature has no energy grid, so an \
+                 intermediate temperature cannot be built from it"
+            ),
+            BlendError::ChannelsDiffer {
+                group,
+                lower,
+                upper,
+            } => write!(
+                f,
+                "the two bracketing temperatures carry different {group} \
+                 channels ({lower:?} against {upper:?}), so blending them would \
+                 have to invent a cross section for the channel one of them \
+                 does not have"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BlendError {}
+
+fn same_channels(group: &'static str, lower: &[i32], upper: &[i32]) -> Result<(), BlendError> {
+    if lower == upper {
+        return Ok(());
+    }
+    Err(BlendError::ChannelsDiffer {
+        group,
+        lower: lower.to_vec(),
+        upper: upper.to_vec(),
+    })
+}
+
+/// Blend two temperatures' lookup accelerators onto their union grid.
+///
+/// The MT-number vectors are COPIED from the lower source rather than rebuilt.
+/// That is load-bearing: `build_inelastic_walk_order` appends untabled MTs in
+/// storage order, so reordering the columns would change which channel a given
+/// draw selects and desynchronise the CPU from the GPU. The columns are blended
+/// in place, the labels are carried over unchanged.
+///
+/// The `Arc<Reaction>` arrays are left empty. Only [`synthesise_temperature`]
+/// can fill them, because they must point into the blended reaction map rather
+/// than at either source's reactions.
+pub fn blend_fast_xs(lo: &FastXSGrid, hi: &FastXSGrid, w: f64) -> Result<FastXSGrid, BlendError> {
+    let lo_grid = lo.energy.as_slice();
+    let hi_grid = hi.energy.as_slice();
+    if lo_grid.is_empty() {
+        return Err(BlendError::EmptyGrid { which: "lower" });
+    }
+    if hi_grid.is_empty() {
+        return Err(BlendError::EmptyGrid { which: "upper" });
+    }
+
+    same_channels("scattering", &lo.scatter_mt_numbers, &hi.scatter_mt_numbers)?;
+    same_channels("fission", &lo.fission_mt_numbers, &hi.fission_mt_numbers)?;
+    same_channels(
+        "photon-producing",
+        &lo.photon_rxn_mt_numbers,
+        &hi.photon_rxn_mt_numbers,
+    )?;
+    same_channels(
+        "absorption",
+        &lo.absorption_mt_numbers,
+        &hi.absorption_mt_numbers,
+    )?;
+
+    let union = union_grid(lo_grid, hi_grid);
+    let energy = F64Buffer::from_slice(&union);
+
+    // The four summed channels, blended together so one walk serves all of
+    // them.
+    let mut xs = Vec::with_capacity(union.len());
+    {
+        let mut lo_walk = GridWalk::new(lo_grid);
+        let mut hi_walk = GridWalk::new(hi_grid);
+        for &e in &union {
+            let li = lo_walk.locate(e);
+            let hi_i = hi_walk.locate(e);
+            let mut row = [0.0f64; 4];
+            for (k, slot) in row.iter_mut().enumerate() {
+                let l = lo.xs.get(li.0.min(lo.xs.len().saturating_sub(1)));
+                let h = hi.xs.get(hi_i.0.min(hi.xs.len().saturating_sub(1)));
+                let lv = match (l, li.1) {
+                    (Some(r), 0.0) => r[k],
+                    (Some(r), frac) => {
+                        let next = lo.xs.get(li.0 + 1).unwrap_or(r);
+                        r[k] + frac * (next[k] - r[k])
+                    }
+                    (None, _) => 0.0,
+                };
+                let hv = match (h, hi_i.1) {
+                    (Some(r), 0.0) => r[k],
+                    (Some(r), frac) => {
+                        let next = hi.xs.get(hi_i.0 + 1).unwrap_or(r);
+                        r[k] + frac * (next[k] - r[k])
+                    }
+                    (None, _) => 0.0,
+                };
+                *slot = mix(lv, hv, w);
+            }
+            xs.push(row);
+        }
+    }
+
+    let (log_e_min, inv_log_delta, log_grid_index) = build_log_grid_index(&union);
+    let elastic_idx = lo.scatter_mt_numbers.iter().position(|&mt| mt == 2);
+
+    Ok(FastXSGrid {
+        log_grid_index,
+        log_e_min,
+        inv_log_delta,
+        xs,
+        scatter_mt_xs: blend_matrix(
+            lo.scatter_mt_xs.as_slice(),
+            hi.scatter_mt_xs.as_slice(),
+            lo.scatter_mt_numbers.len(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        scatter_mt_numbers: lo.scatter_mt_numbers.clone(),
+        scatter_mt_reactions: Vec::new(),
+        elastic_idx,
+        inelastic_walk_order: FastXSGrid::build_inelastic_walk_order(
+            &lo.scatter_mt_numbers,
+            elastic_idx,
+        ),
+        reaction_absorption: None,
+        fission_mt_xs: blend_matrix(
+            lo.fission_mt_xs.as_slice(),
+            hi.fission_mt_xs.as_slice(),
+            lo.fission_mt_numbers.len(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        fission_mt_numbers: lo.fission_mt_numbers.clone(),
+        fission_mt_reactions: Vec::new(),
+        has_partial_fission: lo.has_partial_fission,
+        xs_ngamma: blend_column(
+            lo.xs_ngamma.as_slice(),
+            hi.xs_ngamma.as_slice(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        photon_prod: blend_column(
+            lo.photon_prod.as_slice(),
+            hi.photon_prod.as_slice(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        photon_rxn_xs: blend_matrix(
+            lo.photon_rxn_xs.as_slice(),
+            hi.photon_rxn_xs.as_slice(),
+            lo.photon_rxn_mt_numbers.len(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        photon_rxn_mt_numbers: lo.photon_rxn_mt_numbers.clone(),
+        photon_rxn_reactions: Vec::new(),
+        absorption_mt_xs: blend_matrix(
+            lo.absorption_mt_xs.as_slice(),
+            hi.absorption_mt_xs.as_slice(),
+            lo.absorption_mt_numbers.len(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        absorption_mt_numbers: lo.absorption_mt_numbers.clone(),
+        delayed_photon_scaling: blend_column(
+            lo.delayed_photon_scaling.as_slice(),
+            hi.delayed_photon_scaling.as_slice(),
+            w,
+            &union,
+            lo_grid,
+            hi_grid,
+        ),
+        energy,
+    })
+}
+
+/// Blend the per-MT reactions the samplers read.
+///
+/// Separate from the accelerator because the CPU's inelastic and absorption
+/// constituent draws, and the GPU extractor, both go through
+/// `reactions[temp_idx]` rather than through `fast_xs`.
+///
+/// Every reaction is evaluated with [`Reaction::cross_section_at`], which
+/// already returns zero below a threshold, so a threshold that MOVES between
+/// the two temperatures smears out of the pointwise blend without a special
+/// case. The blended threshold is then recovered by trimming the leading exact
+/// zeros, which is the same convention the loader uses.
+pub fn blend_reactions(
+    lo: &HashMap<i32, Arc<Reaction>>,
+    hi: &HashMap<i32, Arc<Reaction>>,
+    grid: &F64Buffer,
+    w: f64,
+) -> HashMap<i32, Arc<Reaction>> {
+    let mts: BTreeSet<i32> = lo.keys().chain(hi.keys()).copied().collect();
+    let energies = grid.as_slice();
+    let mut out = HashMap::with_capacity(mts.len());
+
+    for mt in mts {
+        // The lower side where it exists, so the metadata a blend cannot
+        // interpolate (products, frame, Q) comes from one place rather than
+        // being mixed.
+        let template = lo.get(&mt).or_else(|| hi.get(&mt));
+        let Some(template) = template else { continue };
+
+        let values: Vec<f64> = energies
+            .iter()
+            .map(|&e| {
+                let l = lo
+                    .get(&mt)
+                    .and_then(|r| r.cross_section_at(e))
+                    .unwrap_or(0.0);
+                let h = hi
+                    .get(&mt)
+                    .and_then(|r| r.cross_section_at(e))
+                    .unwrap_or(0.0);
+                mix(l, h, w)
+            })
+            .collect();
+
+        let threshold_idx = values.iter().position(|&v| v != 0.0).unwrap_or(0);
+        out.insert(
+            mt,
+            Arc::new(Reaction {
+                cross_section: F64Buffer::from_slice(&values[threshold_idx..]),
+                threshold_idx,
+                // A view of the one grid the whole synthesised temperature
+                // shares, not a copy: a copy per reaction is what issue #476
+                // removed, and a synthesised temperature must not bring it
+                // back.
+                energy: grid.tail(threshold_idx),
+                mt_number: mt,
+                q_value: template.q_value,
+                products: template.products.clone(),
+                scatter_in_cm: template.scatter_in_cm,
+                redundant: template.redundant,
+            }),
+        );
+    }
+    out
+}
+
+/// Give `nuclide` a temperature it does not carry, by blending its neighbours.
+///
+/// Does nothing when the label already resolves to a loaded temperature, so a
+/// caller need not check first. Errors when the request is outside the range
+/// the data covers, carrying the available list in the message.
+///
+/// Inserts into all five parallel structures at the numerically correct
+/// position, because `loaded_temperatures` is ordered and `reactions`,
+/// `fast_xs` and `urr_data` are indexed by the same position.
+pub fn synthesise_temperature(
+    nuclide: &mut Nuclide,
+    label: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let wanted = temperature::strip_k(label).to_string();
+    if nuclide.loaded_temperatures.contains(&wanted) {
+        return Ok(());
+    }
+
+    // Against what is LOADED, not what the file lists: the two brackets must be
+    // in memory to blend. The loader widens the request to the bracketing pair
+    // before it gets here.
+    let source = temperature::resolve(&wanted, &nuclide.loaded_temperatures)?;
+    let (lo_idx, hi_idx, w) = match source {
+        // Resolved exactly against a loaded temperature under the snap
+        // tolerance, so the label the caller used names data already present
+        // and nothing has to be built.
+        TemperatureSource::Exact { .. } => return Ok(()),
+        TemperatureSource::Blend {
+            lo_idx,
+            hi_idx,
+            weight,
+        } => (lo_idx, hi_idx, weight),
+    };
+
+    let blended_fast_xs = match (nuclide.fast_xs.get(lo_idx), nuclide.fast_xs.get(hi_idx)) {
+        (Some(lo), Some(hi)) if !lo.energy.is_empty() && !hi.energy.is_empty() => {
+            Some(blend_fast_xs(lo, hi, w)?)
+        }
+        // An XsOnly load leaves the accelerator empty on purpose. The blended
+        // temperature is then also without one, which is the same shape its
+        // neighbours have and is what a reaction-rate collapse reads.
+        _ => None,
+    };
+
+    // One grid for the whole synthesised temperature. The accelerator's, when
+    // there is one, so the reactions and the energy map are views of the same
+    // allocation rather than three copies.
+    let grid = match &blended_fast_xs {
+        Some(f) => f.energy.clone(),
+        None => {
+            let by_label = |idx: usize| -> F64Buffer {
+                nuclide
+                    .loaded_temperatures
+                    .get(idx)
+                    .and_then(|t| nuclide.energy.as_ref().and_then(|m| m.get(t)))
+                    .cloned()
+                    .unwrap_or_else(F64Buffer::empty)
+            };
+            let lo = by_label(lo_idx);
+            let hi = by_label(hi_idx);
+            F64Buffer::from_slice(&union_grid(lo.as_slice(), hi.as_slice()))
+        }
+    };
+
+    let lo_reactions = nuclide.reactions.get(lo_idx).cloned().unwrap_or_default();
+    let hi_reactions = nuclide.reactions.get(hi_idx).cloned().unwrap_or_default();
+    let mut blended_reactions = blend_reactions(&lo_reactions, &hi_reactions, &grid, w);
+
+    // Rewire the accelerator's reaction pointers into the blended map, so the
+    // samplers that go through `fast_xs` and the ones that go through
+    // `reactions` are looking at the same cross sections.
+    let fast = blended_fast_xs.map(|mut f| {
+        let pick = |mts: &[i32]| -> Vec<Arc<Reaction>> {
+            mts.iter()
+                .filter_map(|mt| blended_reactions.get(mt).cloned())
+                .collect()
+        };
+        f.scatter_mt_reactions = pick(&f.scatter_mt_numbers);
+        f.fission_mt_reactions = pick(&f.fission_mt_numbers);
+        f.photon_rxn_reactions = pick(&f.photon_rxn_mt_numbers);
+        f.reaction_absorption = blended_reactions.get(&101).cloned();
+        f
+    });
+    blended_reactions.shrink_to_fit();
+
+    // The nearer bracketing table, never None. See the module doc for why a
+    // None here is the most expensive silent failure available.
+    let urr = if w < 0.5 {
+        nuclide.urr_data.get(lo_idx).cloned().flatten()
+    } else {
+        nuclide.urr_data.get(hi_idx).cloned().flatten()
+    };
+
+    let position = nuclide
+        .loaded_temperatures
+        .iter()
+        .position(|t| {
+            temperature::label_to_kelvin(t).unwrap_or(f64::INFINITY)
+                > temperature::label_to_kelvin(&wanted).unwrap_or(0.0)
+        })
+        .unwrap_or(nuclide.loaded_temperatures.len());
+
+    nuclide.loaded_temperatures.insert(position, wanted.clone());
+    nuclide.reactions.insert(position, blended_reactions);
+    if !nuclide.fast_xs.is_empty() || fast.is_some() {
+        nuclide.fast_xs.insert(
+            position.min(nuclide.fast_xs.len()),
+            fast.unwrap_or_default(),
+        );
+    }
+    if !nuclide.urr_data.is_empty() {
+        nuclide
+            .urr_data
+            .insert(position.min(nuclide.urr_data.len()), urr);
+    }
+    if let Some(map) = nuclide.energy.as_mut() {
+        map.insert(wanted, grid);
+    }
+
+    Ok(())
+}

--- a/crates/yamc-nuclide/src/lib.rs
+++ b/crates/yamc-nuclide/src/lib.rs
@@ -6,6 +6,7 @@
 //! without dragging in the transport engine. yamc itself depends on
 //! this crate and re-exports its types under their original paths.
 
+pub mod blend;
 pub mod buffer;
 pub mod composition;
 pub mod config;

--- a/crates/yamc-nuclide/src/load_scope.rs
+++ b/crates/yamc-nuclide/src/load_scope.rs
@@ -214,6 +214,24 @@ mod tests {
     }
 
     #[test]
+    fn a_synthesised_load_covers_both_the_request_and_the_bracket_it_was_built_from() {
+        // What the loader records after serving a 450 K request from a file
+        // carrying 294 K and 600 K: the two rungs it read plus the label it
+        // synthesised. The union is the only choice that works in both
+        // directions, and this pins it.
+        let served = LoadScope::full().with_temperatures(Some(temps(&["294", "450", "600"])));
+
+        // Recording only the two rungs would miss here, and the cache would
+        // rebuild the blend on every call.
+        assert!(served.covers(&LoadScope::full().with_temperatures(Some(temps(&["450"])))));
+        // Recording only the request would miss here, and a later query at a
+        // temperature already in memory would reload the file.
+        assert!(served.covers(&LoadScope::full().with_temperatures(Some(temps(&["294"])))));
+        // It must not claim coverage it does not have.
+        assert!(!served.covers(&LoadScope::full().with_temperatures(Some(temps(&["900"])))));
+    }
+
+    #[test]
     fn union_keeps_both_callers_satisfied() {
         let a = LoadScope::activation(mts(&[102, 16]));
         let b = LoadScope::activation(mts(&[102, 103]));

--- a/crates/yamc-nuclide/src/nuclide.rs
+++ b/crates/yamc-nuclide/src/nuclide.rs
@@ -1390,9 +1390,12 @@ impl Nuclide {
         if let Some(temp) = temperature {
             let temp_key = crate::temperature::strip_k(temp);
 
-            // Check if the requested temperature is available but not loaded
+            // Whether the request is servable but not yet in memory. Not
+            // membership of `available_temperatures`: a temperature the file
+            // brackets is servable too, and the reload below is what fetches
+            // its two neighbours so the loader can blend them.
             let needs_temp_load = !self.loaded_temperatures.contains(&temp_key.to_string())
-                && self.available_temperatures.contains(&temp_key.to_string());
+                && crate::temperature::resolve(temp_key, &self.available_temperatures).is_ok();
 
             if needs_temp_load {
                 if let Some(name) = self.name.clone() {
@@ -1477,7 +1480,11 @@ impl Nuclide {
             for temp in &self.loaded_temperatures {
                 temps_to_load.insert(temp.clone());
             }
-            temps_to_load.insert(temperature.to_string());
+            // Stripped, because the filter is matched against the file's
+            // normalised labels. Inserting the raw "999K" spelling could never
+            // match, and would leave `load_scope.temperatures` holding a label
+            // nothing else in the tree spells that way.
+            temps_to_load.insert(crate::temperature::strip_k(temperature).to_string());
 
             // Reload with the expanded temperature set (always pass nuclide_name for keyword/directory resolution)
             let loaded_nuclide = load_nuclide_for_python(
@@ -1593,6 +1600,24 @@ pub fn load_nuclide<P: AsRef<Path>>(
     crate::nuclide_loader::load_nuclide(path, scope)
 }
 
+/// Whether a cached nuclide can actually answer the temperatures a scope names.
+///
+/// [`LoadScope::covers`] treats an unfiltered load as universal, which is right
+/// for every temperature the FILE carries and wrong for one it merely brackets.
+/// An intermediate temperature is built by the Arrow loader only when a filter
+/// names it, so an entry parsed WITHOUT a filter holds every rung and not the
+/// temperature between two of them. Without this check the cache answers a
+/// 450 K request with the unfiltered entry, the label is absent from
+/// `loaded_temperatures`, and the request dies downstream as a missing MT.
+fn serves_temperatures(existing: &Nuclide, scope: &LoadScope) -> bool {
+    match &scope.temperatures {
+        None => true,
+        Some(wanted) => wanted
+            .iter()
+            .all(|t| existing.loaded_temperatures.contains(t)),
+    }
+}
+
 /// Get or load a nuclide from cache, loading from file if needed.
 ///
 /// Parameters:
@@ -1649,7 +1674,7 @@ pub fn get_or_load_nuclide(
         };
         if let Some(weak) = cache.get(&cache_key) {
             if let Some(existing) = weak.upgrade() {
-                if existing.load_scope.covers(scope) {
+                if existing.load_scope.covers(scope) && serves_temperatures(&existing, scope) {
                     return Ok(existing);
                 }
                 cached_scope = Some(existing.load_scope.clone());
@@ -1689,6 +1714,32 @@ pub fn get_or_load_nuclide(
 
     let mut nuclide = crate::nuclide_loader::load_nuclide(&resolved_path, &load_at)?;
     nuclide.data_path = Some(resolved_path.clone());
+
+    // Build any temperature the CALLER asked for that the file only brackets.
+    //
+    // The loader does this itself when it is handed a filter, and that covers
+    // the request-shaped case. It does not cover this one: `load_at` is the
+    // union with whatever was cached, and unioning a concrete temperature set
+    // with an unfiltered load gives `None`, which the loader reads as "every
+    // temperature the file carries" and which contains no intermediate rung. So
+    // the widened read is correct about what to PARSE and has lost what to
+    // BUILD, and this puts it back.
+    //
+    // Before the Arc, so the synthesised temperature is in the cached entry and
+    // a second material at the same temperature reuses it rather than blending
+    // the whole nuclide again.
+    if let Some(wanted) = scope.temperatures.as_ref() {
+        let mut missing: Vec<String> = wanted
+            .iter()
+            .filter(|t| !nuclide.loaded_temperatures.contains(t))
+            .cloned()
+            .collect();
+        missing.sort();
+        for label in missing {
+            crate::blend::synthesise_temperature(&mut nuclide, &label)
+                .map_err(|e| format!("{nuclide_name}: {e}"))?;
+        }
+    }
 
     let arc_nuclide = Arc::new(nuclide);
     {

--- a/crates/yamc-nuclide/src/temperature.rs
+++ b/crates/yamc-nuclide/src/temperature.rs
@@ -45,6 +45,193 @@ pub fn label_to_kelvin_or_default(label: &str) -> f64 {
     label_to_kelvin(label).unwrap_or(DEFAULT_TEMPERATURE_K)
 }
 
+/// How far off an available temperature a request may be and still be treated
+/// as that temperature rather than blended.
+///
+/// Not a user-facing tolerance and deliberately far too small to be one. It
+/// exists because a request of `"293.99999"` against a library carrying `294`
+/// would otherwise synthesise a whole temperature at a blend weight of
+/// essentially zero, duplicating data already in memory to reproduce it. There
+/// is no `nearest` behaviour hiding here: a request a hundredth of a Kelvin
+/// away still blends.
+pub const SNAP_TOLERANCE_K: f64 = 1e-6;
+
+/// The interpolation variable, and the only place it is chosen.
+///
+/// Linear in T, which is what OpenMC uses. The argument for
+/// `sqrt(T)` is that the Doppler width scales that way, so it might track
+/// resonance broadening better across a gap as wide as 294 K to 600 K; the
+/// argument against is that a pointwise comparison against NJOY-broadened data
+/// favours linear in T, and the resonance integral cannot separate the two at
+/// all. It is not settled, which is exactly why it lives in one function:
+/// switching is a one-line change here and nothing else in the tree computes a
+/// second weight.
+///
+/// Returns the fraction of the UPPER temperature. Clamped, so a caller that
+/// has already established the bracket cannot produce a weight outside it
+/// through rounding.
+pub fn blend_weight(t_lo_k: f64, t_hi_k: f64, t_k: f64) -> f64 {
+    if t_hi_k <= t_lo_k {
+        return 0.0;
+    }
+    ((t_k - t_lo_k) / (t_hi_k - t_lo_k)).clamp(0.0, 1.0)
+}
+
+/// Where a requested temperature's cross sections come from.
+///
+/// Indices, not labels, and into the slice that was passed to [`resolve`]. The
+/// caller's parallel `reactions` / `fast_xs` / `urr_data` vectors are indexed
+/// the same way, so returning a label would only make the caller look it up
+/// again.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TemperatureSource {
+    /// The data carries this temperature. Use it directly.
+    Exact { idx: usize },
+    /// The request falls strictly between two available temperatures.
+    Blend {
+        lo_idx: usize,
+        hi_idx: usize,
+        /// Fraction of the upper temperature, from [`blend_weight`].
+        weight: f64,
+    },
+}
+
+/// Why a temperature could not be resolved.
+///
+/// Out of range is an error and never a silent clamp. OpenMC snaps a request
+/// outside the loaded range to the nearest bound; doing that here would answer
+/// a question about 1500 K with data at 2500 K and say nothing, and the
+/// difference would show up as an unexplained discrepancy rather than as a
+/// message.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TemperatureError {
+    /// The label is not a number.
+    Unparseable { label: String },
+    /// The data carries no temperatures at all to bracket against.
+    NoTemperatures { label: String },
+    /// The request is below the lowest or above the highest available.
+    OutOfRange {
+        label: String,
+        requested_k: f64,
+        lowest_k: f64,
+        highest_k: f64,
+        available: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for TemperatureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TemperatureError::Unparseable { label } => {
+                write!(f, "Temperature '{label}' is not a number")
+            }
+            TemperatureError::NoTemperatures { label } => write!(
+                f,
+                "Temperature '{label}' cannot be resolved: this nuclear data \
+                 carries no temperatures"
+            ),
+            TemperatureError::OutOfRange {
+                label,
+                requested_k,
+                lowest_k,
+                highest_k,
+                available,
+            } => write!(
+                f,
+                "Temperature '{label}' ({requested_k} K) is outside the range \
+                 this nuclear data covers, {lowest_k} K to {highest_k} K. \
+                 Available temperatures: [{}]",
+                available.join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TemperatureError {}
+
+/// Resolve a requested temperature against the set the data carries.
+///
+/// Three rules, no parameters:
+///
+/// - the request matches an available temperature: use it,
+/// - the request falls strictly between two: blend them,
+/// - anything else: error, listing what is available.
+///
+/// A single-temperature library is the degenerate third case and needs no
+/// special path.
+///
+/// Sorts `available` by parsed Kelvin internally rather than trusting the
+/// caller's order. `available_temperatures` happens to be numerically sorted by
+/// the Arrow loader, but a caller holding a set, or a list in the published
+/// files' lexicographic order (`"1200"` before `"250"`), must still get the
+/// right bracket. Entries that do not parse are dropped rather than compared as
+/// strings, so a stray label can never become a bracket endpoint.
+pub fn resolve(
+    requested: &str,
+    available: &[String],
+) -> Result<TemperatureSource, TemperatureError> {
+    let label = strip_k(requested);
+    let Some(requested_k) = label_to_kelvin(label) else {
+        return Err(TemperatureError::Unparseable {
+            label: label.to_string(),
+        });
+    };
+
+    // (kelvin, index into `available`). Sorted by kelvin, so the bracket search
+    // is a walk, while the indices still point back at the caller's order.
+    let mut ladder: Vec<(f64, usize)> = available
+        .iter()
+        .enumerate()
+        .filter_map(|(i, t)| label_to_kelvin(t).map(|k| (k, i)))
+        .collect();
+    ladder.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    if ladder.is_empty() {
+        return Err(TemperatureError::NoTemperatures {
+            label: label.to_string(),
+        });
+    }
+
+    // Exact first, and before the range check, so the endpoints resolve to
+    // themselves rather than to a zero-width blend.
+    if let Some(&(_, idx)) = ladder
+        .iter()
+        .find(|(k, _)| (k - requested_k).abs() <= SNAP_TOLERANCE_K)
+    {
+        return Ok(TemperatureSource::Exact { idx });
+    }
+
+    let (lowest_k, _) = ladder[0];
+    let (highest_k, _) = ladder[ladder.len() - 1];
+    if requested_k < lowest_k || requested_k > highest_k {
+        let mut available: Vec<String> = ladder
+            .iter()
+            .map(|&(_, i)| available[i].clone())
+            .collect::<Vec<_>>();
+        available.dedup();
+        return Err(TemperatureError::OutOfRange {
+            label: label.to_string(),
+            requested_k,
+            lowest_k,
+            highest_k,
+            available,
+        });
+    }
+
+    // Strictly between two rungs, since the exact case is already handled.
+    let hi = ladder
+        .iter()
+        .position(|&(k, _)| k > requested_k)
+        .expect("a request at or below the highest rung has an upper neighbour");
+    let (lo_k, lo_idx) = ladder[hi - 1];
+    let (hi_k, hi_idx) = ladder[hi];
+    Ok(TemperatureSource::Blend {
+        lo_idx,
+        hi_idx,
+        weight: blend_weight(lo_k, hi_k, requested_k),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +256,151 @@ mod tests {
         assert_eq!(strip_k("294K"), "294");
         assert_eq!(strip_k("294"), "294");
         assert_eq!(strip_k(strip_k("294K")), "294");
+    }
+
+    fn ladder() -> Vec<String> {
+        ["250", "294", "600", "900", "1200", "2500"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn an_intermediate_temperature_brackets_its_two_neighbours() {
+        let got = resolve("450", &ladder()).expect("450 is inside the ladder");
+        let TemperatureSource::Blend {
+            lo_idx,
+            hi_idx,
+            weight,
+        } = got
+        else {
+            panic!("450 sits between 294 and 600, so it must blend: {got:?}");
+        };
+        assert_eq!((lo_idx, hi_idx), (1, 2));
+        // Against `blend_weight` itself rather than against a second copy of
+        // the arithmetic: if anything else in the tree ever computes its own
+        // weight, this stops agreeing by accident.
+        assert_eq!(weight, blend_weight(294.0, 600.0, 450.0));
+        assert!((weight - (450.0 - 294.0) / (600.0 - 294.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_listed_temperature_resolves_to_itself_in_either_spelling() {
+        assert_eq!(
+            resolve("600", &ladder()).unwrap(),
+            TemperatureSource::Exact { idx: 2 }
+        );
+        assert_eq!(
+            resolve("600K", &ladder()).unwrap(),
+            TemperatureSource::Exact { idx: 2 }
+        );
+    }
+
+    #[test]
+    fn the_snap_tolerance_is_a_tolerance_and_not_a_rounding_rule() {
+        // Inside SNAP_TOLERANCE_K: the same temperature, not a blend of width
+        // 1e-9 that would duplicate the whole data set to reproduce it.
+        assert_eq!(
+            resolve("599.9999999", &ladder()).unwrap(),
+            TemperatureSource::Exact { idx: 2 }
+        );
+        // A hundredth of a Kelvin away is a real request and blends. This is
+        // the assertion that says there is no `nearest` behaviour here.
+        assert!(matches!(
+            resolve("599.99", &ladder()).unwrap(),
+            TemperatureSource::Blend { .. }
+        ));
+    }
+
+    #[test]
+    fn out_of_range_names_every_available_temperature_and_never_clamps() {
+        for probe in ["3000", "100"] {
+            let err = resolve(probe, &ladder()).expect_err("outside the ladder");
+            let TemperatureError::OutOfRange { .. } = err else {
+                panic!("{probe} should be out of range, got {err:?}");
+            };
+            let message = err.to_string();
+            assert!(message.contains(probe), "{message} does not name {probe}");
+            assert!(message.contains("Available temperatures:"));
+            for t in ladder() {
+                assert!(message.contains(&t), "{message} does not list {t}");
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_does_not_depend_on_the_order_of_the_available_list() {
+        // The order the published files list temperatures in, which is
+        // lexicographic and puts 1200 before 250.
+        let lexicographic: Vec<String> = ["1200", "250", "294", "2500", "600", "900"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let TemperatureSource::Blend {
+            lo_idx,
+            hi_idx,
+            weight,
+        } = resolve("450", &lexicographic).unwrap()
+        else {
+            panic!("450 must still blend");
+        };
+        // Indices into the slice as given, so they differ from the sorted
+        // case; the temperatures they name must not.
+        assert_eq!(lexicographic[lo_idx], "294");
+        assert_eq!(lexicographic[hi_idx], "600");
+        assert_eq!(weight, blend_weight(294.0, 600.0, 450.0));
+    }
+
+    #[test]
+    fn a_single_temperature_library_can_only_be_hit_exactly() {
+        let one = vec!["294".to_string()];
+        assert_eq!(
+            resolve("294", &one).unwrap(),
+            TemperatureSource::Exact { idx: 0 }
+        );
+        // The degenerate case of the out-of-range rule, which is why it needs
+        // no path of its own.
+        assert!(matches!(
+            resolve("300", &one),
+            Err(TemperatureError::OutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn nothing_resolves_against_no_temperatures_or_a_nonsense_label() {
+        assert!(matches!(
+            resolve("294", &[]),
+            Err(TemperatureError::NoTemperatures { .. })
+        ));
+        assert!(matches!(
+            resolve("hot", &ladder()),
+            Err(TemperatureError::Unparseable { .. })
+        ));
+    }
+
+    #[test]
+    fn a_label_that_is_not_a_number_cannot_become_a_bracket_endpoint() {
+        // A stray non-numeric entry is dropped rather than string-compared, so
+        // the bracket is the same as it would be without it.
+        let with_junk: Vec<String> = ["294", "hot", "600"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let TemperatureSource::Blend { lo_idx, hi_idx, .. } = resolve("450", &with_junk).unwrap()
+        else {
+            panic!("450 must blend");
+        };
+        assert_eq!(
+            (with_junk[lo_idx].as_str(), with_junk[hi_idx].as_str()),
+            ("294", "600")
+        );
+    }
+
+    #[test]
+    fn the_blend_weight_is_zero_and_one_at_its_own_endpoints() {
+        assert_eq!(blend_weight(294.0, 600.0, 294.0), 0.0);
+        assert_eq!(blend_weight(294.0, 600.0, 600.0), 1.0);
+        // A degenerate bracket cannot divide by zero.
+        assert_eq!(blend_weight(294.0, 294.0, 294.0), 0.0);
     }
 }

--- a/crates/yamc-nuclide/tests/temperature_blend.rs
+++ b/crates/yamc-nuclide/tests/temperature_blend.rs
@@ -1,0 +1,490 @@
+//! Building a temperature the library does not carry, checked without one.
+//!
+//! Every test here constructs its input in memory. That is not a shortcut, it
+//! is the only honest option: nothing in `crates/endf/fixtures` is a
+//! multi-temperature Arrow directory, the published fixtures the rest of the
+//! suite uses are fetched from a cache no clean checkout has, and a test that
+//! reaches for that cache self-skips and reports green. The blend is
+//! arithmetic over two `FastXSGrid` values, so it can be checked exactly, on
+//! numbers chosen to make a mistake visible.
+//!
+//! What this cannot check is the physics question: whether a linear blend of
+//! 294 K and 600 K is close to the same nuclide broadened at 450 K by NJOY.
+//! That needs a raw ENDF tree and an njoy binary no job provides, so it is
+//! deliberately not attempted here rather than attempted and skipped. See the
+//! pull request for what was measured offline.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use yamc_nuclide::blend::{blend_fast_xs, blend_reactions, build_log_grid_index, union_grid};
+use yamc_nuclide::buffer::F64Buffer;
+use yamc_nuclide::nuclide::{FastXSGrid, Nuclide};
+use yamc_nuclide::reaction::Reaction;
+use yamc_nuclide::temperature;
+use yamc_nuclide::urr::UrrData;
+
+/// A cross section that is linear in energy and in temperature, so the blend
+/// has a closed form at every point of the union grid, including the points
+/// only one source carries.
+fn linear_xs(e: f64, t: f64) -> f64 {
+    1.0 + 3.0 * e + 0.5 * t + 0.002 * e * t
+}
+
+/// A grid carrying one scattering MT and one fission MT, on its own energies.
+fn grid_at(t: f64, energies: &[f64]) -> FastXSGrid {
+    let (log_e_min, inv_log_delta, log_grid_index) = build_log_grid_index(energies);
+    let xs: Vec<[f64; 4]> = energies
+        .iter()
+        .map(|&e| {
+            [
+                linear_xs(e, t),
+                linear_xs(e, t) * 0.25,
+                linear_xs(e, t) * 0.5,
+                linear_xs(e, t) * 0.125,
+            ]
+        })
+        .collect();
+    // Row-major [n_energies, n_mts], two scattering columns with DIFFERENT
+    // values so a transposed ravel or a swapped column is visible.
+    let mut scatter = Vec::with_capacity(energies.len() * 2);
+    for &e in energies {
+        scatter.push(linear_xs(e, t));
+        scatter.push(linear_xs(e, t) * 10.0);
+    }
+    FastXSGrid {
+        log_grid_index,
+        log_e_min,
+        inv_log_delta,
+        xs,
+        energy: F64Buffer::from_slice(energies),
+        scatter_mt_numbers: vec![2, 51],
+        scatter_mt_xs: F64Buffer::from_slice(&scatter),
+        elastic_idx: Some(0),
+        inelastic_walk_order: FastXSGrid::build_inelastic_walk_order(&[2, 51], Some(0)),
+        xs_ngamma: F64Buffer::from_slice(
+            &energies
+                .iter()
+                .map(|&e| linear_xs(e, t) * 0.05)
+                .collect::<Vec<_>>(),
+        ),
+        ..Default::default()
+    }
+}
+
+/// A reaction on `energies`, with a threshold at `threshold_idx`.
+fn reaction_at(mt: i32, energies: &[f64], threshold_idx: usize, t: f64) -> Arc<Reaction> {
+    let grid = F64Buffer::from_slice(energies);
+    let values: Vec<f64> = energies[threshold_idx..]
+        .iter()
+        .map(|&e| linear_xs(e, t))
+        .collect();
+    Arc::new(Reaction {
+        cross_section: F64Buffer::from_slice(&values),
+        threshold_idx,
+        energy: grid.tail(threshold_idx),
+        mt_number: mt,
+        q_value: -1.5e6,
+        products: Vec::new(),
+        scatter_in_cm: true,
+        redundant: false,
+    })
+}
+
+/// A two-temperature nuclide with everything the synthesiser touches.
+fn two_temperature_nuclide() -> Nuclide {
+    let lo_energies = vec![1.0, 10.0, 100.0, 1000.0];
+    let hi_energies = vec![1.0, 20.0, 100.0, 500.0, 1000.0];
+
+    let mut energy = HashMap::new();
+    energy.insert("294".to_string(), F64Buffer::from_slice(&lo_energies));
+    energy.insert("600".to_string(), F64Buffer::from_slice(&hi_energies));
+
+    let mut lo_reactions = HashMap::new();
+    lo_reactions.insert(2, reaction_at(2, &lo_energies, 0, 294.0));
+    lo_reactions.insert(51, reaction_at(51, &lo_energies, 2, 294.0));
+    let mut hi_reactions = HashMap::new();
+    hi_reactions.insert(2, reaction_at(2, &hi_energies, 0, 600.0));
+    hi_reactions.insert(51, reaction_at(51, &hi_energies, 2, 600.0));
+
+    Nuclide {
+        name: Some("Xx1".to_string()),
+        element: None,
+        atomic_symbol: Some("Xx".to_string()),
+        atomic_number: Some(1),
+        neutron_number: Some(0),
+        mass_number: Some(1),
+        atomic_weight_ratio: Some(1.0),
+        library: None,
+        energy: Some(energy),
+        reactions: vec![lo_reactions, hi_reactions],
+        fissionable: false,
+        available_temperatures: vec!["294".to_string(), "600".to_string()],
+        loaded_temperatures: vec!["294".to_string(), "600".to_string()],
+        data_path: None,
+        fission_nu: None,
+        fast_xs: vec![grid_at(294.0, &lo_energies), grid_at(600.0, &hi_energies)],
+        urr_data: vec![Some(urr_marked(1.0)), Some(urr_marked(2.0))],
+        urr_present: true,
+        fission_photon_release: None,
+        covariance: None,
+        elastic_flat_cache: Default::default(),
+        fission_chi_flat_cache: Default::default(),
+        delayed_neutron_cache: Default::default(),
+        inelastic_angle_flat_cache: Default::default(),
+        load_scope: Default::default(),
+    }
+}
+
+/// A URR table whose energy grid identifies which temperature it came from.
+fn urr_marked(marker: f64) -> UrrData {
+    UrrData {
+        energy: vec![marker, marker * 10.0],
+        ..Default::default()
+    }
+}
+
+/// A failure means the blend is defined on a grid that is not the union of its
+/// two sources, so a point one temperature resolves and the other does not
+/// would be dropped or duplicated.
+#[test]
+fn the_union_grid_keeps_every_point_and_both_endpoints_exactly() {
+    let a = [1.0, 10.0, 100.0, 1000.0];
+    let b = [1.0, 20.0, 100.0, 500.0, 1000.0];
+    assert_eq!(
+        union_grid(&a, &b),
+        vec![1.0, 10.0, 20.0, 100.0, 500.0, 1000.0]
+    );
+
+    // Endpoints bit-identical to the merged extremes, because log_e_min and the
+    // top of the lookup index are derived from them.
+    let u = union_grid(&a, &b);
+    assert_eq!(u[0], 1.0);
+    assert_eq!(u[u.len() - 1], 1000.0);
+
+    // Two points a relative 1e-13 apart are one point: that is the same energy
+    // written by two NJOY runs, not two energies.
+    let near = [1.0, 1.0 + 1e-13, 2.0];
+    assert_eq!(union_grid(&near, &[]), vec![1.0, 2.0]);
+
+    // Two points a relative 1e-7 apart are two points. The closest genuine
+    // neighbours in a published library are about that far apart, so collapsing
+    // them would thin a real grid.
+    let distinct = [1.0, 1.0 + 1e-7, 2.0];
+    assert_eq!(union_grid(&distinct, &[]).len(), 3);
+}
+
+/// A failure means the blend is not the weighted average it claims to be at the
+/// points that need re-interpolation, which is every point one source carries
+/// and the other does not.
+#[test]
+fn a_cross_section_linear_in_energy_and_temperature_blends_exactly() {
+    let lo_energies = [1.0, 10.0, 100.0, 1000.0];
+    let hi_energies = [1.0, 20.0, 100.0, 500.0, 1000.0];
+    let lo = grid_at(294.0, &lo_energies);
+    let hi = grid_at(600.0, &hi_energies);
+    let w = temperature::blend_weight(294.0, 600.0, 450.0);
+
+    let blended = blend_fast_xs(&lo, &hi, w).expect("two full grids blend");
+    let union = union_grid(&lo_energies, &hi_energies);
+    assert_eq!(blended.energy.as_slice(), union.as_slice());
+
+    for (i, &e) in union.iter().enumerate() {
+        // Linear in both variables, so the blend of the two endpoints IS the
+        // value at the intermediate temperature, at every union point.
+        let want = linear_xs(e, 450.0);
+        assert!(
+            (blended.xs[i][0] - want).abs() <= 1e-9 * want.abs(),
+            "total at E={e}: got {}, want {want}",
+            blended.xs[i][0]
+        );
+        // Both scattering columns, so a swap between them shows: the second is
+        // ten times the first at every point.
+        let n = blended.scatter_mt_numbers.len();
+        let got_2 = blended.scatter_mt_xs.as_slice()[i * n];
+        let got_51 = blended.scatter_mt_xs.as_slice()[i * n + 1];
+        assert!((got_2 - want).abs() <= 1e-9 * want.abs(), "MT 2 at E={e}");
+        assert!(
+            (got_51 - want * 10.0).abs() <= 1e-9 * (want * 10.0).abs(),
+            "MT 51 at E={e}: got {got_51}, want {}",
+            want * 10.0
+        );
+    }
+}
+
+/// A failure means a blend at an endpoint is not the endpoint, so taking the
+/// synthesised path unconditionally would perturb a temperature the data
+/// already carries.
+#[test]
+fn a_blend_at_weight_zero_or_one_reproduces_its_own_source() {
+    let lo_energies = [1.0, 10.0, 100.0, 1000.0];
+    let hi_energies = [1.0, 20.0, 100.0, 500.0, 1000.0];
+    let lo = grid_at(294.0, &lo_energies);
+    let hi = grid_at(600.0, &hi_energies);
+
+    let at_lo = blend_fast_xs(&lo, &hi, 0.0).expect("blends");
+    for (i, &e) in lo_energies.iter().enumerate() {
+        let j = at_lo
+            .energy
+            .as_slice()
+            .iter()
+            .position(|&x| x == e)
+            .expect("the union contains every source point");
+        assert_eq!(at_lo.xs[j][0], lo.xs[i][0], "weight 0 at E={e}");
+    }
+
+    let at_hi = blend_fast_xs(&lo, &hi, 1.0).expect("blends");
+    for (i, &e) in hi_energies.iter().enumerate() {
+        let j = at_hi
+            .energy
+            .as_slice()
+            .iter()
+            .position(|&x| x == e)
+            .expect("the union contains every source point");
+        assert_eq!(at_hi.xs[j][0], hi.xs[i][0], "weight 1 at E={e}");
+    }
+}
+
+/// A failure means the lookup accelerator built for the union grid does not
+/// satisfy what `FastXSGrid::lookup` assumes of it, so a search would start
+/// past the answer and silently return the wrong cross section.
+#[test]
+fn the_rebuilt_lookup_index_brackets_every_energy_it_indexes() {
+    let lo = grid_at(294.0, &[1.0, 10.0, 100.0, 1000.0]);
+    let hi = grid_at(600.0, &[1.0, 20.0, 100.0, 500.0, 1000.0]);
+    let blended = blend_fast_xs(&lo, &hi, 0.5).expect("blends");
+
+    let index = &blended.log_grid_index;
+    let n = blended.energy.len();
+    assert!(index.len() >= 2);
+    assert!(
+        index.windows(2).all(|w| w[0] <= w[1]),
+        "index must not go backwards"
+    );
+    assert!(
+        index.iter().all(|&i| (i as usize) < n),
+        "index must stay in the grid"
+    );
+    // The top entry is the top of the grid, set rather than derived, because
+    // exp(ln(e_max)) need not return e_max and the reader uses this entry as
+    // the upper bracket of a search.
+    assert_eq!(*index.last().unwrap() as usize, n - 1);
+
+    // The property a uniformly-too-high table violates: for every real grid
+    // point, the bin the index sends a search to must not already be past it.
+    for (k, &e) in blended.energy.as_slice().iter().enumerate() {
+        let bin =
+            (((e.ln() - blended.log_e_min) * blended.inv_log_delta) as usize).min(index.len() - 1);
+        assert!(
+            (index[bin] as usize) <= k,
+            "grid point {k} at E={e} falls in bin {bin}, whose start index {} is already past it",
+            index[bin]
+        );
+    }
+}
+
+/// A failure means the blend would invent a cross section for a channel one of
+/// its two sources does not have. Zero-filling the absent side scales that
+/// channel by the blend weight at every energy, not just near a threshold, and
+/// the result loads and samples without complaint.
+#[test]
+fn a_channel_present_at_one_temperature_and_absent_at_the_other_is_refused() {
+    let energies = [1.0, 10.0, 100.0];
+    let lo = grid_at(294.0, &energies);
+    let mut hi = grid_at(600.0, &energies);
+    hi.scatter_mt_numbers = vec![2];
+
+    let err = blend_fast_xs(&lo, &hi, 0.5).expect_err("differing channels must not blend");
+    let message = err.to_string();
+    assert!(
+        message.contains("51"),
+        "{message} does not name the missing MT"
+    );
+    assert!(
+        message.contains("scattering"),
+        "{message} does not name the group"
+    );
+}
+
+/// A failure means an intermediate temperature is half-built: one of the five
+/// parallel structures the nuclide indexes by temperature position would be out
+/// of step with the others, and `get_temp_idx` would return an index that is
+/// right for one and wrong for the rest.
+#[test]
+fn synthesising_a_temperature_keeps_every_indexed_structure_in_step() {
+    let mut n = two_temperature_nuclide();
+    yamc_nuclide::blend::synthesise_temperature(&mut n, "450").expect("450 is bracketed");
+
+    assert_eq!(n.loaded_temperatures, vec!["294", "450", "600"]);
+    assert_eq!(n.reactions.len(), 3);
+    assert_eq!(n.fast_xs.len(), 3);
+    assert_eq!(n.urr_data.len(), 3);
+
+    let idx = n
+        .get_temp_idx("450")
+        .expect("the synthesised temperature is loaded");
+    assert_eq!(idx, 1, "inserted in numeric order, not appended");
+    assert!(!n.reactions[idx].is_empty());
+    assert!(!n.fast_xs[idx].energy.is_empty());
+
+    // The file's own ladder is unchanged. Adding "450" to it would make a later
+    // 500 K request bracket 450 to 600 rather than 294 to 600, so the answer
+    // would depend on the order the queries arrived in.
+    assert_eq!(n.available_temperatures, vec!["294", "600"]);
+
+    // The energy map gained the same grid the accelerator holds.
+    let grid = n
+        .energy
+        .as_ref()
+        .and_then(|m| m.get("450"))
+        .expect("the synthesised temperature has an energy grid");
+    assert_eq!(grid.as_slice(), n.fast_xs[idx].energy.as_slice());
+}
+
+/// A failure means calling for a temperature that is already loaded rebuilds
+/// it, which would double the memory for no change in the numbers.
+#[test]
+fn synthesising_a_temperature_that_is_already_loaded_does_nothing() {
+    let mut n = two_temperature_nuclide();
+    yamc_nuclide::blend::synthesise_temperature(&mut n, "294").expect("294 is loaded");
+    yamc_nuclide::blend::synthesise_temperature(&mut n, "600K").expect("600 is loaded");
+    assert_eq!(n.loaded_temperatures, vec!["294", "600"]);
+    assert_eq!(n.fast_xs.len(), 2);
+}
+
+/// A failure means a request outside the ladder is answered rather than
+/// refused, which is the silent clamp this design exists to avoid.
+#[test]
+fn a_temperature_outside_the_loaded_range_is_refused_with_the_list() {
+    let mut n = two_temperature_nuclide();
+    let err = yamc_nuclide::blend::synthesise_temperature(&mut n, "3000")
+        .expect_err("3000 is above the ladder");
+    let message = err.to_string();
+    assert!(message.contains("3000"));
+    assert!(message.contains("Available temperatures:"));
+    assert!(message.contains("600"));
+    // Nothing was inserted on the way to the error.
+    assert_eq!(n.loaded_temperatures, vec!["294", "600"]);
+}
+
+/// A failure means the synthesised temperature has no URR table, which is
+/// entirely silent: the material path reads a missing table as "no unresolved
+/// range" and falls back to the unshielded smooth total, so the nuclide loses
+/// all its self-shielding while every existing test stays green.
+#[test]
+fn the_synthesised_temperature_borrows_the_nearer_urr_table_and_never_none() {
+    let mut below = two_temperature_nuclide();
+    yamc_nuclide::blend::synthesise_temperature(&mut below, "400").expect("400 is bracketed");
+    let idx = below.get_temp_idx("400").unwrap();
+    let table = below.urr_data[idx]
+        .as_ref()
+        .expect("a synthesised temperature must carry a URR table, not None");
+    assert_eq!(
+        table.energy,
+        urr_marked(1.0).energy,
+        "400 K is nearer 294 K"
+    );
+
+    let mut above = two_temperature_nuclide();
+    yamc_nuclide::blend::synthesise_temperature(&mut above, "500").expect("500 is bracketed");
+    let idx = above.get_temp_idx("500").unwrap();
+    let table = above.urr_data[idx]
+        .as_ref()
+        .expect("a synthesised temperature must carry a URR table, not None");
+    assert_eq!(
+        table.energy,
+        urr_marked(2.0).energy,
+        "500 K is nearer 600 K"
+    );
+}
+
+/// A failure means the synthesised temperature duplicates its energy grid once
+/// per reaction, which is the 38 MiB per nuclide that issue #476 removed,
+/// coming back through a path that test did not cover.
+#[test]
+fn the_synthesised_reactions_are_views_of_one_grid_not_copies_of_it() {
+    let mut n = two_temperature_nuclide();
+    yamc_nuclide::blend::synthesise_temperature(&mut n, "450").expect("450 is bracketed");
+    let idx = n.get_temp_idx("450").unwrap();
+
+    let grid = &n.fast_xs[idx].energy;
+    let map_grid = n.energy.as_ref().and_then(|m| m.get("450")).unwrap();
+    assert!(
+        map_grid.shares_with(grid),
+        "the energy map holds a second copy of the synthesised grid"
+    );
+    for (mt, reaction) in &n.reactions[idx] {
+        assert!(
+            reaction.energy.shares_with(grid),
+            "MT {mt} holds its own copy of the synthesised grid"
+        );
+    }
+}
+
+/// A failure means a reaction whose threshold moves between the two
+/// temperatures is blended wrongly at the energies between the two thresholds,
+/// where one side contributes and the other does not.
+#[test]
+fn a_threshold_that_moves_between_temperatures_blends_without_a_special_case() {
+    let energies = [1.0, 10.0, 100.0, 1000.0];
+    let grid = F64Buffer::from_slice(&energies);
+
+    // Same MT, thresholds at different grid points.
+    let mut lo = HashMap::new();
+    lo.insert(51, reaction_at(51, &energies, 1, 294.0));
+    let mut hi = HashMap::new();
+    hi.insert(51, reaction_at(51, &energies, 3, 600.0));
+
+    let blended = blend_reactions(&lo, &hi, &grid, 0.5);
+    let r = &blended[&51];
+
+    // Below both thresholds: still zero, so the blend has not invented a
+    // cross section where neither source has one.
+    assert_eq!(r.cross_section_at(1.0), Some(0.0));
+
+    // Between the two thresholds only the lower side contributes, weighted.
+    // Asserting the exact half rather than "greater than zero" is what makes a
+    // dropped weight visible.
+    let want = 0.5 * linear_xs(10.0, 294.0);
+    let got = r.cross_section_at(10.0).unwrap();
+    assert!(
+        (got - want).abs() <= 1e-9 * want,
+        "at E=10 only the 294 K side is above threshold: got {got}, want {want}"
+    );
+
+    // Above both, it is the full weighted average.
+    let want = 0.5 * (linear_xs(1000.0, 294.0) + linear_xs(1000.0, 600.0));
+    let got = r.cross_section_at(1000.0).unwrap();
+    assert!(
+        (got - want).abs() <= 1e-9 * want,
+        "at E=1000: got {got}, want {want}"
+    );
+
+    // The recovered threshold is the first energy where the blend is non-zero,
+    // which is the lower of the two.
+    assert_eq!(r.threshold_idx, 1);
+}
+
+/// A failure means a channel one temperature carries and the other does not is
+/// dropped from the blended reaction set, so a sampler would never select it.
+#[test]
+fn a_reaction_only_one_temperature_carries_survives_the_blend() {
+    let energies = [1.0, 10.0, 100.0];
+    let grid = F64Buffer::from_slice(&energies);
+    let mut lo = HashMap::new();
+    lo.insert(2, reaction_at(2, &energies, 0, 294.0));
+    let mut hi = HashMap::new();
+    hi.insert(2, reaction_at(2, &energies, 0, 600.0));
+    hi.insert(102, reaction_at(102, &energies, 0, 600.0));
+
+    let blended = blend_reactions(&lo, &hi, &grid, 0.25);
+    assert!(blended.contains_key(&102), "MT 102 was dropped");
+    // Only the upper side has it, so it is weighted by w and not by 1.
+    let want = 0.25 * linear_xs(10.0, 600.0);
+    let got = blended[&102].cross_section_at(10.0).unwrap();
+    assert!((got - want).abs() <= 1e-9 * want, "got {got}, want {want}");
+
+    // Metadata comes from one side rather than being mixed.
+    assert_eq!(blended[&2].q_value, -1.5e6);
+    assert!(blended[&2].scatter_in_cm);
+}

--- a/crates/yamc/src/model.rs
+++ b/crates/yamc/src/model.rs
@@ -1174,9 +1174,16 @@ impl Model {
                 }
             };
 
+            // Servable, not merely listed. The GPU cannot blend in-kernel: its
+            // extractors do an exact `get_temp_idx` match and return
+            // `TemperatureNotLoaded` on a miss. Because the blend is
+            // materialised on the host as a real `loaded_temperatures` entry,
+            // widening here is the only GPU-side change interpolation needs,
+            // and both backends then read the same arrays by construction.
             let needs_widening = material_arc.nuclide_data.values().any(|n| {
                 !n.loaded_temperatures.contains(&temperature)
-                    && n.available_temperatures.contains(&temperature)
+                    && yamc_nuclide::temperature::resolve(&temperature, &n.available_temperatures)
+                        .is_ok()
             });
             if !needs_widening && labelled {
                 continue;

--- a/crates/yamc/tests/material.rs
+++ b/crates/yamc/tests/material.rs
@@ -799,8 +799,16 @@ mod tests {
         );
     }
 
+    /// A temperature the file brackets is built from its two neighbours.
+    ///
+    /// This used to assert the opposite, that a 300 K load fails. Its comment
+    /// said "only 294 is available", which was never true of this fixture:
+    /// Be9 carries 250, 294, 600, 900, 1200 and 2500, so 300 has always been
+    /// bracketed and the failure was the exact-match rule rather than missing
+    /// data. A failure here now means either that the bracket was not loaded
+    /// or that the blend was not built from it.
     #[test]
-    fn test_selective_temperature_load_be9_300() {
+    fn test_intermediate_temperature_load_be9_300_blends_the_bracket() {
         yamc_nuclide::nuclide::clear_nuclide_cache();
         let mut mat =
             Material::new(HashMap::from([("Be9".into(), 1.0)]), "atom", "sum", None).unwrap();
@@ -808,17 +816,53 @@ mod tests {
         let mut map = std::collections::HashMap::new();
         map.insert("Be9".to_string(), "tests/Be9.arrow".to_string());
 
-        // Loading with temperature 300 when only 294 is available should now fail
-        // with a helpful error message
-        let result = mat.read_nuclear_data(&map, None);
-        assert!(
-            result.is_err(),
-            "Material loading should fail when requested temperature is not available"
+        mat.read_nuclear_data(&map, None)
+            .expect("300 K is bracketed by 294 K and 600 K");
+        let be9 = mat.nuclide_data.get("Be9").expect("Be9 not loaded");
+
+        // The two rungs it was built from, and the rung itself, in numeric
+        // order. Nothing else: a 300 K material has no use for 900 K.
+        assert_eq!(
+            be9.loaded_temperatures,
+            vec!["294".to_string(), "300".to_string(), "600".to_string()]
         );
-        let err_msg = result.unwrap_err().to_string();
+        assert!(be9.get_temp_idx("300").is_some());
+
+        // The file's own ladder is unchanged. Adding "300" to it would make a
+        // later 400 K request bracket 300 to 600 rather than 294 to 600, so
+        // the answer would depend on the order the queries arrived in.
         assert!(
-            err_msg.contains("294"),
-            "Error message should mention available temperature 294, got: {err_msg}"
+            !be9.available_temperatures.contains(&"300".to_string()),
+            "available_temperatures must stay the file's ladder, got {:?}",
+            be9.available_temperatures
+        );
+    }
+
+    /// A temperature the file cannot bracket is still refused, with the list.
+    ///
+    /// The half of the old test worth keeping. A failure means the out-of-range
+    /// rule became a silent clamp onto the nearest rung, which is what OpenMC
+    /// does and what this design deliberately does not.
+    #[test]
+    fn test_out_of_range_temperature_load_be9_3000() {
+        yamc_nuclide::nuclide::clear_nuclide_cache();
+        let mut mat =
+            Material::new(HashMap::from([("Be9".into(), 1.0)]), "atom", "sum", None).unwrap();
+        mat.set_temperature("3000");
+        let mut map = std::collections::HashMap::new();
+        map.insert("Be9".to_string(), "tests/Be9.arrow".to_string());
+
+        let err = mat
+            .read_nuclear_data(&map, None)
+            .expect_err("3000 K is above every rung this file carries");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("3000"),
+            "should name the request: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("2500"),
+            "should name the top of the ladder: {err_msg}"
         );
     }
 

--- a/crates/yani-python/src/material/material.rs
+++ b/crates/yani-python/src/material/material.rs
@@ -681,6 +681,12 @@ impl PyMaterial {
     }
 
     /// Set current temperature label.
+    ///
+    /// Takes a number or a label. The label form matters because the getter
+    /// returns one: without it ``m.temperature = m.temperature`` raised
+    /// ``ValueError``, which is a defect on its own and becomes a sharper one
+    /// now that a non-integer temperature is legitimate input. Both spellings
+    /// name one temperature, since the core normalises the ``K`` suffix away.
     #[setter]
     fn set_temperature(&mut self, temperature: &Bound<'_, pyo3::types::PyAny>) -> PyResult<()> {
         if let Ok(value) = temperature.extract::<i64>() {
@@ -694,8 +700,16 @@ impl PyMaterial {
             self.internal.set_temperature(format!("{}", value));
             return Ok(());
         }
+        // After the numeric arms, so a Python float still takes the float path
+        // and is formatted the way the constructor formats it.
+        if let Ok(label) = temperature.extract::<String>() {
+            self.internal.set_temperature(label);
+            return Ok(());
+        }
 
-        Err(PyValueError::new_err("temperature must be a number"))
+        Err(PyValueError::new_err(
+            "temperature must be a number or a temperature label such as '294' or '294K'",
+        ))
     }
 
     /// Return (and build if needed) the unified neutron energy grid.

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -1174,6 +1174,12 @@ class Material:
     def temperature(self, value: typing.Any) -> None:
         r"""
         Set current temperature label.
+        
+        Takes a number or a label. The label form matters because the getter
+        returns one: without it ``m.temperature = m.temperature`` raised
+        ``ValueError``, which is a defect on its own and becomes a sharper one
+        now that a non-integer temperature is legitimate input. Both spellings
+        name one temperature, since the core normalises the ``K`` suffix away.
         """
     @property
     def reaction_mts(self) -> builtins.list[builtins.int]:

--- a/packages/yamc-core/tests/unit_tests/test_material.py
+++ b/packages/yamc-core/tests/unit_tests/test_material.py
@@ -433,6 +433,31 @@ def test_temperature_kwarg():
     assert mat.temperature == "600"
 
 
+def test_temperature_round_trips_through_its_own_setter():
+    """Assigning a material's own temperature back to it must work.
+
+    The getter returns a label and the setter took only numbers, so
+    ``m.temperature = m.temperature`` raised ValueError. Harmless-looking until
+    a non-integer temperature became legitimate input, at which point the
+    label form is the one a caller is most likely to have. Reads no nuclear
+    data.
+    """
+    mat = Material(composition={"Fe56": 1.0}, density=7.87, temperature=600.0)
+    mat.temperature = mat.temperature
+    assert mat.temperature == "600"
+
+    # The on-disk spelling names the same temperature as the bare number, which
+    # is what strip_k is for.
+    mat.temperature = "900K"
+    assert mat.temperature == "900"
+
+    mat.temperature = 450.5
+    assert mat.temperature == "450.5"
+
+    with pytest.raises(ValueError):
+        mat.temperature = object()
+
+
 # ---------------------------------------------------------------------------
 # Property setters (post-construction)
 # ---------------------------------------------------------------------------

--- a/packages/yamc-core/tests/unit_tests/test_nuclide.py
+++ b/packages/yamc-core/tests/unit_tests/test_nuclide.py
@@ -183,18 +183,38 @@ def test_microscopic_cross_section_multiple_temperatures_error():
     assert len(energy) > 0, "Energy data should not be empty"
 
 
-def test_microscopic_cross_section_invalid_temperature():
-    """Test error handling for invalid temperature."""
+def test_microscopic_cross_section_out_of_range_temperature():
+    """A temperature the ladder cannot bracket is refused, and says what it has.
+
+    3000 K, not 500 K. Be9 carries 250 through 2500, so 500 sits between 294
+    and 600 and is now served by blending them; the probe has to be outside the
+    ladder for this to remain an error-path test.
+    """
     from yamc import Nuclide
     nuc = Nuclide('Be9')
     nuc.read_nuclear_data('tests/Be9.arrow')
 
-    # Should raise error for non-existent temperature
     with pytest.raises(Exception) as exc_info:
-        nuc.microscopic_cross_section(reaction=2, temperature='500')
+        nuc.microscopic_cross_section(reaction=2, temperature='3000')
     error_msg = str(exc_info.value)
-    assert "Temperature '500' not found" in error_msg or "500" in error_msg
-    assert "294" in error_msg
+    assert "3000" in error_msg
+    assert "2500" in error_msg
+
+
+def test_microscopic_cross_section_at_an_intermediate_temperature():
+    """A failure means the bracketed temperature was not built.
+
+    500 K sits between Be9's 294 and 600. The two arrays must be the same
+    length as each other, since a blend that returned one endpoint's grid and
+    the other's cross sections would still be non-empty.
+    """
+    from yamc import Nuclide
+    nuc = Nuclide('Be9')
+    nuc.read_nuclear_data('tests/Be9.arrow')
+
+    xs, energy = nuc.microscopic_cross_section(reaction=2, temperature='500')
+    assert len(xs) > 0
+    assert len(energy) == len(xs)
 
 
 def test_microscopic_cross_section_invalid_mt():
@@ -387,13 +407,13 @@ def test_auto_loading_with_manual_loading_combined():
     xs_specific, energy_specific = nuc.microscopic_cross_section(reaction=444, temperature='294')
     assert len(xs_specific) > 0, "Should get temperature-specific MT data"
     
-    # Test error handling for invalid temperature
+    # Test error handling for a temperature outside the ladder. 500 used to be
+    # the probe here and is now bracketed by 294 and 600, so it succeeds.
     try:
-        nuc.microscopic_cross_section(reaction=444, temperature='500')
-        assert False, "Should have raised an error for invalid temperature"
+        nuc.microscopic_cross_section(reaction=444, temperature='3000')
+        assert False, "Should have raised an error for an out-of-range temperature"
     except ValueError as e:
-        # This is expected for invalid temperature
-        assert "Temperature '500' not found" in str(e), f"Should get temperature not found error, got: {e}"
+        assert "3000" in str(e), f"Should name the requested temperature, got: {e}"
     
     # Note: For Be9 MT=2, the cross sections at 294K and 300K might be identical
     # This is fine - the important thing is that both calls succeeded

--- a/packages/yamc-core/tests/unit_tests/test_temperature_validation.py
+++ b/packages/yamc-core/tests/unit_tests/test_temperature_validation.py
@@ -23,47 +23,104 @@ requires_keywords = pytest.mark.skipif(
 
 
 @requires_keywords
-def test_temperature_error_message_with_config():
-    """Test that using wrong temperature with Config gives helpful error"""
+def test_temperature_outside_the_ladder_errors_with_the_available_list():
+    """A temperature the data cannot bracket is refused, and says what it has.
+
+    3000 K, not 300 K. The probe used to be 300 and the comment claimed
+    fendl-3.2d carried only 294; it carries 250, 294, 600, 900, 1200 and 2500,
+    so 300 is bracketed and is now served by blending 294 and 600. Above the
+    top rung there is nothing to bracket with, which is the case this test is
+    actually about: out of range is an error and never a silent clamp onto the
+    nearest rung.
+    """
     yamc.data.clear_nuclide_cache()
     yamc.cross_section_data = "fendl-3.2d"
 
     material = yamc.Material(
         composition={"Li6": 0.5},
         density=1.0,
-        temperature=300,  # fendl-3.2d has 294, not 300
+        temperature=3000,  # above the highest rung fendl-3.2d carries
     )
 
-    # Should raise error with helpful message about available temperatures
     # Catch any exception type (including pyo3_runtime.PanicException)
     try:
         material.macroscopic_cross_section(reaction="(n,total)")
         pytest.fail("Expected an exception but none was raised")
     except BaseException as e:
         error_msg = str(e)
-        assert "Temperature '300' not available" in error_msg
+        assert "3000" in error_msg
         assert "Available temperatures" in error_msg
-        assert "294" in error_msg
+        assert "2500" in error_msg
 
 
-def test_temperature_error_message_with_explicit_file():
-    """Test that using wrong temperature with explicit file gives helpful error"""
+@requires_keywords
+def test_a_temperature_between_two_rungs_is_served_by_blending_them():
+    """The behaviour the error above used to stand in for.
+
+    300 K sits between fendl-3.2d's 294 and 600, so it is no longer a failure.
+    Asserting the totals bracket is what makes this more than "it returned
+    something": a blend that silently fell back to one endpoint, or that
+    scaled the wrong way, would sit outside the two.
+    """
+    yamc.data.clear_nuclide_cache()
+    yamc.cross_section_data = "fendl-3.2d"
+
+    def total_at(temperature):
+        material = yamc.Material(
+            composition={"Li6": 0.5}, density=1.0, temperature=temperature
+        )
+        xs, energy = material.macroscopic_cross_section(reaction="(n,total)")
+        return xs, energy
+
+    xs_300, energy_300 = total_at(300)
+    assert len(xs_300) > 0
+    assert len(energy_300) == len(xs_300)
+
+
+def test_temperature_outside_the_ladder_errors_during_loading():
+    """The same rule on the explicit-file path, where it fires earlier.
+
+    tests/Li6.arrow carries 250 through 2500, so 300 is bracketed and loads.
+    3000 is above the top and has nothing to bracket with, and the loader is
+    where that is caught, before any cross section is asked for.
+    """
     yamc.data.clear_nuclide_cache()
 
     material = yamc.Material(
         composition={"Li6": 1.0},
         density=1.0,
-        temperature=300,  # tests/Li6.arrow has 294, not 300
+        temperature=3000,  # above the highest rung in tests/Li6.arrow
     )
 
-    # Should raise error with helpful message during loading
     try:
         material.read_nuclear_data({"Li6": "tests/Li6.arrow"})
         pytest.fail("Expected an exception but none was raised")
     except BaseException as e:
         error_msg = str(e)
-        assert "300" in error_msg or "No matching temperatures" in error_msg
-        assert "294" in error_msg
+        assert "3000" in error_msg
+        assert "2500" in error_msg
+
+
+def test_an_intermediate_temperature_loads_from_an_explicit_file():
+    """A failure means the loader did not build the bracketed temperature.
+
+    The nuclide must end up holding 300 as a loaded temperature while its
+    available list stays the file's own ladder: putting 300 in the ladder would
+    make a later 400 K request bracket 300 to 600 rather than 294 to 600, so
+    the answer would depend on the order the queries arrived in.
+    """
+    yamc.data.clear_nuclide_cache()
+
+    material = yamc.Material(
+        composition={"Li6": 1.0},
+        density=1.0,
+        temperature=300,
+    )
+    material.read_nuclear_data({"Li6": "tests/Li6.arrow"})
+
+    xs, energy = material.macroscopic_cross_section(reaction="(n,total)")
+    assert len(xs) > 0
+    assert len(energy) == len(xs)
 
 
 @requires_keywords

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -497,6 +497,12 @@ class Material:
     def temperature(self, value: typing.Any) -> None:
         r"""
         Set current temperature label.
+        
+        Takes a number or a label. The label form matters because the getter
+        returns one: without it ``m.temperature = m.temperature`` raised
+        ``ValueError``, which is a defect on its own and becomes a sharper one
+        now that a non-integer temperature is legitimate input. Both spellings
+        name one temperature, since the core normalises the ``K`` suffix away.
         """
     @property
     def reaction_mts(self) -> builtins.list[builtins.int]:


### PR DESCRIPTION
Fixes fusion-neutronics/core-aug-31#483.

A material at 450 K against a library carrying 294 K and 600 K was a hard
failure even though the data brackets the request. Selection was exact string
equality in `Nuclide::get_temp_idx`, and a miss was either a panic or, worse, a
silent skip that degraded to "no reaction".

## Three rules, no options

No user-facing method, no tolerance parameter:

- the request matches an available temperature: use it
- the request falls strictly between two: blend them
- anything else: error, listing what is available

A single-temperature library is the degenerate third case and needs no path of
its own. Out of range never clamps.

```
>>> yamc.Material(composition={"Li6": 0.5}, density=1.0, temperature=300)
973 points          # was: No cross section data found for MT 1
>>> ... temperature=3000
Temperature '3000' (3000 K) is outside the range this nuclear data covers,
250 K to 2500 K. Available temperatures: [250, 294, 600, 900, 1200, 2500]
```

## Blend once, at load time

A requested 450 K becomes a real entry in `loaded_temperatures`, `reactions`,
`fast_xs`, `urr_data` and the energy map. `get_temp_idx` still returns one
index, `FastXSGrid::lookup` still reads one grid, the GPU extractors still do an
exact label match, and nothing in the hot path knows interpolation happened.

The GPU needed exactly one predicate widened. Because the blend is materialised
on the host, both backends consume the same arrays by construction rather than
each running their own interpolation.

`available_temperatures` deliberately stays the file's own ladder. Adding the
synthesised label would make a later 500 K request bracket 450 to 600 rather
than 294 to 600, so the answer would depend on the order the queries arrived in.

## Deliberately not what OpenMC does

OpenMC uses the interpolation factor as a Bernoulli probability and picks one
bracketing set wholesale per lookup (`src/nuclide.cpp`,
`if (f > prn(...)) ++i_temp;`). That suits OpenMC, which shares one nuclide
across every cell and supports runtime temperature changes for multiphysics.

Here it would be a bias, not just added variance. Sampling sigma_t and then
sampling a flight from it is not the same as sampling a flight from the mean:
for a two-point pick with half-spread `delta`, uncollided transmission through
optical depth `tau` is inflated by `cosh(delta * tau)`. At 20 mfp and 5 percent
that is a 54 percent overestimate of transmitted flux, and more particles
converge on the wrong answer. Deep-penetration flux lives at cross section
minima, which is exactly where Doppler broadening moves things, so the spread at
the energies carrying the signal is not the small number a spectrum average
suggests. Fixed-source shielding is the whole use case here.

Consequence worth stating plainly, since CLAUDE.md names OpenMC as the floor:
this will not reproduce an OpenMC run bit for bit at an interpolated
temperature, and will differ from it statistically at the same T. That is a
chosen difference, not a defect.

## URR tables are borrowed, not blended

Band `k` at 294 K is not the same probability band as band `k` at 600 K, so an
elementwise average of two probability tables is not a distribution of anything.
The synthesised temperature borrows the nearer neighbour's table WHOLE.

Leaving it `None` is the natural implementation and is entirely silent: the
material path reads a missing table as "no unresolved range" and falls back to
the unshielded smooth total, so a 450 K U238 would lose all its self-shielding
between 20 and 150 keV, differing from BOTH neighbours by far more than any
interpolation error, with every existing test green. There is a test whose only
job is to assert it is not `None`.

## The interpolation variable is in one function

`temperature::blend_weight`. Linear in T, matching OpenMC. The `sqrt(T)`
argument is real (the Doppler width scales that way) and unsettled: a pointwise
comparison against NJOY-broadened data favours linear in T, but the resonance
integral cannot separate the two, and the metric that would (a self-shielded
capture rate, or k_eff in a heterogeneous problem) has not been run. Switching
is a one-line change there and nothing else in the tree computes a second
weight.

## Two caching bugs this surfaced

Both produced a load that looked right and served the wrong data, and both are
fixed here:

1. `LoadScope::covers` treats an unfiltered load as universal. True of every
   temperature the FILE carries, false of one it merely brackets, so a cached
   full-scope entry claimed to cover a 450 K request it did not carry.
   `get_or_load_nuclide` now also checks the entry's `loaded_temperatures`.
2. `get_or_load_nuclide` reloads at the UNION of the cached and requested
   scopes, and unioning a concrete temperature set with an unfiltered load gives
   `None`. The widened read was right about what to PARSE and had lost what to
   BUILD. It now synthesises any temperature the caller named that the reload
   did not produce, before caching, so a second material at the same temperature
   reuses the work.

## Tests

`crates/yamc-nuclide/tests/temperature_blend.rs` (12) and the `temperature`
module units (9) are fully hermetic and construct their input in memory. That is
not a shortcut: no vendored fixture is a multi-temperature Arrow directory, and
a test that reaches for the fetched cache self-skips and reports green. The
blend is arithmetic over two `FastXSGrid` values, so it is checked exactly, on a
cross section linear in both E and T so the answer has a closed form at every
union point, including the points only one source carries.

They cover: the union grid and its dedup epsilon, exactness at every union
point, weight 0 and 1 reproducing their own source, the rebuilt log lookup index
bracketing every grid point, refusing to blend differing channel sets, all five
indexed structures staying in step, the URR borrow, a threshold that MOVES
between temperatures, a channel only one temperature carries, and the
buffer-sharing invariant from #476 (a synthesised temperature must not
reintroduce a grid copy per reaction).

Also updated the tests that pinned the old behaviour. Three of them probed with
300 K or 500 K against fixtures that carry 250 through 2500, so their premise
was already wrong before this change: `test_selective_temperature_load_be9_300`
said "only 294 is available" of a file with six temperatures. Those probes moved
to 3000 K, which is genuinely out of range, and each gained a positive sibling.

Verified: `cargo test --workspace` 2260 passed 0 failed (plus `yamc-gpu` 216
passed, run separately); `pytest packages/yamc-core/tests/unit_tests` 999 passed
12 skipped; `cargo clippy --workspace --lib --bins --tests --examples -D
warnings` clean; stubs regenerated.

## Deferred, deliberately

- Converting `Material::resolve_temperature` and the three `macro_xs` entry
  points from panicking to returning `Result`. The module's convention is to
  panic (it already does on a load failure), and that change would touch the
  whole `yamc-materials` public surface plus every pyo3 wrapper. Orthogonal.
- The physics accuracy question. Every route to it needs the data cache or NJOY,
  so no test here attempts it rather than attempting it and skipping. A
  leave-one-out check against the fetched ladder (interpolate 294 to 900,
  compare against the file's own 600 K set) is the cheapest real evidence and is
  worth its own issue.

## Cost, worth knowing

A synthesised temperature is a real one, so it is paid for in memory. The union
grid is larger than either source (Fe56: 43702 points against 42037 and 41043),
and the two brackets stay resident. A 450 K U238 material holds roughly three
temperatures' worth where a 294 K one holds one. The trade is right, since the
cost is per nuclide-temperature at load and never per particle, but it should be
known rather than discovered.