### PR TITLE
Key the MPI cache on the MPI it links against

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -237,16 +237,37 @@ jobs:
 
       - name: Set up Rust
         run: rustup update stable && rustup default stable
+
+      # `mpi-sys` bakes an absolute `-L` into its build-script output, and cargo
+      # will not re-run a build script whose Rust-side inputs have not changed.
+      # So when the macOS image upgraded open-mpi from 5.0.9 to 5.0.10 the
+      # cached output kept pointing at
+      # /opt/homebrew/Cellar/open-mpi/5.0.9/lib, a directory that no longer
+      # existed, and every build here failed with `ld: library 'mpi' not found`
+      # on a full cache hit. Keying on the native version is what makes an image
+      # upgrade invalidate the cache instead of poisoning it.
+      - name: Record the native MPI version for the cache key
+        id: mpi
+        shell: bash
+        run: |
+          version="$( { mpirun --version 2>/dev/null || mpiexec --version 2>/dev/null; } \
+                      | head -1 | tr -cs '[:alnum:].' '-' | sed 's/^-*//; s/-*$//' )"
+          echo "version=${version:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "native MPI: ${version:-unknown}"
+
       # Cache the dependency build. Without this every Rust job recompiled the
       # whole workspace -- arrow, faer, wgpu, cubecl -- from scratch on every
       # push, which is most of why these jobs ran as long as they did.
       #
-      # Shared with the workspace tests: the `mpi` feature is a thin layer over
-      # the same dependency build.
+      # Deliberately NOT the `ci` key the workspace tests use. That cache is
+      # shared with jobs that never link MPI, so this job's `mpi-sys` output
+      # went in there and came back out on a machine whose open-mpi had moved.
+      # Its own key costs one cold build per MPI version and keeps a native
+      # upgrade from reaching jobs that do not link against it.
       - name: Cache the Rust build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-mpi-${{ steps.mpi.outputs.version }}
           cache-on-failure: true
 
       - name: Verify MPI installation


### PR DESCRIPTION
Fixes `Test MPI on macos-14`, which has been failing on every branch including `main`.

## The failure

```
ld: warning: search path '/opt/homebrew/Cellar/open-mpi/5.0.9/lib' not found
ld: library 'mpi' not found
clang: error: linker command failed with exit code 1
error: could not compile `yamc` (lib)
```

## Why

The runner image now carries **open-mpi 5.0.10**. Both versions appear in the log, `Cellar/open-mpi/5.0.10` from the brew install and `Cellar/open-mpi/5.0.9` in the linker search path.

`mpi-sys` bakes an absolute `-L` into its build-script output, and cargo will not re-run a build script whose Rust-side inputs have not changed. So the restored output still pointed at the 5.0.9 Cellar directory that the upgrade removed. The decisive line is in the cache step, immediately before the link fails:

```
Restored from cache key "v0-rust-ci-Darwin-arm64-532c96d9-93d15f3d" full match: true.
```

Nothing was wrong with the checkout or the brew install. The stale artifact came back out of the cache.

## The change

The cache key now carries the native MPI version, so an image upgrade invalidates the cache instead of poisoning it:

```yaml
shared-key: ci-mpi-${{ steps.mpi.outputs.version }}
```

It also stops sharing the `ci` key, which is deliberate and is the other half of the fix. Three jobs use `ci`, and two of them never link MPI, so this job was writing its `mpi-sys` output into a cache those jobs also restore. Its own key costs one cold build per MPI version and confines a native upgrade to the job that actually links against it.

## Rejected alternatives

- **Pin the brew formula.** Goes stale the same way, just on your schedule instead of GitHub's.
- **Reinstall open-mpi every run.** `brew install` already no-ops when a version is present, and the problem is the cached artifact rather than the installed library.
- **`cargo clean -p mpi-sys` before building.** Keeps the shared cache, but forces `mpi-sys` and everything downstream of it, including `yamc` itself, to rebuild on every run, and leaves the shared cache still able to carry a stale native path.

## Verified

The version snippet was exercised locally against four cases:

| `mpirun --version` output | resulting key |
| --- | --- |
| `mpirun (Open MPI) 5.0.10` | `ci-mpi-mpirun-Open-MPI-5.0.10` |
| `mpirun (Open MPI) 5.0.9` | `ci-mpi-mpirun-Open-MPI-5.0.9` |
| MPICH-style `HYDRA build details: Version: 4.2.1` | `ci-mpi-HYDRA-build-details-Version-4.2.1` |
| no MPI on `PATH` | `ci-mpi-unknown` |

The two open-mpi versions produce different keys, which is the property that matters. The step runs after the brew and apt installs and before the cache step, and the workflow parses as YAML with the step order confirmed.

Note the first run on this branch is necessarily a cold build for this job, since the key is new.