### PR TITLE
Keep the builder's home out of the shipped binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,36 @@
+# Keep the builder's absolute paths out of the shipped binaries. cargo bakes
+# the registry path of every dependency into panic locations, so an unremapped
+# build leaks either the CI container layout or, for anything built by hand, a
+# developer's home directory. The whole home root is remapped rather than just
+# `.cargo`, because `.rustup` leaks too when the rust-src component is present.
+# `--remap-path-prefix` on a prefix that is not present is a no-op, so all three
+# runner layouts are listed rather than computed; cargo does not expand env vars
+# in `rustflags`.
+#
+# This does not hide dependency names or versions, and is not meant to:
+# THIRD-PARTY-LICENSES.html publishes both, by design, in every wheel.
+#
+# `/rustc/<hash>` paths are not remappable here. They are baked into the
+# precompiled std, so rewriting them would need -Zbuild-std on nightly. They
+# name the compiler commit and nothing about the machine.
+[build]
+rustflags = [
+    '--remap-path-prefix=/root=/build',
+    '--remap-path-prefix=/home/runner=/build',
+    '--remap-path-prefix=/Users/runner=/build',
+]
+
+# NOTE: cargo does not merge this with `[build].rustflags`; the target-specific
+# array wins outright. So the remaps above have to be repeated here, and this is
+# the target that matters most, because the committed wasm blobs are built by
+# hand and ship inside the wheel.
 [target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+rustflags = [
+    '--cfg', 'getrandom_backend="wasm_js"',
+    '--remap-path-prefix=/root=/build',
+    '--remap-path-prefix=/home/runner=/build',
+    '--remap-path-prefix=/Users/runner=/build',
+]
 
 [alias]
 # GPU tests share a process-global cubecl client, so they must run

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,15 @@
 # `/rustc/<hash>` paths are not remappable here. They are baked into the
 # precompiled std, so rewriting them would need -Zbuild-std on nightly. They
 # name the compiler commit and nothing about the machine.
+#
+# LANDMINE: a `RUSTFLAGS` env var REPLACES this block rather than adding to it,
+# so any job that sets one gets none of these remaps. Today that is `test-mpi`
+# and `stubs-typing`, both via `actions-rust-lang/setup-rust-toolchain`, which
+# defaults to `RUSTFLAGS=-D warnings`. Neither ships a binary, so nothing leaks
+# today. The four wheel jobs use `dtolnay/rust-toolchain`, which sets no
+# RUSTFLAGS, which is the only reason this works. Swap a wheel job to the other
+# action and the remap silently dies; `scripts/check_binary_paths.py` runs in
+# those jobs so that this is caught rather than shipped.
 [build]
 rustflags = [
     '--remap-path-prefix=/root=/build',

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -273,6 +273,16 @@ jobs:
               done
             fi
 
+      # `--remap-path-prefix` is a silent no-op when its prefix does not match,
+      # so a runner-image change that moves the home directory would quietly
+      # start shipping it. This is the step that notices. See
+      # `.cargo/config.toml` for the remaps and the script for what it ignores.
+      - name: The wheel must carry no builder paths
+        shell: bash
+        run: |
+          PY="$(command -v python3 || command -v python)"
+          "$PY" scripts/check_binary_paths.py packages/yamc-core/dist/*.whl
+
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -365,6 +375,16 @@ jobs:
       # pytest.ini has named this testpath since #533 and no job ran it, so the
       # suite and the heredoc were drifting apart with only the heredoc gating
       # anything (issue #535).
+      # `--remap-path-prefix` is a silent no-op when its prefix does not match,
+      # so a runner-image change that moves the home directory would quietly
+      # start shipping it. This is the step that notices. See
+      # `.cargo/config.toml` for the remaps and the script for what it ignores.
+      - name: The wheel must carry no builder paths
+        shell: bash
+        run: |
+          PY="$(command -v python3 || command -v python)"
+          "$PY" scripts/check_binary_paths.py packages/yani-core/dist/*.whl
+
       - name: The wheel must carry none of the transport stack
         shell: bash
         run: |
@@ -422,6 +442,16 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --features mesh,cad,gpu
 
+      # `--remap-path-prefix` is a silent no-op when its prefix does not match,
+      # so a runner-image change that moves the home directory would quietly
+      # start shipping it. This is the step that notices. See
+      # `.cargo/config.toml` for the remaps and the script for what it ignores.
+      - name: The wheel must carry no builder paths
+        shell: bash
+        run: |
+          PY="$(command -v python3 || command -v python)"
+          "$PY" scripts/check_binary_paths.py packages/yamc-core/dist/*.whl
+
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -461,6 +491,16 @@ jobs:
           working-directory: packages/yamc-core
           target: aarch64-apple-darwin
           args: --release --out dist --features mesh,cad,gpu
+
+      # `--remap-path-prefix` is a silent no-op when its prefix does not match,
+      # so a runner-image change that moves the home directory would quietly
+      # start shipping it. This is the step that notices. See
+      # `.cargo/config.toml` for the remaps and the script for what it ignores.
+      - name: The wheel must carry no builder paths
+        shell: bash
+        run: |
+          PY="$(command -v python3 || command -v python)"
+          "$PY" scripts/check_binary_paths.py packages/yamc-core/dist/*.whl
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/crates/yamc-plot/Cargo.toml
+++ b/crates/yamc-plot/Cargo.toml
@@ -19,6 +19,9 @@ crate-type = ["rlib"]
 default = []
 # Enables the mesh-geometry path inside build_interactive_html, which
 # embeds the yamt wasm blob into the saved viewer HTML. Only available
-# when the wasm files at `packages/yamc-core/python/yamc/_wasm/yamt_*` exist (CI builds
-# them via wasm-pack as part of the yamc-python build).
+# when the wasm files at `packages/yamc-core/python/yamc/_wasm/yamt_*`
+# exist. Those are committed, and built by hand: nothing in CI produces
+# them. See developer_info.md for the rebuild recipe, which matters
+# because a plain local build bakes the builder's absolute paths into
+# the blob and the blob ships in the wheel.
 mesh = []

--- a/docs/developer_info.md
+++ b/docs/developer_info.md
@@ -387,6 +387,48 @@ If the pre-commit hooks fail (e.g. due to a missing MPI installation) and you st
 git commit --no-verify -m "commit message"
 ```
 
+## Rebuilding the committed wasm blobs
+
+Three wasm binaries are committed under
+`packages/yamc-core/python/yamc/_wasm/` and ship inside the `yamc-core` wheel:
+
+| file | built from |
+| --- | --- |
+| `yamc_sim_bg.wasm` | `crates/yamc`, `--features wasm` (renamed from `yamc_bg.wasm`) |
+| `yamc_geo_bg.wasm` | `crates/yamc-geo` |
+| `yamt_bg.wasm` | `crates/yamt` |
+
+Nothing in CI produces them; they are built by hand and committed. `_export.py`
+base64-embeds `yamc_sim_bg.wasm` into every file `Model.to_html()` writes, so
+whatever is in the blob travels with each exported viewer.
+
+That is why the remaps in `.cargo/config.toml` list the CI layouts, and it is
+also why they do not help here: they cover `/root`, `/home/runner` and
+`/Users/runner`, not your home directory. Rebuilding on a workstation without
+the extra flag bakes your own path into the blob, which is how the currently
+committed ones came to carry one. So pass it:
+
+```bash
+export RUSTFLAGS="--remap-path-prefix=$HOME=/build"
+cd crates/yamc     && wasm-pack build --target web --features wasm
+cd ../yamc-geo     && wasm-pack build --target web
+cd ../yamt         && wasm-pack build --target web
+```
+
+Then copy the `pkg/` output into `packages/yamc-core/python/yamc/_wasm/`,
+renaming the `crates/yamc` pair to `yamc_sim*`, and check the result before
+committing:
+
+```bash
+python scripts/check_binary_paths.py packages/yamc-core/python/yamc/_wasm/*.wasm
+```
+
+Regenerate the `.js` glue alongside the `.wasm` in the same run. The two are a
+matched pair from one `wasm-bindgen` version, and the committed set is currently
+mismatched: two blobs came from `wasm-bindgen 0.2.108` and one from `0.2.121`,
+while `Cargo.lock` pins `0.2.125`. Rebuilding one without the other, or without
+running `ci-wasm.yml`'s browser test, is how that drift goes unnoticed.
+
 ## Releasing
 
 Two distributions are published from this repository, and they carry

--- a/scripts/check_binary_paths.py
+++ b/scripts/check_binary_paths.py
@@ -40,6 +40,22 @@ LEAKS = re.compile(rb"(/home/[A-Za-z0-9._-]+|/Users/[A-Za-z0-9._-]+|/root)/[A-Za
 # text we author.
 BINARY_SUFFIXES = (".so", ".pyd", ".dylib", ".wasm")
 
+# Members known to carry builder paths, with the issue that removes them.
+# These three wasm blobs are committed and built by hand, so the remaps in
+# `.cargo/config.toml` cannot reach them: those cover the CI runner layouts,
+# and a workstation's home is not one. Tracked in
+# https://github.com/fusion-neutronics/core/issues/16.
+#
+# Listing them here rather than skipping `.wasm` wholesale keeps the rest of the
+# coverage: a fourth blob, or a leak in the extension module itself, still
+# fails. And a member that appears here while being clean is also a failure, so
+# the list cannot quietly outlive the fix.
+KNOWN_DIRTY = {
+    "yamc/_wasm/yamc_geo_bg.wasm",
+    "yamc/_wasm/yamc_sim_bg.wasm",
+    "yamc/_wasm/yamt_bg.wasm",
+}
+
 
 def scan(name: str, blob: bytes) -> list[str]:
     """Return a deduplicated, truncated list of leaked paths in one blob."""
@@ -64,14 +80,25 @@ def check(path: Path) -> int:
 
     total = 0
     for name, blob in targets:
+        member = name.split("::", 1)[-1]
+        known = member in KNOWN_DIRTY
         leaks = scan(name, blob)
-        if leaks:
+
+        if leaks and known:
+            print(f"known (see issue 16): {member} carries {len(leaks)} path(s)")
+        elif leaks:
             total += len(leaks)
             print(f"::error::{name} carries {len(leaks)} builder path(s):")
             for leak in leaks[:10]:
                 print(f"    {leak}")
             if len(leaks) > 10:
                 print(f"    ... and {len(leaks) - 10} more")
+        elif known:
+            total += 1
+            print(
+                f"::error::{member} is listed in KNOWN_DIRTY and is now clean. "
+                "Remove it from the list rather than leaving a stale excuse."
+            )
         else:
             print(f"ok: {name}")
     return total
@@ -97,7 +124,8 @@ def main(argv: list[str]) -> int:
             "artifact was built by hand outside CI."
         )
         return 1
-    print(f"checked {len(paths)} file(s): no builder paths")
+    # "no new": a KNOWN_DIRTY member that leaked is reported above, not here.
+    print(f"checked {len(paths)} file(s): no new builder paths")
     return 0
 
 

--- a/scripts/check_binary_paths.py
+++ b/scripts/check_binary_paths.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Fail if a shipped binary carries the absolute path of the machine that built it.
+
+cargo bakes the registry path of every dependency into panic-location strings,
+so an unremapped build leaks either the CI container layout or, for anything
+built by hand, a developer's home directory. `.cargo/config.toml` remaps the
+three runner layouts to `/cargo`; this is the check that says the remap is
+actually taking effect, because a `--remap-path-prefix` whose prefix does not
+match is a silent no-op and the next toolchain or runner-image change could move
+the prefix without anything noticing.
+
+What this deliberately does NOT check:
+
+* Dependency names and versions. Those survive the remap as
+  `/cargo/registry/.../serde_json-1.0.151/src/read.rs`, and they are public by
+  design: THIRD-PARTY-LICENSES.html ships in every wheel and lists both.
+* `/rustc/<hash>` paths. Baked into the precompiled std, so removing them needs
+  -Zbuild-std on nightly. They name the compiler commit, not the machine.
+* Workspace-relative paths such as `crates/endf/src/urr.rs`. cargo emits those
+  relative already, so they name no machine.
+
+Usage:
+    python scripts/check_binary_paths.py dist/*.whl
+    python scripts/check_binary_paths.py path/to/some.wasm path/to/some.so
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+# A home directory, anyone's. `/root` is the manylinux container's, and the
+# reason the published wheels leak today; the other two are the GitHub-hosted
+# runner layouts. Trailing separator so `/rootfs` does not match `/root`.
+LEAKS = re.compile(rb"(/home/[A-Za-z0-9._-]+|/Users/[A-Za-z0-9._-]+|/root)/[A-Za-z0-9._/-]*")
+
+# Binary members worth scanning inside a wheel. Everything else in there is
+# text we author.
+BINARY_SUFFIXES = (".so", ".pyd", ".dylib", ".wasm")
+
+
+def scan(name: str, blob: bytes) -> list[str]:
+    """Return a deduplicated, truncated list of leaked paths in one blob."""
+    found = {m.group(0).decode("utf-8", "replace") for m in LEAKS.finditer(blob)}
+    return sorted(found)
+
+
+def check(path: Path) -> int:
+    """Report on one file. Returns the number of distinct leaks found."""
+    targets: list[tuple[str, bytes]] = []
+
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as zf:
+            for member in zf.namelist():
+                if member.endswith(BINARY_SUFFIXES):
+                    targets.append((f"{path.name}::{member}", zf.read(member)))
+        if not targets:
+            print(f"::error::{path.name} contains no binary members to check")
+            return 1
+    else:
+        targets.append((str(path), path.read_bytes()))
+
+    total = 0
+    for name, blob in targets:
+        leaks = scan(name, blob)
+        if leaks:
+            total += len(leaks)
+            print(f"::error::{name} carries {len(leaks)} builder path(s):")
+            for leak in leaks[:10]:
+                print(f"    {leak}")
+            if len(leaks) > 10:
+                print(f"    ... and {len(leaks) - 10} more")
+        else:
+            print(f"ok: {name}")
+    return total
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: check_binary_paths.py <file> [file ...]", file=sys.stderr)
+        return 2
+
+    paths = [Path(a) for a in argv]
+    missing = [p for p in paths if not p.is_file()]
+    if missing:
+        for p in missing:
+            print(f"::error::{p} is not a file")
+        return 2
+
+    total = sum(check(p) for p in paths)
+    if total:
+        print(
+            "::error::builder paths reached a shipped binary. Either the remaps "
+            "in .cargo/config.toml no longer match the build layout, or this "
+            "artifact was built by hand outside CI."
+        )
+        return 1
+    print(f"checked {len(paths)} file(s): no builder paths")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Step 4 of the packaging plan was "set abi3, strip, remap-path-prefix, verify with `strings`". Only abi3 was ever done. This does the remap and the verify, and records why `strip` is not here.

## What actually leaks

Measured on the published `yani-core` 0.13.0 wheel and the committed wasm blobs.

| artifact | builder paths | whose |
| --- | ---: | --- |
| `yani/_core.abi3.so` (published wheel) | 354 | `/root/.cargo/...`, the manylinux container |
| `_wasm/yamc_sim_bg.wasm` | 76 | **a workstation home directory** |
| `_wasm/yamc_geo_bg.wasm` | 9 | same |
| `_wasm/yamt_bg.wasm` | 7 | same, `.cargo` and `.rustup` both |

The `.so` case is untidy rather than sensitive. The wasm case is the real one: `_export.py:30` base64-embeds `yamc_sim_bg.wasm` into every file `Model.to_html()` writes, so a username travels with each exported viewer.

## The change

`.cargo/config.toml` remaps the three runner home roots to `/build`. Three details worth knowing:

- **The whole home root, not just `.cargo`.** `.rustup` leaks too wherever the rust-src component is present, which is how the wasm blobs picked up `/…/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs`.
- **Hardcoded rather than computed.** cargo does not expand env vars in `rustflags`, and a `--remap-path-prefix` whose prefix is absent is a no-op, so listing all three layouts costs nothing and needs no shell.
- **Repeated verbatim into the `wasm32` block.** cargo *replaces* `[build].rustflags` with `[target.<triple>].rustflags` rather than merging them, so without the duplication the wasm build, the target that matters most here, would get none of it.

`scripts/check_binary_paths.py` is the gate, wired into all four wheel jobs. A remap whose prefix stops matching is silent, so a runner-image change that moves the home directory would otherwise start shipping it again with nothing to notice.

## Two non-goals, stated so they are not mistaken for oversights

**Dependency names and versions are not hidden**, and are not meant to be. They survive as `/build/.cargo/registry/.../serde_json-1.0.151/src/read.rs`, and `THIRD-PARTY-LICENSES.html` already lists every crate and version in both wheels, as license compliance requires. Any argument about dependency-inventory disclosure is void.

**`/rustc/<hash>` paths are untouched.** They are baked into the precompiled std, so removing them needs `-Zbuild-std` on nightly. They name the compiler commit, not the machine.

## Why not `strip`

It came from the same line of that plan, and it does not belong with the rest. The `.so` carries 21,490 `.symtab` symbols while needing exactly one dynamic symbol, `PyInit__core`, and stripping would also cut 15.9% off the wheel. Against that:

- It is a half-measure. The 99 workspace `.rs` paths live in `.rodata`, which is allocated, so **stripping does not remove them**. `strings | grep crates/` still reconstructs the module tree afterwards.
- It costs `perf`. `docs/developer_info.md:304-328` profiles `--release` examples and criterion benches inherit `release`, so a workspace-wide `strip` de-symbolises our own profiling.
- It is not source protection. No source ships either way, the `.pyi` stubs name every public entry point on purpose, and pyo3 embeds all docstrings.

Nothing blocks it if we ever want it: no `ctypes`/`dlsym` anywhere, no `file!()`/`line!()`/`Location::caller`, all 22 `#[should_panic]` assert on message text only, no custom panic hook, and `nuclide_ptr_addr` is `Arc::as_ptr` with zero callers. Unwinding is safe because `.eh_frame`, `.eh_frame_hdr` and `.gcc_except_table` are all ALLOC, so `panic = "unwind"` is unaffected and panic messages keep their `file:line`. If adopted, `[tool.maturin] strip = true` is the only placement needing no other file edited, since `--profile` would collide with the existing `--release` gate.

## A false comment, fixed

`crates/yamc-plot/Cargo.toml` claimed CI builds the wasm blobs via wasm-pack as part of the yamc-python build. `grep -c wasm-pack .github/workflows/ci-python.yml` is **0**, and the home directories in the committed blobs are how we know they are hand-built. `developer_info.md` now carries the rebuild recipe, including the flag a local rebuild needs, because the config's runner prefixes cannot help there.

## Verification

`check_binary_paths.py` was run against three real inputs before wiring it up:

| input | result |
| --- | --- |
| published `yani_core-0.13.0` wheel | fails, 354 paths, exit 1 |
| committed `yamt_bg.wasm` | fails, 7 paths |
| a locally remapped release build | passes, exit 0 |

Also checked: the config parses and preserves the `getrandom_backend="wasm_js"` cfg, `cargo metadata` accepts it, `cargo check --release` compiles with the new flags, the four new CI steps parse as YAML, and the existing "every wheel build must be a release build" gate still passes.

Interpreter resolution in the new steps is `command -v python3 || command -v python`, because `macos-14` has no `python` alias and only the `windows` job runs `setup-python`.

## Not in this change

The committed blobs still carry those paths. They need one rebuild with the `.js` glue regenerated in the same run, because the committed set is already mismatched across three `wasm-bindgen` versions (0.2.108, 0.2.121, lock pins 0.2.125). That wants `ci-wasm.yml`'s browser test behind it, so it is filed separately.