### PR TITLE
Drop the wasm remap comment that #38 replaced

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,11 +29,6 @@ rustflags = [
     '--remap-path-prefix=/Users/runner=/build',
 ]
 
-# NOTE: cargo does not merge this with `[build].rustflags`; the target-specific
-# array wins outright. So the remaps above have to be repeated here, and this is
-# the target that matters most, because the committed wasm blobs are built by
-# hand and ship inside the wheel.
-
 # The remaps are repeated here because cargo does not merge this with
 # `[build].rustflags`: a target-specific array wins outright, so a `[build]`
 # entry alone would be silently ignored for exactly this target. The `--cfg`


### PR DESCRIPTION
My mistake resolving #38 against #15, caught while reading the merged file.

The conflict between those two was entirely in the comment blocks. I kept #15's
side wholesale and then appended the replacement, so `.cargo/config.toml` now
carries two adjacent notes making the same point about the target-specific
array not merging with `[build]`.

The first of the two is also now false:

> because the committed wasm blobs are built by hand and ship inside the wheel

That was exactly right when #15 wrote it, and it is exactly what #38 stopped
being true: the blobs are built in CI now and are not committed. Leaving it in
tells the next reader the opposite of what the block immediately below it says.

Comment only, no behaviour change. `tomllib` still parses the file and the two
`rustflags` arrays are untouched.