### PR TITLE
Key the other MPI cache on the MPI it links against too

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -539,10 +539,44 @@ jobs:
         run: |
           brew install open-mpi
 
+      # Same fix as the MPI job in ci-rust.yml (#39), which this job did not
+      # get. `mpi-sys` bakes an absolute `-L` into its build-script output and
+      # cargo will not re-run a build script whose Rust-side inputs have not
+      # changed, so a cache saved when the macOS image carried open-mpi 5.0.9
+      # keeps pointing at /opt/homebrew/Cellar/open-mpi/5.0.9/lib after the
+      # image moves on, and the link fails with `ld: library 'mpi' not found`
+      # on a full cache hit.
+      #
+      # #39 only re-keyed the ci-rust.yml job, because that one caches through
+      # an explicit `Swatinem/rust-cache` step. This one cached through
+      # `actions-rust-lang/setup-rust-toolchain`, which does it internally and
+      # keys on the job rather than on the native library, so it poisoned
+      # itself across runs in exactly the same way. That is why a pull request
+      # could pass here and fail there, or pass or fail by which runner image
+      # it drew.
+      - name: Record the native MPI version for the cache key
+        id: mpi
+        shell: bash
+        run: |
+          version="$( { mpirun --version 2>/dev/null || mpiexec --version 2>/dev/null; } \
+                      | head -1 | tr -cs '[:alnum:].' '-' | sed 's/^-*//; s/-*$//' )"
+          echo "version=${version:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "native MPI: ${version:-unknown}"
+
+      # `cache: false` and an explicit cache below, rather than this action's
+      # built-in one, so the key can carry the MPI version. It is also what
+      # makes the two MPI jobs use one mechanism instead of two.
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          cache: false
+
+      - name: Cache the Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: python-mpi-${{ steps.mpi.outputs.version }}
+          cache-on-failure: true
 
       - name: Verify MPI installation
         run: |


### PR DESCRIPTION
Follow-up to #39, which fixed one of the two MPI jobs.

There are two, in different workflows, and only `ci-rust.yml`'s was re-keyed.
That is why a pull request could pass the Rust MPI job and fail the Python one
in the same run, which is what happened on #38:

| workflow | job | result |
| --- | --- | --- |
| `Rust tests` | `Test MPI on macos-14` | success |
| `Python CI` | `Test MPI on macos-14` | **failure** |

with

```
ld: warning: search path '/opt/homebrew/Cellar/open-mpi/5.0.9/lib' not found
ld: library 'mpi' not found
```

## Same cause, different cache

#39 already describes it: `mpi-sys` bakes an absolute `-L` into its
build-script output, and cargo will not re-run a build script whose Rust-side
inputs have not changed. So a cache saved when the macOS image carried
open-mpi 5.0.9 keeps pointing at a Cellar directory that no longer exists.

The reason #39 missed this job is that the two cache by different mechanisms:

- `ci-rust.yml` uses an explicit `Swatinem/rust-cache` step with a
  `shared-key`, so #39 could put the MPI version in it.
- `ci-python.yml` cached through `actions-rust-lang/setup-rust-toolchain`,
  which caches internally and keys on the job rather than on the native
  library. So it poisoned itself across runs of the same job, invisibly to
  #39's fix.

`cache: false` on the setup action plus an explicit cache step keyed
`python-mpi-${{ steps.mpi.outputs.version }}` puts both jobs on one mechanism,
with the same version-recording step #39 introduced.

## Why this read as intermittent rather than broken

GitHub rolls runner image updates out gradually, so whether a run passed
depended on whether the image it drew still had 5.0.9 to match the cached path.
#15 passed on exactly that coincidence: its log shows `open-mpi/5.0.9`
installed and `Compiling mpi-sys` appearing zero times, so the stale path
happened to be correct. Nothing about #15 or #38 caused or fixed this; they
just drew different images.

Keying on the version is what makes an image upgrade invalidate the cache
instead of poisoning it.

## Not changed

`stubs-typing` also uses `actions-rust-lang/setup-rust-toolchain` and is left
alone deliberately: it never links MPI, so its cache cannot carry an
`mpi-sys` path. `ci-rust.yml` is untouched, since #39 already covers it.