### PR TITLE
Stop dev and test builds carrying full DWARF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,28 @@ lto = "thin"
 # across the extension boundary, so aborting here would turn every recoverable
 # error in the bindings into a killed interpreter.
 panic = "unwind"
+
+# Dev and test builds carried full DWARF, and this workspace cannot afford it.
+# There was no `[profile.dev]`, so cargo's default `debug = 2` applied to every
+# `cargo test`: full type and variable-location info for arrow, faer, wgpu,
+# cubecl, rustpython and nalgebra, plus a copy in each of the ~40 test
+# binaries. A local `target/debug` reached 103 GB, and CI does not have that:
+# on 2026-09-02 the ubuntu runner logged "Free space left: 0 MB" and one second
+# later `ld` died with SIGBUS writing its own mmapped output, which is what a
+# full filesystem looks like from inside the linker rather than a clean ENOSPC.
+# The same failure hit `main` and an unrelated pull request in the same hour, so
+# it was the workspace outgrowing the runner and not anything either change did.
+#
+# `line-tables-only` keeps the line-number program and drops the rest, so a
+# panic backtrace still names the file and line that panicked, which is what
+# these builds are actually read for. What is lost is stepping in a debugger
+# with variable inspection; anyone who needs that can build with
+# `RUSTFLAGS=-Cdebuginfo=2` for the one crate they are debugging.
+#
+# The next lever, if this stops being enough, is `debug = false` under
+# `[profile.dev.package."*"]`, which keeps line tables for this workspace's own
+# crates and drops them for every dependency. Not done yet because it makes a
+# backtrace through faer or arrow unreadable, and those are exactly the frames a
+# numerical bug tends to sit in.
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
CI is failing because the runners are out of disk, not because of any code
change. This halves the dev and test build footprint.

## The evidence

From the ubuntu-latest `Test` step on `main` (run 33664156111):

```
18:06:07 ##[warning]You are running out of disk space. The runner will stop
                    working when the machine runs out of disk space.
                    Free space left: 0 MB
18:06:08 collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
```

One second apart. SIGBUS rather than a clean ENOSPC is what a full filesystem
looks like from inside the linker: `ld` mmaps its output and the kernel cannot
back a page.

The same failure hit `main` and PR #15 in the same hour, in different
workflows, so it is neither #15's `--remap-path-prefix` change nor #13's
temperature work. The `Documentation` job failed alongside with
`Artifact storage quota has been hit`, which is the same problem on the other
axis and is worth clearing separately.

## Why this workspace tips over

There is no `[profile.dev]`, so cargo's default `debug = 2` applies to every
`cargo test`: full type and variable-location DWARF for arrow, faer, wgpu,
cubecl, rustpython and nalgebra, plus a copy in each of the roughly forty test
binaries. `[profile.release]` was tuned for #576; dev never was.

A local `target/debug` in this repo had reached **103 GB**.

## The change

```toml
[profile.dev]
debug = "line-tables-only"
```

Measured on `cargo test -p yamc-nuclide --no-run` into a clean target
directory:

| | size |
| --- | --- |
| `debug = 2` (before) | 2.0 GB |
| `line-tables-only` | 1.1 GB |

A little under half, on one crate. CI builds the whole workspace.

## What is kept, and what is not

Kept: a panic backtrace still names the file, line and column of every frame.
Verified rather than assumed:

```
   2: zz_bt::inner
             at ./tests/zz_bt.rs:1:14
   3: zz_bt::outer
             at ./tests/zz_bt.rs:2:14
```

Lost: variable inspection in a debugger. Anyone who needs it can build the one
crate they are debugging with `RUSTFLAGS=-Cdebuginfo=2`.

Coverage is unaffected in principle, since `-C instrument-coverage` writes its
own coverage-mapping section and does not read DWARF. Not verified locally
because cargo-llvm-cov is not installed here, and that job is informational and
cannot fail the build, so the risk is bounded.

`cargo test -p yamc-nuclide -p yamc-convert` under the new profile: 374 passed,
0 failed.

## Next lever, deliberately not pulled

`debug = false` under `[profile.dev.package."*"]` would keep line tables for
this workspace's own crates and drop them for every dependency, saving more.
Left out because it makes a backtrace through faer or arrow unreadable, and
those are exactly the frames a numerical bug tends to sit in. Worth doing if
this stops being enough.

Also worth considering separately, and not done here: reclaiming the ~30 GB the
runner images spend on the dotnet, GHC and Android SDK trees, which is the
standard fix when a build genuinely needs the space.