### PR TITLE
Close eleven of the coverage gaps the value-comparison tests published

### DIFF
--- a/crates/yamc-convert/tests/section_values_fission.rs
+++ b/crates/yamc-convert/tests/section_values_fission.rs
@@ -6,7 +6,11 @@
 //! No arithmetic happens in `crates/yamc-convert/src/fission_nu.rs` at all, so
 //! every numeric assertion here is exact equality and a tolerance anywhere
 //! would only hide the wrong-slot and wrong-unit mistakes these tests exist to
-//! find.
+//! find. The one arithmetic step anywhere in the chain is upstream, the NPLY=2
+//! unit correction at `crates/endf/src/fission_energy.rs:132-138`, and nothing
+//! here reaches it: a test that tried was dropped because the guard does not
+//! gate the way its own comment says, which is its own issue rather than
+//! something to pin from here.
 //!
 //! Neither section is reachable through `entry::convert_neutron_transport`
 //! without NJOY, so both writers are called directly. That loses nothing:
@@ -19,13 +23,20 @@
 //! # Two kinds of input, and they are not interchangeable
 //!
 //! The first two tests are handed VENDORED evaluations, and are parity checks
-//! against them. The last three are handed inputs this file BUILDS BY HAND, and
-//! are not parity checks against anything: no vendored evaluation reaches those
-//! branches, so a constructed `IncidentNeutron` or `FissionEnergyRelease` is
-//! the only way to reach them at all. Each says so in its own doc comment, and
-//! each gives its constructed fields values that differ from every constant the
-//! writer might hard-code, because two fields that happen to be equal on a
-//! fixture cannot tell a copy from a constant.
+//! against them. Everything below the CONSTRUCTED INPUTS banner is handed input
+//! this file BUILDS BY HAND, and is a parity check against nothing: no vendored
+//! evaluation reaches those branches, so a constructed `IncidentNeutron`, a
+//! constructed `FissionEnergyRelease`, or a parsed `Material` with one
+//! coefficient replaced, is the only way to reach them at all. Each says so in
+//! its own doc comment, and each gives its constructed fields values that
+//! differ from every constant the writer might hard-code, because two fields
+//! that happen to be equal on a fixture cannot tell a copy from a constant.
+//!
+//! Two of them go further and pin behaviour that is not evaluation parity in
+//! any sense: which of two candidates the writer picks when an input carries
+//! both, where no evaluation carries both and there is no evaluated answer.
+//! Those two say in their own doc comments which part of what they assert is a
+//! fact about fission and which part is a choice being held still.
 
 mod section_values;
 use section_values::*;
@@ -437,6 +448,46 @@ const SENTINEL_PARTICLE: &str = "sentinel-particle";
 /// precursor and carries zero here, so zero is the constant to defend against.
 const SENTINEL_DECAY_RATE: f64 = 3.75e-3;
 
+/// The redundant MT 18 that stands beside the derived total in every
+/// constructed nuclide here.
+///
+/// Its ordinary PROMPT product is what a writer that fell back to
+/// `products.first()` would find, and its name, mode, decay rate and yield all
+/// differ from every sentinel below, so that fallback fails on four columns
+/// rather than passing unnoticed.
+fn constructed_redundant_mt18() -> endf::Reaction {
+    let mut mt18 = endf::Reaction::new(18);
+    mt18.redundant = true;
+    mt18.products.push(endf::Product {
+        name: "neutron".to_string(),
+        emission_mode: endf::EmissionMode::Prompt,
+        decay_rate: 0.0,
+        yield_: Yield::Tabulated(Tabulated1D::new(vec![1.0e-5, 2.0e7], vec![2.41, 4.20])),
+        ..Default::default()
+    });
+    mt18
+}
+
+/// A derived total-nu product carrying the four fields `write_total_nu` copies.
+///
+/// Every other field is left at its default, because the writer reads no other
+/// field: `fission_nu.rs:43-76` touches `name`, `emission_mode`, `decay_rate`
+/// and `yield_` and nothing else.
+fn constructed_total(
+    name: &str,
+    emission_mode: endf::EmissionMode,
+    decay_rate: f64,
+    yield_: Yield,
+) -> endf::Product {
+    endf::Product {
+        name: name.to_string(),
+        emission_mode,
+        decay_rate,
+        yield_,
+        ..Default::default()
+    }
+}
+
 /// A fissionable `IncidentNeutron` built by hand, with a derived total nu-bar
 /// on `fission_mt`.
 ///
@@ -451,25 +502,16 @@ const SENTINEL_DECAY_RATE: f64 = 3.75e-3;
 /// MT 18 prompt product, whose fields differ from the sentinel ones on every
 /// column below.
 fn constructed_fissile_nuclide(fission_mt: i32, total_yield: Yield) -> endf::IncidentNeutron {
-    let mut mt18 = endf::Reaction::new(18);
-    mt18.redundant = true;
-    mt18.products.push(endf::Product {
-        name: "neutron".to_string(),
-        emission_mode: endf::EmissionMode::Prompt,
-        decay_rate: 0.0,
-        yield_: Yield::Tabulated(Tabulated1D::new(vec![1.0e-5, 2.0e7], vec![2.41, 4.20])),
-        ..Default::default()
-    });
+    let mut mt18 = constructed_redundant_mt18();
 
-    let total = endf::Product {
-        name: SENTINEL_PARTICLE.to_string(),
-        // Neither "total" (what the section is for) nor "prompt" (what #364
-        // wrote instead), so a writer that hard-codes either one fails.
-        emission_mode: endf::EmissionMode::Delayed,
-        decay_rate: SENTINEL_DECAY_RATE,
-        yield_: total_yield,
-        ..Default::default()
-    };
+    // Neither "total" (what the section is for) nor "prompt" (what #364 wrote
+    // instead), so a writer that hard-codes either one fails.
+    let total = constructed_total(
+        SENTINEL_PARTICLE,
+        endf::EmissionMode::Delayed,
+        SENTINEL_DECAY_RATE,
+        total_yield,
+    );
 
     let mut data = endf::IncidentNeutron::new(92, 240, 0);
     if fission_mt == 18 {
@@ -688,4 +730,301 @@ fn a_polynomial_release_term_with_no_coefficients_is_refused() {
             "{role}: the refusal must leave no half-written section behind"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Which of two candidates the writer picks.
+//
+// `write_total_nu` makes two tie-breaks that no vendored evaluation ever puts
+// to the test, because the parser attaches at most one derived product to at
+// most one fission reaction: `fission_products_ace` pushes a single total
+// (`reaction.rs:817-853`) and the ENDF route does the same
+// (`reaction.rs:406-435`). Both are reachable only from a constructed nuclide,
+// and neither is a parity claim.
+// ---------------------------------------------------------------------------
+
+/// With two derived products on one fission reaction, the FIRST one is written.
+///
+/// CONSTRUCTED INPUT, and this test pins a CHOICE rather than a fact. No parser
+/// path produces two derived products on a reaction, so there is no evaluated
+/// answer to "which of two totals is this nuclide's nu-bar" and none is being
+/// claimed. What is not arbitrary is that the writer be deterministic about it
+/// and not change its mind silently: `derived_products.first()`
+/// (`fission_nu.rs:38`) is the behaviour, and replacing it with `.last()` is
+/// invisible to every other test in the workspace.
+///
+/// Both orderings are built and the assertion in each is that the FRONT product
+/// won, which is what makes this more than a restatement of `.first()`. A
+/// writer that picked by `emission_mode == Total`, or by "the one with a
+/// tabulated yield", satisfies one ordering and fails the other. The two
+/// products differ on all four columns compared, so a failure names the column.
+#[test]
+fn total_nu_takes_the_first_derived_product_when_a_reaction_carries_two() {
+    // A tabulated total against a polynomial one, so `yield_type` separates
+    // them as well as the three scalar columns do.
+    let tabulated = || {
+        constructed_total(
+            "first-of-two-totals",
+            endf::EmissionMode::Total,
+            1.25e-2,
+            Yield::Tabulated(Tabulated1D::new(vec![1.0e-5, 2.0e7], vec![2.44, 4.55])),
+        )
+    };
+    let polynomial = || {
+        constructed_total(
+            "second-of-two-totals",
+            endf::EmissionMode::Delayed,
+            7.5e-2,
+            Yield::Polynomial(Polynomial::new(vec![9.99, -8.88])),
+        )
+    };
+
+    for (label, front, back, front_yield_type) in [
+        (
+            "a Total ahead of a Delayed",
+            tabulated(),
+            polynomial(),
+            "Tabulated1D",
+        ),
+        (
+            "a Delayed ahead of a Total",
+            polynomial(),
+            tabulated(),
+            "Polynomial",
+        ),
+    ] {
+        // Read off before the product is moved into the reaction, so the
+        // expectation is the front product's own fields and not a transcription.
+        let (name, mode, decay_rate) = (
+            front.name.clone(),
+            front.emission_mode.name(),
+            front.decay_rate,
+        );
+
+        let mut mt18 = constructed_redundant_mt18();
+        mt18.derived_products.push(front);
+        mt18.derived_products.push(back);
+        let mut data = endf::IncidentNeutron::new(92, 240, 0);
+        data.reactions.insert(18, mt18);
+
+        let dir = scratch();
+        assert!(
+            yamc_convert::fission_nu::write_total_nu(&data, dir.path()).expect("the writer runs"),
+            "{label}: a derived total is present, so a nu-bar must be written"
+        );
+        let batch = section(dir.path(), "total_nu.arrow");
+        assert_eq!(
+            batch.num_rows(),
+            1,
+            "{label}: total_nu.arrow is one row per nuclide, so the second derived \
+             product is dropped rather than written as a second row the reader \
+             would never look at"
+        );
+
+        assert_eq!(
+            str_at(&batch, "particle", 0),
+            name,
+            "{label}: the written particle is not the front product's"
+        );
+        assert_eq!(
+            str_at(&batch, "emission_mode", 0),
+            mode,
+            "{label}: the written emission_mode is not the front product's"
+        );
+        assert_eq!(
+            f64_at(&batch, "decay_rate", 0),
+            decay_rate,
+            "{label}: the written decay_rate is not the front product's"
+        );
+        assert_eq!(
+            str_at(&batch, "yield_type", 0),
+            front_yield_type,
+            "{label}: the written yield is not the front product's"
+        );
+    }
+}
+
+/// With a derived total on MT 18 AND on MT 19, MT 18 is the one written.
+///
+/// CONSTRUCTED INPUT: the parser attaches the NU block to exactly one reaction,
+/// so no evaluation carries a derived total on two fission MTs at once, and
+/// `find_map` over `FISSION_MTS` (`fission_nu.rs:35`) never has to break a tie.
+/// Iterating that list backwards passes every other test in this file, because
+/// every other nuclide here has its total on exactly one MT.
+///
+/// Unlike the two-derived-products tie above, this one pins a FACT and not just
+/// a choice. MT 18 is total fission and MTs 19, 20, 21 and 38 are its first-,
+/// second-, third- and fourth-chance partials, so where MT 18 has a total
+/// nu-bar it is the nuclide's, and the one-row section holds the nuclide's.
+/// Writing the first-chance nu-bar in its place would be low wherever
+/// second-chance fission contributes, which for a fusion source is exactly the
+/// energies that matter, and nothing on disk would say so.
+#[test]
+fn total_nu_prefers_mt_18_when_two_fission_mts_carry_a_total() {
+    let mut mt18 = constructed_redundant_mt18();
+    mt18.derived_products.push(constructed_total(
+        "mt18-total-fission",
+        endf::EmissionMode::Total,
+        1.0e-3,
+        Yield::Tabulated(Tabulated1D::new(vec![1.0e-5, 2.0e7], vec![2.44, 4.55])),
+    ));
+
+    let mut mt19 = endf::Reaction::new(19);
+    mt19.derived_products.push(constructed_total(
+        "mt19-first-chance",
+        endf::EmissionMode::Delayed,
+        2.0e-3,
+        Yield::Polynomial(Polynomial::new(vec![9.99, -8.88])),
+    ));
+
+    let mut data = endf::IncidentNeutron::new(92, 240, 0);
+    data.reactions.insert(18, mt18);
+    data.reactions.insert(19, mt19);
+
+    let dir = scratch();
+    assert!(
+        yamc_convert::fission_nu::write_total_nu(&data, dir.path()).expect("the writer runs"),
+        "both fission MTs carry a derived total, so one of them must be written"
+    );
+    let batch = section(dir.path(), "total_nu.arrow");
+    assert_eq!(batch.num_rows(), 1);
+
+    assert_eq!(
+        str_at(&batch, "particle", 0),
+        "mt18-total-fission",
+        "the written nu-bar is MT 19's first-chance total, not MT 18's"
+    );
+    assert_eq!(str_at(&batch, "emission_mode", 0), "total");
+    assert_eq!(f64_at(&batch, "decay_rate", 0), 1.0e-3);
+    assert_eq!(str_at(&batch, "yield_type", 0), "Tabulated1D");
+}
+
+/// A multi-region tabulated release term is never silently truncated to one
+/// region.
+///
+/// CONSTRUCTED INPUT. Every vendored EGP tabulation is a single linear-linear
+/// region (U235's is `[2]` and `[18]`), so `t.interpolation.clone()` and
+/// `vec![t.interpolation[0]]` write the same bytes there, and so do the two
+/// forms of the breakpoint copy.
+///
+/// This is the one place in the file where the writer's current behaviour is
+/// arguably wrong, so the test says what it is doing. The writer copies both
+/// region lists through, and the reader then refuses the file it produced:
+/// `ReleaseFunction::from_tabulated` (`crates/yamc-nuclide/src/fission_photon.rs:66-73`)
+/// errors on `interpolation.len() > 1 || breakpoints.len() > 1`. This input
+/// therefore has no outcome that is both written and loadable, which is the
+/// asymmetric validation this pull request reports: the writer refuses an empty
+/// polynomial because the reader refuses one, and applies no equivalent check
+/// to a tabulated term.
+///
+/// So the assertion is the invariant rather than today's return value. The
+/// writer either refuses the term, naming it and leaving no file, or copies
+/// both region lists whole; adding the missing refusal is then a passing change
+/// rather than a spurious failure. What both arms rule out is the third
+/// outcome, and it is the dangerous one: truncating to the first region turns a
+/// file the reader REFUSES into a file the reader ACCEPTS, evaluating a
+/// histogram tail as linear-linear with nothing on disk to say so. That is the
+/// #369 class of error the reader's refusal exists to prevent. Neither arm is
+/// vacuous, and a writer that simply always failed would be caught by
+/// `fission_photon_carries_both_release_terms_in_their_own_forms` above.
+#[test]
+fn a_multi_region_release_table_is_never_silently_truncated_to_one_region() {
+    // Two regions of different widths and different schemes: linear-linear to
+    // the second point, histogram to the fourth. Truncating either list to its
+    // first element therefore loses a value that differs from the one kept.
+    let x = vec![1.0e-5, 1.0e3, 1.0e6, 3.0e7];
+    let y = vec![6.60e6, 6.81e6, 7.42e6, 1.023e7];
+    let breakpoints = vec![2, 4];
+    let interpolation = vec![2, 1];
+    let release = constructed_release(
+        Component::Tabulated(Tabulated1D::with_regions(
+            x.clone(),
+            y.clone(),
+            breakpoints.clone(),
+            interpolation.clone(),
+        )),
+        Component::Polynomial(Polynomial::new(vec![6.33e6, -0.075])),
+    );
+
+    let dir = scratch();
+    match yamc_convert::fission_nu::write_fission_photon(&release, dir.path()) {
+        Ok(()) => {
+            let batch = section(dir.path(), "fission_photon.arrow");
+            assert_eq!(str_at(&batch, "kind", 0), "tabulated");
+            assert_f64_slice_eq("prompt_photons x", &f64_list(&batch, "x", 0), &x);
+            assert_f64_slice_eq("prompt_photons y", &f64_list(&batch, "y", 0), &y);
+            assert_i32_slice_eq(
+                "prompt_photons interpolation",
+                &i32_list(&batch, "interpolation", 0),
+                &interpolation,
+            );
+            assert_i32_slice_eq(
+                "prompt_photons breakpoints",
+                &i32_list(&batch, "breakpoints", 0),
+                &breakpoints,
+            );
+        }
+        Err(error) => {
+            let message = error.to_string();
+            assert!(
+                message.contains("prompt_photons"),
+                "a refusal must name the term it refused, got: {message}"
+            );
+            assert!(
+                absent(dir.path(), "fission_photon.arrow"),
+                "a refusal must leave no half-written section behind"
+            );
+        }
+    }
+}
+
+/// Neither writer reports success for a section it could not write.
+///
+/// CONSTRUCTED INPUT, and a constructed destination: every other call in this
+/// file writes into a scratch directory that exists, so nothing here or
+/// anywhere else in the workspace exercises the `?` on `write_section`. The
+/// directory named below is never created, so `File::create`
+/// (`sections.rs:45`) fails with `NotFound` on every platform, with no `chmod`
+/// and no assumption about who the test runs as.
+///
+/// What that defends. `write_total_nu` returns a bool the caller writes into
+/// the manifest, so a swallowed error there means `entry.rs` records a
+/// `total_nu.arrow` that is not on disk, and the reader then falls back to the
+/// PROMPT yield, which is issue #364 arriving by a different route. A swallowed
+/// error in `write_fission_photon` loses the delayed photon scaling the same
+/// way. Both are silent: the conversion reports success and the wrong numbers
+/// turn up in a transport result.
+#[test]
+fn neither_writer_reports_success_for_a_section_it_could_not_write() {
+    let dir = scratch();
+    let missing = dir.path().join("this-directory-is-never-created");
+    assert!(!missing.exists(), "the destination must not exist");
+
+    let data =
+        constructed_fissile_nuclide(18, Yield::Polynomial(Polynomial::new(vec![2.44, 0.01])));
+    let error = yamc_convert::fission_nu::write_total_nu(&data, &missing)
+        .expect_err("write_total_nu must report a directory it cannot write into");
+    assert_eq!(
+        error
+            .downcast_ref::<std::io::Error>()
+            .map(std::io::Error::kind),
+        Some(std::io::ErrorKind::NotFound),
+        "the failure must be the IO one, not something further down: {error}"
+    );
+    assert!(absent(&missing, "total_nu.arrow"));
+
+    let release = constructed_release(
+        Component::Polynomial(Polynomial::new(vec![6.33e6, -0.075])),
+        Component::Polynomial(Polynomial::new(vec![5.11e6, -0.081])),
+    );
+    let error = yamc_convert::fission_nu::write_fission_photon(&release, &missing)
+        .expect_err("write_fission_photon must report a directory it cannot write into");
+    assert_eq!(
+        error
+            .downcast_ref::<std::io::Error>()
+            .map(std::io::Error::kind),
+        Some(std::io::ErrorKind::NotFound),
+        "the failure must be the IO one, not the empty-polynomial refusal: {error}"
+    );
+    assert!(absent(&missing, "fission_photon.arrow"));
 }

--- a/crates/yamc-convert/tests/section_values_neutron.rs
+++ b/crates/yamc-convert/tests/section_values_neutron.rs
@@ -15,17 +15,28 @@
 //! `synthetic-urr.ace.xz`, the only vendored input that reaches
 //! `write_urr`'s write branch at all.
 //!
-//! Three of the eleven tests are built from a HAND-CONSTRUCTED
+//! Six of the fourteen tests are built from a HAND-CONSTRUCTED
 //! `IncidentNeutron` rather than from a parsed evaluation, and their names all
 //! begin with `constructed_`. They exist because of what the vendored bytes
-//! cannot say: every vendored neutron evaluation carries at most ONE
-//! temperature, and the single one that carries unresolved resonance tables
-//! carries a single row whose scalar columns are all equal to each other or to
-//! a constant. A writer that swapped two of those columns, or that ignored a
-//! parsed field and wrote a literal in its place, passes every test built from
-//! vendored bytes. The constructed inputs give those fields deliberately
-//! DIFFERENT values, which is the only thing that separates them. They are not
-//! evaluation parity and nothing in them should be read as such.
+//! cannot say:
+//!
+//! * every vendored neutron evaluation carries at most ONE temperature, so
+//!   `temperatures`, `energy_temperatures` and `xs_temperatures` are one
+//!   element lists with no permutation to catch;
+//! * the single one that carries unresolved resonance tables carries a single
+//!   row whose scalar columns are all equal to each other or to a constant;
+//! * Li6 carries its OWN MT 1 and MT 101, and the ENDF route synthesizes
+//!   nothing at all, so no vendored route writes a synthesized MT 1 or MT 101
+//!   with a number in it;
+//! * no vendored reaction has more than one cross section at a temperature
+//!   outside `temperatures()`, so the extras phase has no order to get wrong.
+//!
+//! A writer that swapped two of those columns, that ignored a parsed field and
+//! wrote a literal in its place, or that dropped a term from a sum whose other
+//! terms Li6 happens not to carry, passes every test built from vendored bytes.
+//! The constructed inputs give those fields deliberately DIFFERENT values,
+//! which is the only thing that separates them. They are not evaluation parity
+//! and nothing in them should be read as such.
 
 mod section_values;
 
@@ -602,6 +613,13 @@ fn reaction_flags_are_the_parsed_reactions_own_flags() {
     // earns its place because `redundant = true` is what keeps a synthesized
     // row out of the sums (reactions.rs:43-45): changing the literal changes
     // the arithmetic of every row above it.
+    //
+    // One of the three is no longer only a pin:
+    // `constructed_synthesized_rows_are_redundant_so_the_rest_sum_to_the_total`
+    // checks `redundant` against the rule a consumer applies to it rather than
+    // against a copy of the literal. `Q_value` and `center_of_mass` are still
+    // transcriptions here and there, and a synthesized sum has no products, so
+    // there is nothing downstream that reads either one to check them by.
     for mt in [3, 4, 27] {
         let row = mt_rows[&mt];
         assert_eq!(f64_at(&batch, "Q_value", row), 0.0, "MT {mt} Q value");
@@ -686,6 +704,12 @@ fn reaction_cross_sections_are_the_parsed_curves_unshifted() {
 /// removed: MT 3 is pinned EXACTLY against those same partial rows a few lines
 /// above, so that assertion could only ever fail on a property of the
 /// evaluation's own seven digit ACE columns, never on a converter defect.
+///
+/// Two of the five synthesized MTs are not reached here at all. Li6 carries its
+/// own MT 1 and its own MT 101, so those two rows are copies of the
+/// evaluation's columns and the values the writer synthesized for them are
+/// discarded. Both are checked on a constructed input in
+/// `constructed_partials_pin_synthesized_mt_101_and_the_mt_3_term_of_mt_1`.
 #[test]
 fn the_synthesized_rows_are_the_sum_of_the_rows_beside_them() {
     let data = li6_ace();
@@ -745,18 +769,25 @@ fn the_synthesized_rows_are_the_sum_of_the_rows_beside_them() {
     // while MT 27 is synthesized as the sum of MT 102, and on this fixture the
     // two are bit identical. So this pins the synthesized absorption against a
     // column the evaluation stored itself. It says nothing about a SYNTHESIZED
-    // MT 101, which nothing in this file reaches: MT 101 is parsed on the ACE
-    // route and empty on the ENDF route. If a future fixture or parser change
-    // breaks the bit equality, 1e-6 relative is the honest fallback rather
-    // than deleting the check.
+    // MT 101, which no VENDORED route in this file reaches: MT 101 is parsed on
+    // the ACE route and empty on the ENDF route. The synthesized row is checked
+    // in
+    // `constructed_partials_pin_synthesized_mt_101_and_the_mt_3_term_of_mt_1`,
+    // on a hand-built nuclide with two disappearance channels rather than
+    // Li6's one. If a future fixture or parser change breaks the bit equality
+    // below, 1e-6 relative is the honest fallback rather than deleting the
+    // check.
     assert_f64_slice_eq("MT 101 against MT 27", &written(101), &written(27));
 }
 
 /// A failure means the writer changed how it handles an evaluation with no
-/// nuclide grid. This is still the only case in this file, vendored or
-/// constructed, where `xs_temperatures` comes from the extras branch at
-/// reactions.rs:87 rather than from the filtered list at :82-86: here
-/// `temperatures()` is empty and the "0K" key comes entirely from `rx.xs`.
+/// nuclide grid. It is the only VENDORED case where `xs_temperatures` comes
+/// from the extras branch at reactions.rs:87 rather than from the filtered list
+/// at :82-86, and the only case anywhere in this file where the filtered list
+/// is EMPTY: `temperatures()` has no entries and the "0K" key comes entirely
+/// from `rx.xs`. With one extra key there is no order to check, which is what
+/// `constructed_extra_temperatures_follow_the_processed_ones_in_map_order`
+/// adds beside it.
 ///
 /// It also pins what the writer actually does with the synthesized MTs on this
 /// route, which is NOT "write no row": `n_energy` is 0 at every temperature so
@@ -1220,5 +1251,387 @@ fn constructed_two_temperature_reactions_keep_each_curve_with_its_own_temperatur
         "MT 1 xs_threshold_idx",
         &i32_list(&batch, "xs_threshold_idx", row),
         &[0, 0],
+    );
+}
+
+/// A hand-built nuclide carrying a NON-ELASTIC partial in every summation
+/// group the synthesized rows are built from.
+///
+/// Parsed from nothing. One temperature, a four point grid and six reactions
+/// whose cross sections are distinct powers of two, so every subset sum is a
+/// different number and a synthesized row built from the wrong set cannot land
+/// on the right value by accident. Three of the six start above the bottom of
+/// the grid, at two different thresholds, so a partial laid on the grid at the
+/// wrong offset changes the sums as well.
+///
+/// What each channel is here for, and what it looks like on the grid:
+///
+/// * MT 2, elastic, `[1, 1, 1, 1]`. The one channel MT 3 excludes, and the
+///   term MT 1 adds to MT 3.
+/// * MT 16, (n,2n), `[0, 0, 2, 2]`. Neutron emitting and not level inelastic,
+///   so it enters MT 3 and nothing else.
+/// * MT 51, first inelastic level, `[0, 4, 4, 4]`. The only term of MT 4.
+/// * MT 102, capture, `[8, 8, 8, 8]`, and MT 103, (n,p), `[0, 0, 16, 16]`.
+///   Both disappearance, so MT 101 is their sum.
+/// * MT 18, fission, `[0, 0, 32, 32]`. Reaches MT 27 and MT 3 through the
+///   fission term and nothing else.
+///
+/// No vendored neutron evaluation has this shape. Li6 carries no MT 16, no
+/// MT 18 and no MT 103, and it carries its OWN MT 1 and MT 101, so on the only
+/// fixture that reaches these rows with real numbers MT 1 and MT 101 are
+/// parsed columns rather than synthesized ones. The numbers here are invented.
+fn multi_channel_nuclide() -> IncidentNeutron {
+    let mut data = IncidentNeutron::new(26, 56, 0);
+    data.k_ts = vec![k_t(294.0)];
+    data.energy
+        .insert("294K".to_string(), vec![1.0, 2.0, 3.0, 4.0]);
+    for (mt, x, y, threshold) in [
+        (2, vec![1.0, 2.0, 3.0, 4.0], vec![1.0; 4], 0),
+        (16, vec![3.0, 4.0], vec![2.0; 2], 2),
+        (18, vec![3.0, 4.0], vec![32.0; 2], 2),
+        (51, vec![2.0, 3.0, 4.0], vec![4.0; 3], 1),
+        (102, vec![1.0, 2.0, 3.0, 4.0], vec![8.0; 4], 0),
+        (103, vec![3.0, 4.0], vec![16.0; 2], 2),
+    ] {
+        let mut rx = Reaction::new(mt);
+        rx.xs
+            .insert("294K".to_string(), partial_xs(x, y, threshold));
+        data.reactions.insert(mt, rx);
+    }
+    data
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. The synthesized MT 101 row, and the
+/// MT 3 term of the synthesized MT 1 row.
+///
+/// No vendored evaluation reaches either. Li6 ACE carries its own MT 1 and its
+/// own MT 101 in the ESZ block, so both rows are PARSED there and the
+/// synthesized values are computed and thrown away; the ENDF route has no
+/// nuclide grid, so it synthesizes nothing and writes those rows empty; and the
+/// only other constructed nuclide in this file has elastic alone, which makes
+/// its MT 3 identically zero and its MT 101 all zeros. Against all three, a
+/// writer that dropped a channel from the disappearance sum, or dropped the
+/// `add(&mut mt1, &mt3)` term of MT 1 entirely, stays green. So the input here
+/// is built by hand with a partial in every group. The numbers are invented and
+/// nothing below is parity with any evaluation.
+///
+/// Every expected row is written out as a literal, computed by hand from the
+/// table in `multi_channel_nuclide`, and then again as a sum of the file's own
+/// partial rows. The literals are the part that does not go through the writer.
+#[test]
+fn constructed_partials_pin_synthesized_mt_101_and_the_mt_3_term_of_mt_1() {
+    let data = multi_channel_nuclide();
+    assert_eq!(data.temperatures(), vec!["294K".to_string()]);
+    for mt in [1, 3, 4, 27, 101] {
+        assert!(
+            !data.reactions.contains_key(&mt),
+            "MT {mt} must be absent from the input or the writer copies it \
+             instead of synthesizing it"
+        );
+    }
+
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+    let n = data.energy["294K"].len();
+    assert_eq!(n, 4);
+
+    let on_grid = |mt: i32| written_on_grid(&batch, &mt_rows, mt, n);
+    let sum = |mts: &[i32]| -> Vec<f64> {
+        let mut acc = vec![0.0; n];
+        for &mt in mts {
+            for (a, b) in acc.iter_mut().zip(on_grid(mt)) {
+                *a += b;
+            }
+        }
+        acc
+    };
+
+    assert_eq!(
+        written_mts(&batch),
+        vec![2, 16, 18, 51, 102, 103, 1, 3, 4, 27, 101],
+        "the parsed reactions then the five synthesized MTs, none of which the \
+         input carries"
+    );
+
+    // The partials first, so a failure in the sums below cannot be blamed on
+    // the rows they are summed from. Every value is a small integer, so every
+    // sum in this test is exact in f64 whatever order it is taken in.
+    assert_f64_slice_eq("MT 2", &on_grid(2), &[1.0, 1.0, 1.0, 1.0]);
+    assert_f64_slice_eq("MT 16", &on_grid(16), &[0.0, 0.0, 2.0, 2.0]);
+    assert_f64_slice_eq("MT 18", &on_grid(18), &[0.0, 0.0, 32.0, 32.0]);
+    assert_f64_slice_eq("MT 51", &on_grid(51), &[0.0, 4.0, 4.0, 4.0]);
+    assert_f64_slice_eq("MT 102", &on_grid(102), &[8.0, 8.0, 8.0, 8.0]);
+    assert_f64_slice_eq("MT 103", &on_grid(103), &[0.0, 0.0, 16.0, 16.0]);
+
+    // THE SYNTHESIZED DISAPPEARANCE ROW. Capture plus (n,p), and neither one
+    // alone: 8 is MT 102 by itself and 16 is MT 103 by itself, so a sum missing
+    // either term is a different number at every point above the (n,p)
+    // threshold. Li6 has no MT 103 at all, which is why a disappearance set
+    // that lost it passes every other test here.
+    assert_f64_slice_eq("MT 101", &on_grid(101), &[8.0, 8.0, 24.0, 24.0]);
+    assert_f64_slice_eq(
+        "MT 101 against MT 102 + MT 103",
+        &on_grid(101),
+        &sum(&[102, 103]),
+    );
+
+    // MT 4 is the level inelastic sum and MT 27 is fission plus disappearance.
+    assert_f64_slice_eq("MT 4", &on_grid(4), &[0.0, 4.0, 4.0, 4.0]);
+    assert_f64_slice_eq("MT 4 against MT 51", &on_grid(4), &sum(&[51]));
+    assert_f64_slice_eq("MT 27", &on_grid(27), &[8.0, 8.0, 56.0, 56.0]);
+    assert_f64_slice_eq(
+        "MT 27 against MT 18 + MT 101",
+        &on_grid(27),
+        &sum(&[18, 101]),
+    );
+
+    // MT 3 is everything but elastic: the neutron emitting channels, plus
+    // fission, plus disappearance.
+    assert_f64_slice_eq("MT 3", &on_grid(3), &[8.0, 12.0, 62.0, 62.0]);
+    assert_f64_slice_eq(
+        "MT 3 against its partials",
+        &on_grid(3),
+        &sum(&[16, 18, 51, 102, 103]),
+    );
+
+    // THE MT 3 TERM OF MT 1. Elastic is 1 barn flat, so a writer that wrote
+    // MT 1 as elastic alone gets [1, 1, 1, 1] and this fires at index 0. On
+    // Li6 the same defect is invisible because MT 1 is the evaluation's own
+    // column, and on an elastic-only nuclide it is invisible because MT 3 is
+    // zero.
+    assert_f64_slice_eq("MT 1", &on_grid(1), &[9.0, 13.0, 63.0, 63.0]);
+    assert_f64_slice_eq("MT 1 against MT 2 + MT 3", &on_grid(1), &sum(&[2, 3]));
+    assert_ne!(
+        on_grid(3),
+        vec![0.0; n],
+        "MT 3 must be non-zero or MT 1 cannot show that it added it"
+    );
+
+    // No two synthesized rows are equal, so a row copied from its neighbour is
+    // visible. Without this the pairs (MT 27, MT 101) and (MT 3, MT 4) are the
+    // easy mistakes to make, and on a nuclide with no fission MT 27 and MT 101
+    // are identical.
+    let synthesized: Vec<(i32, Vec<f64>)> = [1, 3, 4, 27, 101]
+        .into_iter()
+        .map(|mt| (mt, on_grid(mt)))
+        .collect();
+    for (i, (mt, xs)) in synthesized.iter().enumerate() {
+        for (other, other_xs) in &synthesized[i + 1..] {
+            assert_ne!(
+                xs, other_xs,
+                "MT {mt} and MT {other} hold the same curve, so a copy between \
+                 them would pass"
+            );
+        }
+        // Each one spans the whole grid from index 0, whatever its partials'
+        // thresholds were.
+        assert_i32_slice_eq(
+            &format!("MT {mt} xs_threshold_idx"),
+            &i32_list(&batch, "xs_threshold_idx", mt_rows[mt]),
+            &[0],
+        );
+        assert_eq!(
+            nested_f64_list(&batch, "xs_values", mt_rows[mt])[0].len(),
+            n,
+            "MT {mt} is not defined on the whole grid"
+        );
+    }
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. `redundant = true` on a synthesized
+/// row, checked by the rule a consumer applies to that column rather than by
+/// transcribing the literal.
+///
+/// The three synthesized rows on Li6 (MT 3, 4 and 27) have no parsed side, so
+/// `reaction_flags_are_the_parsed_reactions_own_flags` can only compare the
+/// writer's literals at reactions.rs:130-132 against a copy of them, and says
+/// so. This test replaces the copy for ONE of the three columns. A consumer
+/// with no fast_xs grid reconstructs the total by summing every reaction whose
+/// `redundant` flag is false (yamc-gpu `total_xs_at`,
+/// crates/yamc-gpu/src/neutron/xs/extract.rs:151-163, and the same guard on the
+/// scattering sum at crates/yamc-nuclide/src/nuclide/sampling.rs:499). On this
+/// input that sum must come out as the MT 1 row exactly, and it does so only
+/// because the five synthesized rows are excluded from it. A writer that
+/// flagged them `false` makes the consumer count MT 3, 4, 27 and 101 a second
+/// time, and the assertion below fires whether or not the transcription
+/// elsewhere in this file was changed to match.
+///
+/// No vendored evaluation reaches this. It needs a nuclide whose parsed rows
+/// are all non-redundant and partition the total, which Li6 is not: its MT 1,
+/// MT 101 and MT 203 to 207 are parsed AND redundant, so the same sum there is
+/// a statement about the evaluation rather than about the writer's literal.
+///
+/// Still a transcription after this, and still recorded as such: `Q_value` 0.0
+/// and `center_of_mass` false on those rows. A synthesized sum has no products,
+/// so nothing downstream reads either one, and there is no rule to check them
+/// against.
+#[test]
+fn constructed_synthesized_rows_are_redundant_so_the_rest_sum_to_the_total() {
+    let data = multi_channel_nuclide();
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+    let n = data.energy["294K"].len();
+
+    let mut plain = Vec::new();
+    let mut redundant = Vec::new();
+    let mut plain_sum = vec![0.0; n];
+    let mut every_row_sum = vec![0.0; n];
+    for row in 0..batch.num_rows() {
+        let mt = i32_at(&batch, "mt", row);
+        let xs = written_on_grid(&batch, &mt_rows, mt, n);
+        for (a, b) in every_row_sum.iter_mut().zip(&xs) {
+            *a += b;
+        }
+        if bool_at(&batch, "redundant", row) {
+            redundant.push(mt);
+        } else {
+            plain.push(mt);
+            for (a, b) in plain_sum.iter_mut().zip(&xs) {
+                *a += b;
+            }
+        }
+    }
+
+    // The consumer's rule, first, so it is what fires. Exact: every value in
+    // the file is a small integer.
+    assert_f64_slice_eq(
+        "the non-redundant rows summed, against the MT 1 row",
+        &plain_sum,
+        &written_on_grid(&batch, &mt_rows, 1, n),
+    );
+    // And the filter is load bearing: without it the same consumer counts the
+    // sums as well as their parts.
+    assert_ne!(
+        every_row_sum, plain_sum,
+        "every row is flagged the same way, so the redundant filter cannot be \
+         shown to matter on this input"
+    );
+
+    // Which rows ended up on which side, as documentation. This part IS a
+    // transcription of reactions.rs:132 and the parser's default; the sum above
+    // is the assertion that does not depend on it.
+    assert_eq!(plain, vec![2, 16, 18, 51, 102, 103]);
+    assert_eq!(redundant, yamc_convert::synthesis::SYNTHETIC_MTS.to_vec());
+
+    // The other two literals on those rows, pinned and not endorsed: there is
+    // no parsed side and no consumer rule to check them against.
+    for &mt in &redundant {
+        let row = mt_rows[&mt];
+        assert_eq!(f64_at(&batch, "Q_value", row), 0.0, "MT {mt} Q value");
+        assert!(!bool_at(&batch, "center_of_mass", row), "MT {mt}");
+    }
+}
+
+/// CONSTRUCTED INPUT, not an evaluation. TWO cross sections at temperatures the
+/// nuclide was never processed at, so the order the extras phase writes them in
+/// is finally visible.
+///
+/// No vendored evaluation reaches this. The extras branch at reactions.rs:87 is
+/// reached only on the ENDF route, where `temperatures()` is empty and `rx.xs`
+/// holds the single key "0K": one extra has no order. Everything else in this
+/// file has one temperature and no extras at all. So a writer that reversed or
+/// re-sorted the extras is green everywhere else, and the input here is built
+/// by hand with three keys whose curves have three different lengths, three
+/// different thresholds and no shared value.
+///
+/// What the assertion pins is the writer's rule and not a physical fact: the
+/// processed temperatures in `k_ts` order, then whatever `rx.xs` holds that
+/// `temperatures()` does not, in the map's own (BTreeMap, so lexicographic)
+/// order. The load bearing half is that `xs_values` and `xs_threshold_idx` are
+/// built by walking that same list, so each curve keeps its own name and its
+/// own threshold whichever order the names come out in.
+#[test]
+fn constructed_extra_temperatures_follow_the_processed_ones_in_map_order() {
+    let mut data = IncidentNeutron::new(3, 6, 0);
+    data.k_ts = vec![k_t(294.0)];
+    data.energy.insert("294K".to_string(), vec![1.0, 2.0, 3.0]);
+    let mut elastic = Reaction::new(2);
+    // Only "294K" is a processed temperature. "0K" is the unbroadened grid the
+    // NJOY route leaves behind and "600K" stands for a broadened set that was
+    // never named in k_ts; both are extras.
+    elastic.xs.insert(
+        "294K".to_string(),
+        partial_xs(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0], 0),
+    );
+    elastic.xs.insert(
+        "0K".to_string(),
+        partial_xs(vec![2.0, 3.0], vec![10.0, 20.0], 1),
+    );
+    // "600K" has no grid in `data.energy` at all, so its abscissae are its
+    // own: four points starting at index 4 of a grid this nuclide does not
+    // carry. Nothing checks a span for a temperature with no grid, which is
+    // exactly the situation the extras branch exists for.
+    elastic.xs.insert(
+        "600K".to_string(),
+        partial_xs(
+            vec![5.0, 6.0, 7.0, 8.0],
+            vec![100.0, 200.0, 300.0, 400.0],
+            4,
+        ),
+    );
+    data.reactions.insert(2, elastic);
+    assert_eq!(data.temperatures(), vec!["294K".to_string()]);
+
+    let dir = scratch();
+    yamc_convert::reactions::write_reactions(&data, dir.path())
+        .expect("reactions.arrow is written");
+    let batch = section(dir.path(), "reactions.arrow");
+    let mt_rows = rows_by_mt(&batch);
+
+    let row = mt_rows[&2];
+    let temperatures = str_list(&batch, "xs_temperatures", row);
+    assert_eq!(
+        temperatures,
+        vec!["294K".to_string(), "0K".to_string(), "600K".to_string()],
+        "the processed temperature first, then the two extras in the map's own \
+         order, which is lexicographic and puts 0K before 600K"
+    );
+    // The restated rule beside the literal, on the only input in this file
+    // where the extras phase holds more than one name.
+    assert_eq!(
+        temperatures,
+        expected_xs_temperatures(&data, &data.reactions[&2])
+    );
+
+    // Each curve with its own name. Three lengths, three thresholds, no shared
+    // value, so a permutation cannot pass on either column.
+    let values = nested_f64_list(&batch, "xs_values", row);
+    assert_f64_slice_eq("MT 2 at 294K", &values[0], &[1.0, 2.0, 3.0]);
+    assert_f64_slice_eq("MT 2 at 0K", &values[1], &[10.0, 20.0]);
+    assert_f64_slice_eq("MT 2 at 600K", &values[2], &[100.0, 200.0, 300.0, 400.0]);
+    assert_i32_slice_eq(
+        "MT 2 xs_threshold_idx",
+        &i32_list(&batch, "xs_threshold_idx", row),
+        &[0, 1, 4],
+    );
+
+    // The synthesized rows are built from `temperatures` rather than from
+    // `rx.xs`, so no extra may leak into them: a nuclide processed at one
+    // temperature has one synthesized curve, whatever else the reaction was
+    // stored at.
+    for mt in [1, 3, 4, 27, 101] {
+        let row = mt_rows[&mt];
+        assert_eq!(
+            str_list(&batch, "xs_temperatures", row),
+            vec!["294K".to_string()],
+            "MT {mt} gained a temperature the nuclide was not processed at"
+        );
+        assert_eq!(
+            nested_f64_list(&batch, "xs_values", row).len(),
+            1,
+            "MT {mt}"
+        );
+    }
+    // MT 1 is elastic alone here, on the 294K grid only.
+    assert_f64_slice_eq(
+        "MT 1 at 294K",
+        &nested_f64_list(&batch, "xs_values", mt_rows[&1])[0],
+        &[1.0, 2.0, 3.0],
     );
 }

--- a/crates/yamc-convert/tests/section_values_photon.rs
+++ b/crates/yamc-convert/tests/section_values_photon.rs
@@ -48,7 +48,8 @@ use std::sync::OnceLock;
 
 use endf::function::Tabulated1D;
 use endf::incident_photon::{
-    compton_subshell_map, AtomicRelaxation, ComptonProfiles, PhotonReaction, Transitions, SUBSHELLS,
+    compton_subshell_map, AtomicRelaxation, Bremsstrahlung, ComptonProfiles, PhotonReaction,
+    Transitions, SUBSHELLS,
 };
 use endf::{IncidentPhoton, PhotonData};
 
@@ -329,6 +330,165 @@ fn element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid() {
         "heating_xs is written as an empty list, not as a null"
     );
     assert_eq!(list_len(&batch, "heating_xs", 0), 0);
+}
+
+/// A failure means an interpolated cross section is no longer the number the
+/// evaluation implies.
+///
+/// Four of the twelve spot values in
+/// `element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid`
+/// are GOLDEN: they fall between two tabulated points and were captured from a
+/// run of the same `Tabulated1D::eval` the writer ran, so they detect a CHANGE
+/// to `eval` without saying the value is right. This test derives all four
+/// from the evaluation instead.
+///
+/// The two tabulated points bracketing each one are transcribed here and
+/// checked to appear, side by side and in that order, in the decompressed
+/// fixture text, so they are reads of the file rather than captures of the
+/// code. The interpolant is then formed as the weighted average
+/// `(y0 (x1 - e) + y1 (e - x0)) / (x1 - x0)`, deliberately NOT the slope form
+/// `y0 + (e - x0) / (x1 - x0) * (y1 - y0)` that `eval` uses
+/// (`crates/endf/src/function.rs:103`). The two forms agree to one ulp at worst
+/// on these four points, which is why this is the one comparison in the
+/// vendored half of this file made to a relative tolerance.
+///
+/// What this does NOT close. No mutation separates it from the golden
+/// literals: any change to `eval` turns both red, so the gain is that the
+/// expected value is now derived from the file and cannot be "refreshed" from
+/// a run. And every interpolation region in this evaluation is scheme 2, so
+/// nothing here checks `eval` in a log region; the expected value is a second
+/// hand-written implementation of the same lin-lin rule, not an outside
+/// source.
+#[test]
+fn element_interior_spot_values_are_the_lin_lin_interpolant_of_two_fixture_points() {
+    /// One interpolated spot value and the two tabulated points it comes from.
+    struct Probe {
+        column: &'static str,
+        mt: i32,
+        /// Index into the union grid, which is where the written column is
+        /// read.
+        index: usize,
+        below: (f64, f64),
+        above: (f64, f64),
+        /// The two points exactly as they appear in the fixture text, one
+        /// eleven-column field each with the single space between them.
+        below_text: &'static str,
+        above_text: &'static str,
+        /// The literal the vendored spot-value test asserts, so the two cannot
+        /// drift apart.
+        golden: f64,
+    }
+
+    let probes = [
+        Probe {
+            column: "coherent_xs",
+            mt: 502,
+            index: 137,
+            below: (13.5990191, 8.93264869),
+            above: (13.6538059, 9.51682411),
+            below_text: "13.5990191 8.93264869",
+            above_text: "13.6538059 9.51682411",
+            golden: 8.943107736147576,
+        },
+        Probe {
+            column: "coherent_xs",
+            mt: 502,
+            index: 1000,
+            below: (629462.706, 1.16803e-5),
+            above: (690192.132, 9.71529e-6),
+            below_text: "629462.706 1.16803E-5",
+            above_text: "690192.132 9.71529E-6",
+            golden: 1.0422148052673345e-5,
+        },
+        Probe {
+            column: "incoherent_xs",
+            mt: 504,
+            index: 137,
+            below: (13.3350268, 1.70030e-5),
+            above: (13.9234189, 1.85363e-5),
+            below_text: "13.3350268 1.70030E-5",
+            above_text: "13.9234189 1.85363E-5",
+            golden: 1.769349772687295e-5,
+        },
+        Probe {
+            column: "photoelectric_xs",
+            mt: 522,
+            index: 1000,
+            below: (663552.073, 4.80501e-9),
+            above: (683911.700, 4.46483e-9),
+            below_text: "663552.073 4.80501E-9",
+            above_text: "683911.700 4.46483E-9",
+            golden: 4.724903727980379e-9,
+        },
+    ];
+
+    let c = convert(true, false);
+    let batch = section(&c.dir, "element.arrow");
+    let grid = union_grid_expected(&c.data);
+    let raw = text(H_PHOTOAT);
+
+    for p in &probes {
+        let (x0, y0) = p.below;
+        let (x1, y1) = p.above;
+
+        // In the file, as a pair, in that order.
+        assert!(
+            raw.contains(p.below_text),
+            "`{}` is not in photoat-001_H_000.endf, so it is not a fixture read",
+            p.below_text
+        );
+        assert!(
+            raw.contains(p.above_text),
+            "`{}` is not in photoat-001_H_000.endf, so it is not a fixture read",
+            p.above_text
+        );
+
+        // And consecutive points of the reaction the column names, so the
+        // transcription is the right bracket rather than two points from
+        // elsewhere on the curve.
+        let f = c
+            .data
+            .get(p.mt)
+            .and_then(|rx| rx.xs.as_ref())
+            .unwrap_or_else(|| panic!("MT {} has no cross section", p.mt));
+        let k =
+            f.x.iter()
+                .position(|&v| v == x0)
+                .unwrap_or_else(|| panic!("MT {} does not tabulate {x0:e}", p.mt));
+        assert_eq!(f.y[k], y0, "MT {} at {x0:e}", p.mt);
+        assert_eq!(f.x[k + 1], x1, "MT {} after {x0:e}", p.mt);
+        assert_eq!(f.y[k + 1], y1, "MT {} after {x0:e}", p.mt);
+        // One region, lin-lin, which is the rule the expected value uses.
+        assert_eq!(f.breakpoints, vec![f.x.len() as i32]);
+        assert_eq!(f.interpolation, vec![2]);
+
+        // The union grid point really is inside that bin, so the value is
+        // interpolated rather than tabulated or clamped.
+        let e = grid[p.index];
+        assert!(
+            x0 < e && e < x1,
+            "grid[{}] = {e:e} is not strictly between {x0:e} and {x1:e}",
+            p.index
+        );
+
+        let expected = (y0 * (x1 - e) + y1 * (e - x0)) / (x1 - x0);
+        let written = f64_list(&batch, p.column, 0)[p.index];
+        assert_close(
+            &format!("{}[{}]", p.column, p.index),
+            written,
+            expected,
+            1e-15,
+        );
+        // The same number as the literal in the vendored spot-value test, bit
+        // for bit. Refreshing that literal from a run after an `eval` change
+        // fails the comparison above, and dropping this one would let the two
+        // tests disagree in silence.
+        assert_eq!(
+            written, p.golden,
+            "{}[{}] no longer matches the literal the spot-value test asserts",
+            p.column, p.index
+        );
+    }
 }
 
 /// A failure means a form factor or an anomalous scattering term is in the
@@ -1412,4 +1572,377 @@ fn constructed_out_of_order_subshell_rows_are_refused_by_write_compton() {
         "L2",
         "the rows really were out of order, rather than the guard misfiring"
     );
+}
+
+// ---------------------------------------------------------------------------
+// The gaps the pull request published, closed where a constructed input can
+// reach the writer at all.
+// ---------------------------------------------------------------------------
+
+/// [`constructed_element`] with every `element.arrow` column the writer can
+/// populate carrying its own distinct values. NOT A PARSED EVALUATION.
+///
+/// Three changes to the shared builder, each of them because two equal columns
+/// cannot discriminate a swap between them:
+///
+/// * MT 517 and MT 515 are added, so the two pair-production columns are no
+///   longer both empty. Their abscissae are already union grid points, so the
+///   grid stays `[1, 5, 10, 20, 50, 100]`, and their ordinates do not start at
+///   zero, unlike a real evaluation's, so `eval`'s clamp below the threshold is
+///   visible on them too.
+/// * The coherent form factor becomes the line from `(0, 10)` to `(3, 0)`.
+///   Squared and divided by `Z^2 = 100` that is the line from `(0, 1)` to
+///   `(9, 0)`, whose cumulative integral is `[0, 4.5]`. The shared builder's
+///   `[0, 2]` is the same pair as its own `coherent_ff_x`.
+/// * The incoherent form factor gets the abscissa `[0, 7]`, which the shared
+///   builder shares with `coherent_anomalous_imag_x`.
+fn constructed_element_fully_populated() -> IncidentPhoton {
+    let mut data = constructed_element();
+
+    for (mt, x, y) in [
+        (517, [20.0, 100.0], [41.0, 43.0]),
+        (515, [50.0, 100.0], [47.0, 53.0]),
+    ] {
+        let mut rx = PhotonReaction::new(mt);
+        rx.xs = Some(Tabulated1D::new(x.to_vec(), y.to_vec()));
+        data.reactions.insert(mt, rx);
+    }
+
+    data.reactions
+        .get_mut(&502)
+        .expect("MT 502")
+        .scattering_factor = Some(Tabulated1D::new(vec![0.0, 3.0], vec![10.0, 0.0]));
+    data.reactions
+        .get_mut(&504)
+        .expect("MT 504")
+        .scattering_factor = Some(Tabulated1D::new(vec![0.0, 7.0], vec![0.0, 10.0]));
+
+    data
+}
+
+/// A failure means two `element.arrow` columns were exchanged.
+///
+/// CONSTRUCTED INPUT, not an evaluation. `element.arrow` declares seventeen
+/// consecutive `list<double>` fields and a permutation among any two that are
+/// EMPTY on the input at hand writes a byte-identical file. On
+/// [`constructed_element`] three of them are empty at once
+/// (`pair_production_nuclear_xs`, `pair_production_electron_xs` and
+/// `heating_xs`), so exchanging the two pair-production slots in
+/// `write_element`'s argument vector leaves all eight constructed tests green.
+///
+/// Here sixteen of the seventeen carry values that are pairwise different, and
+/// `heating_xs` is empty on every input the writer can be handed
+/// (`constructed_mt_525_is_dropped_from_the_heating_column`), which makes it
+/// the unique empty column and so makes a permutation involving it visible as
+/// well. The pairwise comparison at the end of this test is the property that
+/// says so: no two of the seventeen columns are equal, therefore every
+/// permutation of them changes the file.
+#[test]
+fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisible() {
+    /// The seventeen list columns, in the order `write_element` passes them.
+    const LIST_COLUMNS: [&str; 17] = [
+        "ln_energy",
+        "coherent_xs",
+        "incoherent_xs",
+        "photoelectric_xs",
+        "pair_production_nuclear_xs",
+        "pair_production_electron_xs",
+        "heating_xs",
+        "coherent_int_ff_x",
+        "coherent_int_ff_y",
+        "coherent_ff_x",
+        "coherent_ff_y",
+        "coherent_anomalous_real_x",
+        "coherent_anomalous_real_y",
+        "coherent_anomalous_imag_x",
+        "coherent_anomalous_imag_y",
+        "incoherent_ff_x",
+        "incoherent_ff_y",
+    ];
+
+    let data = constructed_element_fully_populated();
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "element.arrow");
+    assert_schema_is_declared(&batch, "element.arrow");
+
+    // Those seventeen are every column but the two scalars, in that order, so
+    // the pairwise property below cannot miss one that was added later.
+    let names: Vec<String> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().to_string())
+        .collect();
+    assert_eq!(names.len(), 2 + LIST_COLUMNS.len());
+    assert_eq!(names[0], "name");
+    assert_eq!(names[1], "Z");
+    for (i, expected) in LIST_COLUMNS.iter().enumerate() {
+        assert_eq!(
+            names[2 + i],
+            *expected,
+            "column {} is not the one write_element writes there",
+            2 + i
+        );
+    }
+
+    // The grid is the shared builder's, unchanged: both added channels are
+    // tabulated on points it already carries.
+    let grid = union_grid_expected(&data);
+    assert_f64_slice_eq("the constructed union grid", &grid, &CONSTRUCTED_GRID);
+    let ln_energy = f64_list(&batch, "ln_energy", 0);
+    let expected_ln: Vec<f64> = grid.iter().map(|e| e.ln()).collect();
+    assert_f64_slice_eq("ln_energy", &ln_energy, &expected_ln);
+    assert_eq!(ln_energy[0], 0.0, "ln(1 eV) is exactly zero");
+
+    // The five channels ELEMENT_MTS lets through, each against the reaction it
+    // names. A restatement of the writer's own `eval`, so this pins WIRING,
+    // which is what a permutation is.
+    for (col, mt) in [
+        ("coherent_xs", 502),
+        ("incoherent_xs", 504),
+        ("photoelectric_xs", 522),
+        ("pair_production_nuclear_xs", 517),
+        ("pair_production_electron_xs", 515),
+    ] {
+        let written = f64_list(&batch, col, 0);
+        assert_f64_slice_eq(col, &written, &eval_on(&data, mt, &grid));
+        assert_eq!(written.len(), grid.len(), "{col} is on the union grid");
+    }
+
+    // The two pair-production channels in closed form. Their first three
+    // points are below the tabulated range, where `eval` clamps to y[0]: 41
+    // and 47, not zero. The evaluation's own pair-production curves start at
+    // zero, so on hydrogen that clamp cannot be told from a zero fill.
+    assert_f64_slice_eq(
+        "pair_production_nuclear_xs",
+        &f64_list(&batch, "pair_production_nuclear_xs", 0),
+        &[41.0, 41.0, 41.0, 41.0, 41.75, 43.0],
+    );
+    assert_f64_slice_eq(
+        "pair_production_electron_xs",
+        &f64_list(&batch, "pair_production_electron_xs", 0),
+        &[47.0, 47.0, 47.0, 47.0, 47.0, 53.0],
+    );
+    // The other three at the bottom of the grid, where the three differ.
+    assert_eq!(f64_list(&batch, "coherent_xs", 0)[0], 2.0);
+    assert_eq!(f64_list(&batch, "incoherent_xs", 0)[0], 7.0);
+    assert_eq!(f64_list(&batch, "photoelectric_xs", 0)[0], 17.0);
+
+    // The ten copied columns, verbatim.
+    for (col, expected) in [
+        ("coherent_int_ff_x", vec![0.0, 9.0]),
+        ("coherent_int_ff_y", vec![0.0, 4.5]),
+        ("coherent_ff_x", vec![0.0, 3.0]),
+        ("coherent_ff_y", vec![10.0, 0.0]),
+        ("coherent_anomalous_real_x", vec![1.0, 2.0]),
+        ("coherent_anomalous_real_y", vec![-1.5, -0.5]),
+        ("coherent_anomalous_imag_x", vec![1.0, 3.0]),
+        ("coherent_anomalous_imag_y", vec![0.25, 0.75]),
+        ("incoherent_ff_x", vec![0.0, 7.0]),
+        ("incoherent_ff_y", vec![0.0, 10.0]),
+    ] {
+        assert_f64_slice_eq(col, &f64_list(&batch, col, 0), &expected);
+    }
+
+    // Sixteen populated, one empty, and the empty one is the MT 525 defect.
+    let written: Vec<Vec<f64>> = LIST_COLUMNS
+        .iter()
+        .map(|&c| f64_list(&batch, c, 0))
+        .collect();
+    for (col, values) in LIST_COLUMNS.iter().zip(&written) {
+        assert_eq!(
+            values.is_empty(),
+            *col == "heating_xs",
+            "{col} is the wrong side of the populated/empty divide"
+        );
+    }
+
+    // The property this element exists for.
+    for i in 0..LIST_COLUMNS.len() {
+        for j in (i + 1)..LIST_COLUMNS.len() {
+            assert_ne!(
+                written[i], written[j],
+                "{} and {} carry the same values, so exchanging the two slots \
+                 would write an identical file",
+                LIST_COLUMNS[i], LIST_COLUMNS[j]
+            );
+        }
+    }
+}
+
+/// A failure means `compton.arrow` stopped taking its momentum grid from the
+/// first shell.
+///
+/// CONSTRUCTED INPUT, and a deliberately malformed one. No parser can produce
+/// a ragged `ComptonProfiles`: `IncidentPhoton::add_photon_data`
+/// (`crates/endf/src/incident_photon.rs:286-300`) builds every row as
+/// `Tabulated1D::new(data.pz.clone(), row)`, one shared abscissa, so on every
+/// input the writer can be handed through a parser `first.x` and `last.x` are
+/// the same values and `photon.rs:281` could read either. Nothing here says an
+/// evaluation can be ragged; it says what the writer does when it is handed
+/// one, which is to use shell 0's abscissa for every shell and say nothing.
+///
+/// PINS TWO SUSPECTED DEFECTS, neither of them endorsed. `write_compton`
+/// validates nothing about the shape of `profiles.j`, so when the rows differ
+/// in length it writes a `J_shape` that describes the first row alone while
+/// `J_data` concatenates all of them, and `compton_profile_cdfs`
+/// (`crates/endf/src/incident_photon.rs:551-564`) stops each row at
+/// `pz.len()`, leaving the tail of a longer row at zero and the cumulative
+/// distribution decreasing. A writer that refused a ragged input, or that
+/// wrote the true row length, would turn this test red; see the assertions
+/// below before changing them.
+#[test]
+fn constructed_ragged_compton_profiles_are_written_on_the_first_shell_abscissa() {
+    let mut data = constructed_element();
+    data.compton_profiles = Some(ComptonProfiles {
+        num_electrons: vec![2.0, 8.0],
+        binding_energy: vec![51.0, 6.0],
+        j: vec![
+            Tabulated1D::new(vec![0.0, 1.0, 2.0], vec![0.9, 0.5, 0.1]),
+            // A different abscissa, of a different length, which is what no
+            // parser produces.
+            Tabulated1D::new(vec![0.0, 4.0, 8.0, 10.0], vec![0.8, 0.4, 0.2, 0.05]),
+        ],
+    });
+
+    let profiles = data.compton_profiles.as_ref().expect("just set");
+    assert_ne!(
+        profiles.j[0].x, profiles.j[1].x,
+        "the two shells have to disagree about the momentum grid for this test \
+         to discriminate between them"
+    );
+
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "compton.arrow");
+    assert_schema_is_declared(&batch, "compton.arrow");
+
+    // Shell 0's abscissa, not shell 1's.
+    let pz = f64_list(&batch, "pz", 0);
+    assert_f64_slice_eq("compton.pz", &pz, &[0.0, 1.0, 2.0]);
+    assert_f64_slice_eq("compton.pz", &pz, &profiles.j[0].x);
+
+    // Every ordinate is still written, so the flat array is longer than the
+    // shape says. DEFECT: `[2, 3]` describes six values and there are seven.
+    let j_data = f64_list(&batch, "J_data", 0);
+    assert_f64_slice_eq("J_data", &j_data, &[0.9, 0.5, 0.1, 0.8, 0.4, 0.2, 0.05]);
+    let j_shape = i32_list(&batch, "J_shape", 0);
+    assert_i32_slice_eq("J_shape", &j_shape, &[2, 3]);
+    assert_ne!(
+        (j_shape[0] * j_shape[1]) as usize,
+        j_data.len(),
+        "the shape and the data agreeing would mean the writer had learned to \
+         refuse or to describe a ragged profile set; read this test's doc \
+         comment before deleting the assertion"
+    );
+
+    // Shell 1's own abscissa is never used: its cumulative distribution is
+    // integrated against shell 0's spacing. With its own [0, 4, 8, 10] the
+    // first step would be 0.5 * (0.8 + 0.4) * 4 = 2.4, not 0.6. DEFECT: the
+    // trailing 0.0 is the tail `compton_profile_cdfs` never reaches, so the
+    // row falls from 0.9 back to zero.
+    let cdf = f64_list(&batch, "J_cdf_data", 0);
+    assert_f64_slice_close(
+        "J_cdf_data",
+        &cdf,
+        &[0.0, 0.7, 1.0, 0.0, 0.6, 0.9, 0.0],
+        1e-15,
+    );
+    assert!(
+        cdf[6] < cdf[5],
+        "the second row's tail is what makes this a defect rather than a \
+         curiosity: a cumulative distribution that decreases"
+    );
+    assert_i32_slice_eq("J_cdf_shape", &i32_list(&batch, "J_cdf_shape", 0), &[2, 3]);
+}
+
+/// A failure means a `bremsstrahlung.arrow` column was sourced from the wrong
+/// place.
+///
+/// CONSTRUCTED INPUT, not an evaluation. On hydrogen `ionization_energy` is
+/// `[13.6]`, which is also the MF=28 K-shell binding energy and also the MF=23
+/// MT=522 threshold, so a column wired to the relaxation data instead of to
+/// the Seltzer-Berger tabulation writes identical bytes and no assertion
+/// against the vendored fixture can tell the two apart. The element built here
+/// has three subshells bound at 50, 20 and 5 eV and two ionization energies of
+/// 21.5 and 7.25 eV, so every candidate source is a different number.
+///
+/// The DCS is 3 by 2 rather than 200 by 30, which is enough on its own to tell
+/// a row-major ravel from a column-major one and a `[rows, cols]` shape from
+/// its transpose. What it does not do is check the not-a-knot spline that
+/// produces the real one: those numbers are the parser's and verifying them
+/// needs a second spline implementation, which is a test of `crates/endf` and
+/// not of this writer.
+#[test]
+fn constructed_bremsstrahlung_columns_come_from_the_attached_tabulation() {
+    let mut data = constructed_element();
+    data.bremsstrahlung = Some(Bremsstrahlung {
+        i: 42.5,
+        num_electrons: vec![4.0, 6.0],
+        ionization_energy: vec![21.5, 7.25],
+        electron_energy: vec![1000.0, 2000.0, 4000.0],
+        photon_energy: vec![0.125, 0.5],
+        dcs: vec![vec![1.5, 2.5], vec![3.5, 4.5], vec![5.5, 6.5]],
+    });
+
+    let (_scratch, dir) = write_constructed(&data);
+    let batch = section(&dir, "bremsstrahlung.arrow");
+    assert_schema_is_declared(&batch, "bremsstrahlung.arrow");
+    assert_eq!(batch.num_rows(), 1);
+
+    assert_eq!(f64_at(&batch, "I", 0), 42.5);
+    assert_f64_slice_eq(
+        "electron_energy",
+        &f64_list(&batch, "electron_energy", 0),
+        &[1000.0, 2000.0, 4000.0],
+    );
+    assert_f64_slice_eq(
+        "photon_energy",
+        &f64_list(&batch, "photon_energy", 0),
+        &[0.125, 0.5],
+    );
+    assert_f64_slice_eq(
+        "bremsstrahlung.num_electrons",
+        &f64_list(&batch, "num_electrons", 0),
+        &[4.0, 6.0],
+    );
+
+    let ionization = f64_list(&batch, "ionization_energy", 0);
+    assert_f64_slice_eq("ionization_energy", &ionization, &[21.5, 7.25]);
+
+    // None of the other places the column could have come from. The subshell
+    // binding energies are read out of the file this same conversion wrote,
+    // so this is a comparison between two written sections and not between two
+    // expressions in this test.
+    let subshells = section(&dir, "subshells.arrow");
+    let bound: Vec<f64> = (0..subshells.num_rows())
+        .map(|r| f64_at(&subshells, "binding_energy", r))
+        .collect();
+    assert_f64_slice_eq(
+        "the relaxation binding energies",
+        &bound,
+        &[50.0, 20.0, 5.0],
+    );
+    for &v in &ionization {
+        assert!(
+            !bound.contains(&v),
+            "{v} is a relaxation binding energy as well, so this element cannot \
+             tell the two sources apart"
+        );
+    }
+    let compton_bound = f64_list(&section(&dir, "compton.arrow"), "binding_energy", 0);
+    assert_f64_slice_eq("the Compton binding energies", &compton_bound, &[51.0, 6.0]);
+    for &v in &ionization {
+        assert!(!compton_bound.contains(&v));
+    }
+    assert_ne!(ionization, f64_list(&batch, "num_electrons", 0));
+    assert!(!ionization.contains(&f64_at(&batch, "I", 0)));
+
+    // Row-major, one row per electron energy.
+    let dcs = f64_list(&batch, "dcs_data", 0);
+    assert_f64_slice_eq("dcs_data", &dcs, &[1.5, 2.5, 3.5, 4.5, 5.5, 6.5]);
+    let shape = i32_list(&batch, "dcs_shape", 0);
+    assert_i32_slice_eq("dcs_shape", &shape, &[3, 2]);
+    assert_eq!(shape[0] as usize, list_len(&batch, "electron_energy", 0));
+    assert_eq!(shape[1] as usize, list_len(&batch, "photon_energy", 0));
+    assert_eq!((shape[0] * shape[1]) as usize, dcs.len());
 }


### PR DESCRIPTION
Follow-up to #8, which shipped 47 hermetic value-comparison tests together with
an honest list of what they could NOT discriminate. This closes eleven of those.

## Why they were open

Almost all of them for the same reason: no vendored evaluation reaches the
branch. Li6 is not fissile. Hydrogen has Z = 1 and one subshell. No vendored
neutron evaluation carries more than one temperature. And a swap between two
columns that hold equal values on the only fixture that reaches them is
invisible by construction, however the test is written.

So these are closed by handing the writer the shape directly, which is the
pattern #8 already established for its constructed cases. Every constructed
field gets a deliberately distinct value, because that is the entire point: two
columns that agree cannot discriminate a swap between them. Every new test says
in its doc comment that no vendored evaluation reaches the branch and that the
input is constructed, so none of them reads as evaluation parity.

## What is now discriminated

| Section | Gap closed |
| --- | --- |
| `reactions.arrow` | the MT 3 term of synthesized MT 1; a synthesized MT 101; the `redundant` flag that keeps a synthesized row out of the sums; the extras phase of `xs_temperatures` |
| `total_nu.arrow` | which derived product is taken when a reaction carries two; which fission MT wins when two carry a total; the IO failure path in both writers |
| `fission_photon.arrow` | a multi-region tabulated term is not silently truncated to its first region |
| `element.arrow` | every list column pairwise distinct, so no permutation among them is invisible; the interior spot values as a lin-lin interpolant rather than a regression capture of `Tabulated1D::eval` |
| `compton.arrow` | which shell's abscissa `pz` comes from, on ragged profiles |
| `bremsstrahlung.arrow` | the columns come from the attached tabulation and not from the relaxation data, which happens to hold the same number on hydrogen |

`section_values_fission.rs` 5 to 9 tests, `section_values_neutron.rs` 11 to 14,
`section_values_photon.rs` 12 to 16. 58 tests across the five value files, up
from 47.

## All eleven verified by mutation

Same discipline as #8: for each one the defect it claims to catch was
introduced in the writer, the test confirmed red, and the writer restored.
Twelve mutations in all, across `yamc-convert` and `crates/endf`:

`derived_products.first` to `.last`; the `FISSION_MTS` search order reversed;
dropping `add(&mut mt1, &mt3)` from the synthesis; swapping `coherent` and
`incoherent` in the `element.arrow` column list; taking `pz` from the last
Compton shell instead of the first; truncating a tabulated release term to one
region; writing the synthesized rows as not redundant; perturbing the
union-grid evaluation by 1e-7 relative; dropping the extras phase from
`xs_temperatures`; making `write_total_nu` swallow its IO error and report
success; swapping two `bremsstrahlung.arrow` columns.

## One test written and then dropped

It claimed the NPLY=2 second-order unit correction
(`crates/endf/src/fission_energy.rs:132-138`) fires only above its stated
threshold. That is not what the code does: a coefficient of `1e-6`, whose guard
product is 2.5e7 against a threshold of 1e8, is divided by `EV_PER_MEV` anyway,
while `0.0` is left alone. So the boundary is somewhere below `1e-6`, not at
`4e-6` where the arithmetic in the comment puts it.

Whether the guard is firing when it should not, or the comment and its
arithmetic are misleading, needs reading `from_material` end to end rather than
a test asserting one of the two readings. Filed as #17 with the measurements.
The module doc of `section_values_fission.rs` no longer claims that branch is
reached, since it now is not.

## Still open, and still published

`section_values_products.rs` and `section_values_fast_xs.rs` are unchanged
here, so their gap lists stand as #8 published them. The most valuable of those
remain:

- the boundary comparison in `log_grid_index` (`<=` versus `<`), undiscriminated
  because no bin probe coincides bit for bit with a grid point
- the U240 shape, MT 18 redundant beside non-redundant MT 19/20/21/38 in one
  evaluation, which is where the two sides of `MT 27 - fission` can disagree
- the Kalbach-Mann zero-padding branch, the correlated missing-mu fallback, the
  `univariate_flat::cdf` trapezoid arm and the degenerate-Uniform branch, all
  unreachable through the parser and all reachable by handing the writer the
  shape directly
- `dist_idx` and the applicability index, which no vendored evaluation
  discriminates because no product carries more than one distribution

Genuinely unclosable with vendored bytes, and recorded rather than papered over:
MT 901 heating (needs a HEATR tape, and nothing in `crates/endf/fixtures` is
one), the covariance NC-only columns, `EmissionMode::Total`, and a fissile ACE
table.

Verified: `cargo test -p yamc-convert` 106 passed 0 failed, stable across
repeated runs; `cargo clippy -p yamc-convert --tests -D warnings` clean;
`cargo fmt` clean. No `src/` change in this PR.