### PR TITLE
Resolve a reaction rate onto the spectrum's own energy groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "yani-python"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "endf",
  "pyo3",

--- a/crates/yani-python/Cargo.toml
+++ b/crates/yani-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "yani-python"
 # transport converter says nothing about the inventory package. Bump it with
 # `cargo set-version -p yani-python <version>`.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for the transmutation stack: materials, nuclides, chains, irradiation schedules and inventories. Shared by the yamc and yani wheels."

--- a/crates/yani-python/src/transmutation_results.rs
+++ b/crates/yani-python/src/transmutation_results.rs
@@ -677,6 +677,76 @@ impl PyTransmutationResults {
         Some(out.into_any().unbind())
     }
 
+    /// One channel's reaction rate over one step, resolved onto the groups of
+    /// the spectrum that drove it.
+    ///
+    /// ``get_reaction_rates`` answers with one number per edge, already
+    /// collapsed against the whole spectrum. That number cannot say which part
+    /// of the spectrum made it, and where a cross section spans decades the two
+    /// readings are different physics: an effective ``W186(n,gamma)`` of 57 mb
+    /// against a spectrum 89% of which sits in 12-16 MeV and 0.7% of which is
+    /// below 100 keV is either a fast-capture rate or a resonance-region rate,
+    /// and only the breakdown says which. A disagreement can then be pinned on
+    /// resonance processing rather than guessed at, and a covariance grid that
+    /// stops short of the spectrum can be checked against where the rate
+    /// actually is.
+    ///
+    /// The per-group entries sum to the collapsed rate for the same channel, to
+    /// floating-point rounding, because both come from the same walk of the
+    /// same cross sections with the same self-shielding weighting.
+    ///
+    /// Nothing is stored for this. The breakdown is re-derived from the
+    /// spectrum when asked for, which is one reaction over the group structure;
+    /// keeping it for every channel would be tens of megabytes on a 709-group
+    /// structure, and a run that never asks should not pay that.
+    ///
+    /// Args:
+    ///     material_id: Material ID number.
+    ///     nuclide: The parent the reaction happens on, e.g. ``"W186"``.
+    ///     kind: The reaction, spelled as the chain spells it, e.g.
+    ///         ``"(n,gamma)"``.
+    ///     step: Schedule step index, as ``get_reaction_rates`` takes it.
+    ///
+    /// Returns:
+    ///     dict | None: ``boundaries``, the group boundaries [eV] ascending and
+    ///     one longer than the rates, and ``rates``, each group's contribution
+    ///     to the rate [1/s]. None when the material, the step, the nuclide or
+    ///     the channel is unknown; for a step that drove no flux, whether by
+    ///     being a cooldown or by carrying a zero rate; for ``(n,n')``, whose
+    ///     rate comes from the branching overlay's partials rather than from a
+    ///     group average; and for a transport-coupled solve, which scores its
+    ///     rates at the collision energy and keeps no group structure to
+    ///     resolve them onto.
+    ///
+    /// Examples:
+    ///     >>> spectrum = results.get_reaction_rate_spectrum(
+    ///     ...     material_id=1, nuclide="W186", kind="(n,gamma)", step=0
+    ///     ... )
+    ///     >>> sum(spectrum["rates"])  # the collapsed rate
+    ///     1.9e-09
+    ///     >>> # where in energy that rate came from
+    ///     >>> below_100_keV = sum(
+    ///     ...     r
+    ///     ...     for lo, r in zip(spectrum["boundaries"], spectrum["rates"])
+    ///     ...     if lo < 1.0e5
+    ///     ... )
+    fn get_reaction_rate_spectrum(
+        &self,
+        py: Python<'_>,
+        material_id: u32,
+        nuclide: &str,
+        kind: &str,
+        step: usize,
+    ) -> Option<Py<PyAny>> {
+        let spectrum = self
+            .inner
+            .get_reaction_rate_spectrum(material_id, nuclide, kind, step)?;
+        let out = PyDict::new(py);
+        out.set_item("boundaries", spectrum.boundaries).unwrap();
+        out.set_item("rates", spectrum.rates).unwrap();
+        Some(out.into_any().unbind())
+    }
+
     /// Flux-weighted isomeric branching at one step.
     ///
     /// Which state a reaction leaves its product in is energy dependent, so the

--- a/crates/yani-transmute/examples/collapse_golden.rs
+++ b/crates/yani-transmute/examples/collapse_golden.rs
@@ -98,7 +98,7 @@ fn main() {
     let masses: Vec<f64> = flux.iter().map(|f| f / total).collect();
 
     // Per group, so a single group average that moves is visible where it moved.
-    let per_group = per_group_reaction_rates(&material, &chain, &masses, &boundaries);
+    let per_group = per_group_reaction_rates(&material, &chain, &masses, &boundaries, None);
     let mut nuclides: Vec<&String> = per_group.keys().collect();
     nuclides.sort();
     for name in nuclides {

--- a/crates/yani-transmute/src/flux_uncertainty.rs
+++ b/crates/yani-transmute/src/flux_uncertainty.rs
@@ -140,9 +140,17 @@ const FLUX_STREAM: u32 = 0xF10D_5EED;
 
 /// Apply one replica's flux perturbation to a set of unit-flux rates.
 ///
+/// The perturbation is applied as a factor on the rate, not as a replacement
+/// for it: the terms say how the rate is distributed over the bins, and the
+/// rate itself stays the one the collapse produced. So an unperturbed replica
+/// reproduces the nominal rate bit for bit rather than to rounding, and a
+/// weighting the terms do not describe cannot be silently substituted for the
+/// one that drove the nominal run.
+///
 /// Rates with no per-group terms are passed through unchanged, which is what a
 /// nuclide whose cross sections were never collapsed against this spectrum
-/// looks like.
+/// looks like, and so is a channel whose rate comes from the branching overlay
+/// rather than from a group average.
 pub fn perturb_rates(
     rates: &ReactionRates,
     per_group: &PerGroupRates,
@@ -157,14 +165,16 @@ pub fn perturb_rates(
             let Some(rate) = nuclide_rates.get_mut(kind) else {
                 continue;
             };
-            // Sum the same terms the nominal rate is the sum of, weighted. With
-            // every delta zero this reproduces the nominal rate exactly, which
-            // is what keeps an unperturbed replica honest.
-            *rate = terms
+            let nominal: f64 = terms.iter().sum();
+            if nominal <= 0.0 {
+                continue;
+            }
+            let perturbed: f64 = terms
                 .iter()
                 .zip(delta)
                 .map(|(term, d)| term * (1.0 + d))
                 .sum();
+            *rate *= perturbed / nominal;
         }
     }
     out
@@ -211,6 +221,35 @@ mod tests {
         let nominal: f64 = terms.iter().sum();
         let out = perturb_rates(&rates(nominal), &per_group(terms), &[0.0, 0.0, 0.0]);
         assert_eq!(out["Li6"]["(n,t)"], nominal);
+    }
+
+    /// And reproduces it even when the terms describe a different weighting.
+    ///
+    /// The terms are a shape, not a substitute for the rate. Assigning their
+    /// sum instead of scaling by it is how a shielded rate used to be replaced
+    /// by a dilute one at zero perturbation.
+    #[test]
+    fn an_unperturbed_replica_does_not_replace_the_rate_with_the_terms() {
+        // A rate 30% below what the terms sum to, which is roughly what
+        // self-shielding does to a resonance absorber's capture.
+        let shielded = 0.7;
+        let out = perturb_rates(
+            &rates(shielded),
+            &per_group(vec![0.25, 0.5, 0.25]),
+            &[0.0, 0.0, 0.0],
+        );
+        assert_eq!(out["Li6"]["(n,t)"], shielded);
+    }
+
+    /// A term set summing to nothing has no shape to perturb along.
+    #[test]
+    fn a_channel_with_no_rate_in_any_bin_is_left_alone() {
+        let out = perturb_rates(
+            &rates(1.0),
+            &per_group(vec![0.0, 0.0, 0.0]),
+            &[0.5, 0.5, 0.5],
+        );
+        assert_eq!(out["Li6"]["(n,t)"], 1.0);
     }
 
     /// The rate is linear in the flux, so a uniform perturbation scales it.

--- a/crates/yani-transmute/src/lib.rs
+++ b/crates/yani-transmute/src/lib.rs
@@ -120,8 +120,10 @@ pub fn load_configured_chain() -> Result<yani::LoadedChain, Box<dyn std::error::
     )
 }
 pub use derived::{Estimate, LineEstimate};
-pub use multigroup::{compute_multigroup_reaction_rates, scale_rates, EnergyGroups};
-pub use results::TransmutationResults;
+pub use multigroup::{
+    compute_multigroup_reaction_rates, reaction_rate_spectrum, scale_rates, EnergyGroups,
+};
+pub use results::{CollapseInputs, RateSpectrum, TransmutationResults};
 pub use schedule::{duration_to_seconds, Schedule, ScheduleStep};
 pub use self_shielding::{Shape, Shielding, ShieldingInfo};
 pub use transmutation::TransmutationDriver;

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -394,6 +394,23 @@ pub fn transmute_material_shielded(
     // rather than from whatever a second load of the chain path returns.
     results.chain = Some(Arc::clone(&chain));
 
+    // And the spectra it collapsed against, for the same reason: an
+    // energy-resolved view of a rate is a statement about the spectrum that
+    // drove it, and re-deriving one channel's breakdown on demand costs a few
+    // KB of stored spectrum rather than the tens of MB the whole breakdown
+    // would (yani#27).
+    results.collapse = Some(crate::results::CollapseInputs {
+        spectra: spectra
+            .iter()
+            .map(|s| (s.boundaries.clone(), s.masses.clone()))
+            .collect(),
+        step_spectrum: steps
+            .iter()
+            .map(|st| st.irradiation.map(|(idx, _)| idx))
+            .collect(),
+        shielding: shielding.copied(),
+    });
+
     Ok(results)
 }
 

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -380,6 +380,7 @@ pub fn transmute_material_shielded(
             parts,
             &stepper,
             request,
+            shielding,
         )?;
         results.uncertainty.insert(material_id, ensemble);
         results.uncertainty_info = Some(info);
@@ -685,6 +686,7 @@ fn run_replicas(
     parts: yani::ChainParts,
     stepper: &ForwardEulerStepper,
     request: &DataUncertainty,
+    shielding: Option<&Shielding>,
 ) -> Result<(Ensemble, Info), Box<dyn std::error::Error>> {
     // One fold and one factorization per distinct spectrum, not per replica.
     // The fold is relativized, so the per-step `scale_rates` leaves it correct:
@@ -745,6 +747,7 @@ fn run_replicas(
                         &per_spectrum[idx].2,
                         &spectrum.masses,
                         &spectrum.boundaries,
+                        shielding,
                     ),
                 )));
             }

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -490,7 +490,6 @@ pub fn compute_multigroup_reaction_rates_shielded(
 ) -> (ReactionRates, FissionYieldWeights, ShieldingInfo) {
     let mut rates: ReactionRates = HashMap::new();
     let mut fy_weights: FissionYieldWeights = HashMap::new();
-    let n_groups = multigroup_flux.len();
 
     let mut info = ShieldingInfo::default();
     if let Some(s) = shielding {
@@ -504,39 +503,8 @@ pub fn compute_multigroup_reaction_rates_shielded(
     }
 
     // Total scalar flux = sum of group fluxes
-    let total_flux: f64 = multigroup_flux.iter().sum();
-    if total_flux <= 0.0 {
+    let Some(setup) = CollapseSetup::new(material, multigroup_flux, shielding) else {
         return (rates, fy_weights, info);
-    }
-
-    // The flux depression is a property of the whole material, so the mixture
-    // total is gathered once and every nuclide's shape is built against it.
-    let densities = material.get_atoms_per_barn_cm().unwrap_or_default();
-    let temperature_for = |name: &str| -> Option<String> {
-        let nd = material.nuclide_data.get(name)?;
-        if material.temperature().is_empty() {
-            crate::default_temperature(nd)
-        } else {
-            Some(material.temperature().to_string())
-        }
-    };
-    let mixture = shielding.map(|_| mixture_total(material, &densities, &temperature_for));
-
-    // The groups worth walking, decided once for the whole spectrum rather than
-    // per nuclide per reaction. A group with no flux contributes `sigma_g * 0.0`
-    // to the collapse and `scale = 0.0` to the yield fold, both of which are
-    // exactly `+0.0`, so skipping it is bit-neutral -- and a monoenergetic 14
-    // MeV source in CCFE-709 leaves 1 group of 709 (issue #576, finding 2).
-    //
-    // Only on the dilute path. `info.strongest_factor` mins over every group a
-    // shielded run walks, zero-flux ones included, so skipping them there would
-    // change a reported number rather than only the time taken.
-    let active: Vec<usize> = if shielding.is_none() {
-        (0..n_groups)
-            .filter(|&g| multigroup_flux[g] != 0.0)
-            .collect()
-    } else {
-        (0..n_groups).collect()
     };
 
     // One nuclide's collapse is independent of every other's: it reads the
@@ -549,17 +517,13 @@ pub fn compute_multigroup_reaction_rates_shielded(
     // comes out in the order the sequential loop produced rather than merely
     // holding the same names.
     let entries: Vec<(&String, &ChainNuclide)> = chain.iter().collect();
-    let context = Collapse {
+    let context = setup.context(
         material,
         multigroup_flux,
         group_boundaries,
         source_rate,
         shielding,
-        densities: &densities,
-        mixture: mixture.as_ref(),
-        active: &active,
-        total_flux,
-    };
+    );
     let collapsed: Vec<Option<NuclideCollapse>> = {
         let one = |&(name, chain_nuclide): &(&String, &ChainNuclide)| {
             context.collapse_nuclide(name, chain_nuclide)
@@ -627,6 +591,113 @@ struct NuclideCollapse {
     strongest_factor: Option<f64>,
 }
 
+/// Everything derived from the material and the spectrum that every nuclide's
+/// collapse shares, gathered once.
+///
+/// A struct rather than four locals so that [`reaction_rate_spectrum`], which
+/// walks one channel long after the solve, builds its context the same way
+/// [`compute_multigroup_reaction_rates_shielded`] does. Two copies of this
+/// gather would be two chances for an energy-resolved rate and the collapsed
+/// rate it is supposed to sum to to disagree.
+struct CollapseSetup<'a> {
+    densities: HashMap<String, f64>,
+    mixture: Option<crate::self_shielding::MixtureTotal<'a>>,
+    active: Vec<usize>,
+    total_flux: f64,
+}
+
+impl<'a> CollapseSetup<'a> {
+    /// `None` when the spectrum carries no flux, which drives nothing.
+    fn new(
+        material: &'a Material,
+        multigroup_flux: &[f64],
+        shielding: Option<&Shielding>,
+    ) -> Option<Self> {
+        let total_flux: f64 = multigroup_flux.iter().sum();
+        if total_flux <= 0.0 {
+            return None;
+        }
+
+        // The flux depression is a property of the whole material, so the
+        // mixture total is gathered once and every nuclide's shape is built
+        // against it.
+        let densities = material.get_atoms_per_barn_cm().unwrap_or_default();
+        let temperature_for = |name: &str| -> Option<String> {
+            let nd = material.nuclide_data.get(name)?;
+            if material.temperature().is_empty() {
+                crate::default_temperature(nd)
+            } else {
+                Some(material.temperature().to_string())
+            }
+        };
+        let mixture = shielding.map(|_| mixture_total(material, &densities, &temperature_for));
+
+        // The groups worth walking, decided once for the whole spectrum rather
+        // than per nuclide per reaction. A group with no flux contributes
+        // `sigma_g * 0.0` to the collapse and `scale = 0.0` to the yield fold,
+        // both of which are exactly `+0.0`, so skipping it is bit-neutral --
+        // and a monoenergetic 14 MeV source in CCFE-709 leaves 1 group of 709
+        // (issue #576, finding 2).
+        //
+        // Only on the dilute path. `info.strongest_factor` mins over every
+        // group a shielded run walks, zero-flux ones included, so skipping them
+        // there would change a reported number rather than only the time taken.
+        let n_groups = multigroup_flux.len();
+        let active: Vec<usize> = if shielding.is_none() {
+            (0..n_groups)
+                .filter(|&g| multigroup_flux[g] != 0.0)
+                .collect()
+        } else {
+            (0..n_groups).collect()
+        };
+
+        Some(Self {
+            densities,
+            mixture,
+            active,
+            total_flux,
+        })
+    }
+
+    /// The per-nuclide collapse context this setup supports.
+    fn context<'b>(
+        &'b self,
+        material: &'b Material,
+        multigroup_flux: &'b [f64],
+        group_boundaries: &'b [f64],
+        source_rate: f64,
+        shielding: Option<&'b Shielding>,
+    ) -> Collapse<'b>
+    where
+        'a: 'b,
+    {
+        Collapse {
+            material,
+            multigroup_flux,
+            group_boundaries,
+            source_rate,
+            shielding,
+            densities: &self.densities,
+            mixture: self.mixture.as_ref(),
+            active: &self.active,
+            total_flux: self.total_flux,
+        }
+    }
+}
+
+/// What one channel's walk accumulates besides the rate itself.
+///
+/// Returned rather than written in place so the walk is a pure function of its
+/// inputs and both of its callers can ignore what they do not want.
+#[derive(Default)]
+struct ChannelWalk {
+    /// The strongest per-group suppression the shielded average applied.
+    strongest_factor: Option<f64>,
+    /// Numerator and denominator of the dilute run's self-shielding indicator.
+    bound_shielded: f64,
+    bound_dilute: f64,
+}
+
 /// What one nuclide's collapse needs from outside itself. All of it read-only,
 /// which is what makes the map safe to run in parallel.
 struct Collapse<'a> {
@@ -642,6 +713,97 @@ struct Collapse<'a> {
 }
 
 impl Collapse<'_> {
+    /// The flux shape one nuclide's group averages are taken under, with what
+    /// a report should say about it: `(shape, why not, whether it was)`.
+    ///
+    /// One flux shape per nuclide: the mixture sets the depression, the
+    /// nuclide's own elastic scattering fills its resonance dips. `None` on the
+    /// dilute path, and on the shielded path for a nuclide whose name or data
+    /// will not support one.
+    fn shape_for(
+        &self,
+        nuclide_name: &str,
+        reactions: &HashMap<i32, std::sync::Arc<Reaction>>,
+    ) -> (Option<FluxShape>, Option<String>, bool) {
+        match (self.shielding, self.mixture) {
+            (Some(request), Some(mix)) => match mass_number_of(nuclide_name) {
+                Some(mass_number) => {
+                    let elastic = reactions
+                        .get(&crate::self_shielding::MT_ELASTIC)
+                        .map(|r| r.as_ref());
+                    let why_not = elastic.is_none().then(|| "no MT=2 elastic".to_string());
+                    let density = self.densities.get(nuclide_name).copied().unwrap_or(0.0);
+                    (
+                        Some(flux_shape(mix, elastic, density, mass_number, request)),
+                        why_not,
+                        true,
+                    )
+                }
+                None => (
+                    None,
+                    Some("mass number not parsable from the name".to_string()),
+                    false,
+                ),
+            },
+            _ => (None, None, false),
+        }
+    }
+
+    /// Walk one channel over every active group, handing each group's average
+    /// to `on_group` as `(g, sigma_g, phi_g)`.
+    ///
+    /// This is the one definition of what `sigma_g` means for a group, so the
+    /// collapsed rate and any energy-resolved view of it cannot drift apart:
+    /// [`Collapse::collapse_nuclide`] sums `sigma_g * phi_g` out of it and
+    /// [`reaction_rate_spectrum`] keeps the terms.
+    ///
+    /// `bound_density` (atoms/barn-cm, and only meaningful when positive) turns
+    /// on the dilute run's self-shielding indicator. A caller that does not
+    /// want it passes `None` and the walk does less work.
+    fn walk_channel(
+        &self,
+        reaction: &Reaction,
+        shape: Option<&FluxShape>,
+        bound_density: Option<f64>,
+        mut on_group: impl FnMut(usize, f64, f64),
+    ) -> ChannelWalk {
+        let mut walk = ChannelWalk::default();
+        for &g in self.active {
+            let e_lo = self.group_boundaries[g];
+            let e_hi = self.group_boundaries[g + 1];
+            let phi = self.multigroup_flux[g];
+            // One walk of this group's points, whichever of the three
+            // integrals over them are wanted.
+            let terms = walk_group(
+                reaction,
+                e_lo,
+                e_hi,
+                shape,
+                // `strongest_possible_suppression` skips a group with no
+                // flux in it, so the indicator must not accumulate one here.
+                bound_density.filter(|_| phi > 0.0),
+            );
+            let sigma_g = if shape.is_some() {
+                let shielded = terms.shielded();
+                let dilute = terms.dilute(e_lo, e_hi);
+                if dilute > 0.0 {
+                    let factor = shielded / dilute;
+                    walk.strongest_factor =
+                        Some(walk.strongest_factor.map_or(factor, |f: f64| f.min(factor)));
+                }
+                shielded
+            } else {
+                terms.dilute(e_lo, e_hi)
+            };
+            if let Some((s, d)) = terms.bound_contribution(phi) {
+                walk.bound_shielded += s;
+                walk.bound_dilute += d;
+            }
+            on_group(g, sigma_g, phi);
+        }
+        walk
+    }
+
     /// Collapse one nuclide, or `None` when it has nothing to contribute.
     fn collapse_nuclide(
         &self,
@@ -674,28 +836,9 @@ impl Collapse<'_> {
             strongest_factor: None,
         };
 
-        // One flux shape per nuclide: the mixture sets the depression, the
-        // nuclide's own elastic scattering fills its resonance dips.
-        let shape: Option<FluxShape> = match (self.shielding, self.mixture) {
-            (Some(request), Some(mix)) => match mass_number_of(nuclide_name) {
-                Some(mass_number) => {
-                    let elastic = reactions
-                        .get(&crate::self_shielding::MT_ELASTIC)
-                        .map(|r| r.as_ref());
-                    if elastic.is_none() {
-                        out.not_shielded = Some("no MT=2 elastic".to_string());
-                    }
-                    let density = self.densities.get(nuclide_name).copied().unwrap_or(0.0);
-                    out.shielded = true;
-                    Some(flux_shape(mix, elastic, density, mass_number, request))
-                }
-                None => {
-                    out.not_shielded = Some("mass number not parsable from the name".to_string());
-                    None
-                }
-            },
-            _ => None,
-        };
+        let (shape, not_shielded, shielded) = self.shape_for(nuclide_name, reactions);
+        out.not_shielded = not_shielded;
+        out.shielded = shielded;
 
         // Get unique reaction types from chain
         let mut reaction_types: Vec<&str> = chain_nuclide
@@ -741,58 +884,36 @@ impl Collapse<'_> {
                 .is_none()
                 .then(|| self.densities.get(nuclide_name).copied().unwrap_or(0.0))
                 .filter(|&d| d > 0.0);
-            let (mut bound_shielded, mut bound_dilute) = (0.0, 0.0);
 
             // Collapse: σ_eff = Σ(σ_g × φ_g) / Σ(φ_g)
             let mut sigma_phi_sum = 0.0;
-            for &g in self.active {
-                let e_lo = self.group_boundaries[g];
-                let e_hi = self.group_boundaries[g + 1];
-                let phi = self.multigroup_flux[g];
-                // One walk of this group's points, whichever of the three
-                // integrals over them are wanted.
-                let terms = walk_group(
-                    reaction,
-                    e_lo,
-                    e_hi,
-                    shape.as_ref(),
-                    // `strongest_possible_suppression` skips a group with no
-                    // flux in it, so the indicator must not accumulate one here.
-                    bound_density.filter(|_| phi > 0.0),
-                );
-                let sigma_g = if shape.is_some() {
-                    let shielded = terms.shielded();
-                    let dilute = terms.dilute(e_lo, e_hi);
-                    if dilute > 0.0 {
-                        let factor = shielded / dilute;
-                        out.strongest_factor =
-                            Some(out.strongest_factor.map_or(factor, |f: f64| f.min(factor)));
+            let walk = self.walk_channel(
+                reaction,
+                shape.as_ref(),
+                bound_density,
+                |g, sigma_g, phi| {
+                    sigma_phi_sum += sigma_g * phi;
+                    if let Some(fy_set) = fold_yields {
+                        add_group_fission_xs_by_yield_point(
+                            reaction,
+                            fy_set,
+                            &fy_energies,
+                            self.group_boundaries[g],
+                            self.group_boundaries[g + 1],
+                            phi,
+                            &mut yield_shares,
+                        );
                     }
-                    shielded
-                } else {
-                    terms.dilute(e_lo, e_hi)
-                };
-                if let Some((s, d)) = terms.bound_contribution(phi) {
-                    bound_shielded += s;
-                    bound_dilute += d;
-                }
-                sigma_phi_sum += sigma_g * phi;
-                if let Some(fy_set) = fold_yields {
-                    add_group_fission_xs_by_yield_point(
-                        reaction,
-                        fy_set,
-                        &fy_energies,
-                        e_lo,
-                        e_hi,
-                        phi,
-                        &mut yield_shares,
-                    );
-                }
+                },
+            );
+            if let Some(factor) = walk.strongest_factor {
+                out.strongest_factor =
+                    Some(out.strongest_factor.map_or(factor, |f: f64| f.min(factor)));
             }
 
             if bound_density.is_some() {
-                let bound = if bound_dilute > 0.0 {
-                    (bound_shielded / bound_dilute).min(1.0)
+                let bound = if walk.bound_dilute > 0.0 {
+                    (walk.bound_shielded / walk.bound_dilute).min(1.0)
                 } else {
                     1.0
                 };
@@ -835,6 +956,88 @@ fn fy_set_for(chain_nuclide: &ChainNuclide) -> Option<&FissionYieldSet> {
         .fission_yields
         .as_deref()
         .filter(|s| !s.yields.is_empty())
+}
+
+/// The per-group contributions to one channel's collapsed reaction rate.
+///
+/// `out[g]` is `1e-24 * sigma_g * phi_g * source_rate` in 1/s, so summing over
+/// the groups gives the rate
+/// [`compute_multigroup_reaction_rates_shielded`] reports for the same
+/// channel, and each entry is that group's share of it. Both come from
+/// [`Collapse::walk_channel`], self-shielding included, so the two cannot
+/// disagree about what `sigma_g` means; they agree to floating-point rounding
+/// rather than bit-exactly, because the collapse divides the sum by the total
+/// flux and multiplies it back.
+///
+/// # Why one channel, and nothing stored
+///
+/// This is the question a one-group rate cannot answer: a rate of 57 mb
+/// against a spectrum that is 89% fast and 0.7% below 100 keV says nothing
+/// about which of those two the rate came from, and the answer decides whether
+/// a disagreement belongs to resonance processing or to the fast cross section
+/// (yani#27).
+///
+/// Keeping the breakdown for every channel would be the rate map times the
+/// group count, tens of MB on a 709-group structure, which is why
+/// [`per_group_reaction_rates`] is built only when flux uncertainty asks for it
+/// (issue #559). A diagnostic asks about one channel at a time, and walking a
+/// single reaction over 709 groups is fast enough to do on demand, so nothing
+/// is stored and the default path pays nothing.
+///
+/// # Returns
+///
+/// `None` when the material holds no data for `nuclide`, when `kind` names no
+/// MT this build collapses, when the reaction is absent from the data, or when
+/// the spectrum carries no flux. `(n,n')` is the notable absence: it has no
+/// transport total, so its rate comes from the branching overlay's MF=10
+/// partials rather than from a group average, and there is no `sigma_g` here
+/// to report.
+pub fn reaction_rate_spectrum(
+    material: &Material,
+    multigroup_flux: &[f64],
+    group_boundaries: &[f64],
+    source_rate: f64,
+    shielding: Option<&Shielding>,
+    nuclide: &str,
+    kind: &str,
+) -> Option<Vec<f64>> {
+    // A pulse at zero flux drives nothing, exactly as
+    // `compute_multigroup_reaction_rates_shielded` treats it, and a vector of
+    // zeros would read as a rate resolved rather than as no rate at all.
+    if source_rate == 0.0 {
+        return None;
+    }
+    let mt = reaction_type_to_mt(kind)?;
+    let nuclide_data = material.nuclide_data.get(nuclide)?;
+    let temperature = if material.temperature().is_empty() {
+        crate::default_temperature(nuclide_data)?
+    } else {
+        material.temperature().to_string()
+    };
+    let reactions = nuclide_data.reactions_for_temp(&temperature)?;
+    let reaction = reactions.get(&mt)?;
+
+    let setup = CollapseSetup::new(material, multigroup_flux, shielding)?;
+    let context = setup.context(
+        material,
+        multigroup_flux,
+        group_boundaries,
+        source_rate,
+        shielding,
+    );
+    // The shielded average needs the nuclide's flux shape; the self-shielding
+    // indicator does not belong to a rate, so its density is left off and the
+    // walk skips that accumulation.
+    let (shape, _, _) = context.shape_for(nuclide, reactions);
+
+    // A zero-flux group is not walked on the dilute path, and its term is
+    // exactly zero, so the vector is sized to the whole structure and only the
+    // active groups are written into it.
+    let mut out = vec![0.0; multigroup_flux.len()];
+    context.walk_channel(reaction, shape.as_ref(), None, |g, sigma_g, phi| {
+        out[g] = sigma_g * phi * 1.0e-24 * source_rate;
+    });
+    Some(out)
 }
 
 /// The per-group contributions to each reaction rate, for flux uncertainty.

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -713,6 +713,21 @@ struct Collapse<'a> {
 }
 
 impl Collapse<'_> {
+    /// The reactions loaded for one nuclide at the temperature in use.
+    ///
+    /// Shared so that every consumer of the collapse resolves the temperature
+    /// the same way; a second copy of this is a second chance to read a
+    /// different evaluation than the one the rates came from.
+    fn reactions_for(&self, nuclide_name: &str) -> Option<&HashMap<i32, std::sync::Arc<Reaction>>> {
+        let nuclide_data = self.material.nuclide_data.get(nuclide_name)?;
+        let temperature = if self.material.temperature().is_empty() {
+            crate::default_temperature(nuclide_data)?
+        } else {
+            self.material.temperature().to_string()
+        };
+        nuclide_data.reactions_for_temp(&temperature)
+    }
+
     /// The flux shape one nuclide's group averages are taken under, with what
     /// a report should say about it: `(shape, why not, whether it was)`.
     ///
@@ -814,18 +829,7 @@ impl Collapse<'_> {
             return None;
         }
 
-        // Get nuclide data
-        let nuclide_data = self.material.nuclide_data.get(nuclide_name)?;
-
-        // Get temperature for data lookup
-        let temperature = if self.material.temperature().is_empty() {
-            crate::default_temperature(nuclide_data)?
-        } else {
-            self.material.temperature().to_string()
-        };
-
-        // Get reactions for this temperature
-        let reactions = nuclide_data.reactions_for_temp(&temperature)?;
+        let reactions = self.reactions_for(nuclide_name)?;
 
         let mut out = NuclideCollapse {
             rates: HashMap::new(),
@@ -840,16 +844,7 @@ impl Collapse<'_> {
         out.not_shielded = not_shielded;
         out.shielded = shielded;
 
-        // Get unique reaction types from chain
-        let mut reaction_types: Vec<&str> = chain_nuclide
-            .reactions
-            .iter()
-            .map(|r| r.kind.as_str())
-            .collect();
-        reaction_types.sort();
-        reaction_types.dedup();
-
-        for &rx_type in &reaction_types {
+        for &rx_type in &kinds_of(chain_nuclide) {
             let mt = match reaction_type_to_mt(rx_type) {
                 Some(mt) => mt,
                 None => continue,
@@ -950,6 +945,18 @@ impl Collapse<'_> {
     }
 }
 
+/// The reaction kinds the chain drives on one nuclide, sorted and deduped.
+fn kinds_of(chain_nuclide: &ChainNuclide) -> Vec<&str> {
+    let mut kinds: Vec<&str> = chain_nuclide
+        .reactions
+        .iter()
+        .map(|r| r.kind.as_str())
+        .collect();
+    kinds.sort();
+    kinds.dedup();
+    kinds
+}
+
 /// The nuclide's fission yields, if it has any tabulated.
 fn fy_set_for(chain_nuclide: &ChainNuclide) -> Option<&FissionYieldSet> {
     chain_nuclide
@@ -1008,15 +1015,6 @@ pub fn reaction_rate_spectrum(
         return None;
     }
     let mt = reaction_type_to_mt(kind)?;
-    let nuclide_data = material.nuclide_data.get(nuclide)?;
-    let temperature = if material.temperature().is_empty() {
-        crate::default_temperature(nuclide_data)?
-    } else {
-        material.temperature().to_string()
-    };
-    let reactions = nuclide_data.reactions_for_temp(&temperature)?;
-    let reaction = reactions.get(&mt)?;
-
     let setup = CollapseSetup::new(material, multigroup_flux, shielding)?;
     let context = setup.context(
         material,
@@ -1025,6 +1023,8 @@ pub fn reaction_rate_spectrum(
         source_rate,
         shielding,
     );
+    let reactions = context.reactions_for(nuclide)?;
+    let reaction = reactions.get(&mt)?;
     // The shielded average needs the nuclide's flux shape; the self-shielding
     // indicator does not belong to a rate, so its density is left off and the
     // walk skips that accumulation.
@@ -1043,26 +1043,32 @@ pub fn reaction_rate_spectrum(
 /// The per-group contributions to each reaction rate, for flux uncertainty.
 ///
 /// `out[nuclide][kind][g]` is that group's share of the rate, so the nominal
-/// rate is the sum over `g`. Computed by the same collapse as
-/// [`compute_multigroup_reaction_rates`] and against the same cross sections,
-/// so the sums agree with the rates it returns.
+/// rate is the sum over `g`. Every group average comes from
+/// [`Collapse::walk_channel`], the same walk
+/// [`compute_multigroup_reaction_rates_shielded`] collapses with and under the
+/// same `shielding`, so the terms sum to the rate that run produced rather than
+/// to a differently weighted one.
 ///
 /// Separate rather than an extra return value because it is only ever wanted
 /// when flux uncertainty is requested: it is the rate map times the group
 /// count, which on a 709-group structure is tens of MB, and the default path
-/// should not pay that (issue #559).
+/// should not pay that (issue #559). [`reaction_rate_spectrum`] is the
+/// one-channel form, for asking rather than for perturbing.
 pub fn per_group_reaction_rates(
     material: &Material,
     chain: &HashMap<String, ChainNuclide>,
     multigroup_flux: &[f64],
     group_boundaries: &[f64],
+    shielding: Option<&Shielding>,
 ) -> crate::flux_uncertainty::PerGroupRates {
     let mut out: crate::flux_uncertainty::PerGroupRates = HashMap::new();
     let n_groups = multigroup_flux.len();
-    let total_flux: f64 = multigroup_flux.iter().sum();
-    if n_groups == 0 || total_flux <= 0.0 {
+    let Some(setup) = CollapseSetup::new(material, multigroup_flux, shielding) else {
         return out;
-    }
+    };
+    // Unit source rate: these decompose the unit-flux rates the replicas
+    // perturb, and the step's magnitude is applied to both alike afterwards.
+    let context = setup.context(material, multigroup_flux, group_boundaries, 1.0, shielding);
 
     // Per nuclide and independent, exactly as the collapse it mirrors is, and
     // merged into a map keyed by a name that appears once -- so the order the
@@ -1072,40 +1078,26 @@ pub fn per_group_reaction_rates(
         if chain_nuclide.reactions.is_empty() {
             return None;
         }
-        let nuclide_data = material.nuclide_data.get(nuclide_name)?;
-        let temperature = if material.temperature().is_empty() {
-            crate::default_temperature(nuclide_data)?
-        } else {
-            material.temperature().to_string()
-        };
-        let reactions = nuclide_data.reactions_for_temp(&temperature)?;
-
-        let mut kinds: Vec<&str> = chain_nuclide
-            .reactions
-            .iter()
-            .map(|r| r.kind.as_str())
-            .collect();
-        kinds.sort();
-        kinds.dedup();
+        let reactions = context.reactions_for(nuclide_name)?;
+        let (shape, _, _) = context.shape_for(nuclide_name, reactions);
 
         let mut per_kind: HashMap<String, Vec<f64>> = HashMap::new();
-        for kind in kinds {
+        for kind in kinds_of(chain_nuclide) {
             let Some(mt) = reaction_type_to_mt(kind) else {
                 continue;
             };
             let Some(reaction) = reactions.get(&mt) else {
                 continue;
             };
-            let terms: Vec<f64> = (0..n_groups)
-                .map(|g| {
-                    let sigma_g =
-                        group_averaged_xs(reaction, group_boundaries[g], group_boundaries[g + 1]);
-                    // The same 1e-24 barn-to-cm^2 factor the rate carries, so
-                    // these sum to the rate rather than to something
-                    // proportional to it.
-                    sigma_g * multigroup_flux[g] * 1.0e-24
-                })
-                .collect();
+            // A group the walk skips carries no flux, so its term is exactly
+            // zero and the vector is sized to the whole structure regardless:
+            // the perturbation indexes it by the caller's own bin.
+            let mut terms = vec![0.0; n_groups];
+            context.walk_channel(reaction, shape.as_ref(), None, |g, sigma_g, phi| {
+                // The same 1e-24 barn-to-cm^2 factor the rate carries, so these
+                // sum to the rate rather than to something proportional to it.
+                terms[g] = sigma_g * phi * 1.0e-24;
+            });
             if terms.iter().any(|t| *t > 0.0) {
                 per_kind.insert(kind.to_string(), terms);
             }

--- a/crates/yani-transmute/src/results.rs
+++ b/crates/yani-transmute/src/results.rs
@@ -70,6 +70,50 @@ pub struct TransmutationResults {
     ///
     /// `None` on results built by hand, which is what the tests do.
     pub chain: Option<std::sync::Arc<HashMap<String, yani::ChainNuclide>>>,
+
+    /// What the multigroup collapse was driven with, for re-deriving an
+    /// energy-resolved view of a rate afterwards.
+    ///
+    /// `None` when there was no multigroup collapse: a transport-coupled solve
+    /// scores its rates at the collision energy and keeps no group structure to
+    /// resolve them onto, and results built by hand have no spectrum at all.
+    pub collapse: Option<CollapseInputs>,
+}
+
+/// The spectra a solve collapsed against, and how its steps used them.
+///
+/// Small on purpose. Two vectors per distinct spectrum is a few KB against the
+/// tens of MB the full per-group rate breakdown would be, and it is enough to
+/// re-derive any single channel's breakdown on demand
+/// (see [`crate::multigroup::reaction_rate_spectrum`]).
+#[derive(Debug, Clone)]
+pub struct CollapseInputs {
+    /// One entry per distinct spectrum: group boundaries [eV], ascending and
+    /// one longer than the flux, and the flux shape the collapse weighted with.
+    ///
+    /// The shape is normalized, so the magnitude of a step's flux is its entry
+    /// in [`TransmutationResults::source_rates`], exactly as the solve applies
+    /// it.
+    pub spectra: Vec<(Vec<f64>, Vec<f64>)>,
+
+    /// Which spectrum each schedule step used, indexed as
+    /// [`TransmutationResults::timesteps`]. `None` for a decay-only step, which
+    /// drives no reactions.
+    pub step_spectrum: Vec<Option<usize>>,
+
+    /// The self-shielding request the collapse ran under, when there was one,
+    /// so a re-derived breakdown is weighted the way the solve weighted it.
+    pub shielding: Option<crate::self_shielding::Shielding>,
+}
+
+/// One channel's reaction rate, resolved onto the spectrum's own groups.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RateSpectrum {
+    /// Group boundaries [eV], ascending, one longer than `rates`.
+    pub boundaries: Vec<f64>,
+    /// Each group's contribution to the rate [1/s], summing to the rate
+    /// [`TransmutationResults::get_reaction_rates`] reports for the channel.
+    pub rates: Vec<f64>,
 }
 
 /// Flux-weighted isomeric branching: `parent -> kind -> [(target, fraction)]`.
@@ -142,6 +186,7 @@ impl TransmutationResults {
             uncertainty_info: None,
             shielding_info: None,
             chain: None,
+            collapse: None,
         }
     }
 
@@ -182,6 +227,68 @@ impl TransmutationResults {
     /// `Some(&empty)` for a decay-only step.
     pub fn get_reaction_rates(&self, material_id: u32, step: usize) -> Option<&EdgeRates> {
         self.reaction_rates.get(&material_id)?.get(step)
+    }
+
+    /// One channel's reaction rate over one step, resolved onto the groups of
+    /// the spectrum that drove it.
+    ///
+    /// [`Self::get_reaction_rates`] answers with one number per edge, already
+    /// collapsed. That number cannot say which part of the spectrum made it,
+    /// and on a channel whose cross section spans decades the two readings are
+    /// different physics: an effective `W186(n,gamma)` of 57 mb against a
+    /// spectrum 89% of which sits in 12-16 MeV and 0.7% below 100 keV is
+    /// either a fast-capture rate or a resonance-region rate, and only the
+    /// breakdown says which (yani#27). A disagreement can then be attributed
+    /// to resonance processing rather than guessed at, and a covariance grid
+    /// that stops short of the spectrum can be checked against where the rate
+    /// actually is.
+    ///
+    /// The entries sum to the collapsed rate for the same `(nuclide, kind)`,
+    /// up to floating-point rounding, because both come from the same walk of
+    /// the same cross sections, self-shielding included.
+    ///
+    /// Nothing is stored for this: the breakdown is re-derived from the
+    /// spectrum and the step's initial composition when asked for, which is one
+    /// reaction over the group structure. Keeping it for every channel would be
+    /// tens of MB on a 709-group structure, and the default path should not pay
+    /// that.
+    ///
+    /// `step` indexes [`Self::timesteps`], as [`Self::get_reaction_rates`]
+    /// does.
+    ///
+    /// `None` when the material, the step, the nuclide or the channel is
+    /// unknown; when the step drove no flux, whether by being decay-only or by
+    /// carrying a zero rate; and on a transport-coupled solve, which scores its
+    /// rates at the collision energy and keeps no group structure to resolve
+    /// them onto.
+    pub fn get_reaction_rate_spectrum(
+        &self,
+        material_id: u32,
+        nuclide: &str,
+        kind: &str,
+        step: usize,
+    ) -> Option<RateSpectrum> {
+        let inputs = self.collapse.as_ref()?;
+        let spectrum = (*inputs.step_spectrum.get(step)?)?;
+        let (boundaries, flux) = inputs.spectra.get(spectrum)?;
+        let source_rate = self.source_rates.get(step).copied()?;
+        // The collapse is done once from the initial composition and scaled per
+        // step, so this is the material it read, and `source_rate` is the
+        // scaling the step applied.
+        let material = self.get_material(material_id, 0)?;
+        let rates = crate::multigroup::reaction_rate_spectrum(
+            material,
+            flux,
+            boundaries,
+            source_rate,
+            inputs.shielding.as_ref(),
+            nuclide,
+            kind,
+        )?;
+        Some(RateSpectrum {
+            boundaries: boundaries.clone(),
+            rates,
+        })
     }
 
     /// Flux-weighted isomeric branching for one material over one step:
@@ -773,5 +880,49 @@ mod tests {
         );
         assert!(results.get_reaction_rates(7, 1).expect("step 1").is_empty());
         assert!(results.get_reaction_rates(7, 2).is_none());
+    }
+
+    /// A rate that came from somewhere other than a multigroup collapse has no
+    /// group structure to resolve onto, and must say so rather than answer with
+    /// a spectrum it invented.
+    #[test]
+    fn a_rate_from_no_spectrum_has_no_spectrum() {
+        let mut results = TransmutationResults::new(vec![1.0], vec![1.0e14]);
+        results.add_initial(7, material("initial"));
+        results.add_step_rates(7, EdgeRates::new());
+        results.add_step(7, material("after"));
+
+        // This is the transport-coupled case: the rates are scored at the
+        // collision energy and no spectrum is kept.
+        assert!(results.collapse.is_none());
+        assert!(results
+            .get_reaction_rate_spectrum(7, "Fe56", "(n,gamma)", 0)
+            .is_none());
+    }
+
+    /// A decay-only step drives no reactions, so there is nothing to resolve,
+    /// and the step after it must still be answerable.
+    #[test]
+    fn a_decay_only_step_has_no_rate_spectrum() {
+        let mut results = TransmutationResults::new(vec![1.0, 2.0], vec![0.0, 1.0e14]);
+        results.add_initial(7, material("initial"));
+        results.collapse = Some(CollapseInputs {
+            spectra: vec![(vec![1.0e-5, 1.0e5, 2.0e7], vec![1.0, 1.0])],
+            step_spectrum: vec![None, Some(0)],
+            shielding: None,
+        });
+
+        assert!(results
+            .get_reaction_rate_spectrum(7, "Fe56", "(n,gamma)", 0)
+            .is_none());
+        // The irradiation step is reachable, and stops on the material's data
+        // rather than on the indexing: this one was built by hand and carries
+        // no cross sections.
+        assert!(results
+            .get_reaction_rate_spectrum(7, "Fe56", "(n,gamma)", 1)
+            .is_none());
+        assert!(results
+            .get_reaction_rate_spectrum(7, "Fe56", "(n,gamma)", 2)
+            .is_none());
     }
 }

--- a/crates/yani-transmute/tests/flux_uncertainty_under_shielding.rs
+++ b/crates/yani-transmute/tests/flux_uncertainty_under_shielding.rs
@@ -1,0 +1,261 @@
+//! A flux perturbation must move the rates the run actually used.
+//!
+//! The flux replicas are built from the per-group terms of the collapse, and
+//! those terms used to be computed dilute whatever the run asked for, then
+//! ASSIGNED to the rate. So a run that combined a self-shielding chord with a
+//! per-bin flux sigma had every replica's rate quietly replaced by the dilute
+//! one, even at zero perturbation, and the ensemble drifted off the nominal it
+//! is supposed to spread around.
+//!
+//! Both halves are checked: that the terms are shielded when the run is, and
+//! that the perturbation is a factor on the rate rather than a substitute for
+//! it.
+//!
+//! Self-skips when the nuclear-data fixtures are missing.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use yamc_materials::Material;
+use yani_transmute::multigroup::{
+    compute_multigroup_reaction_rates_shielded, per_group_reaction_rates,
+};
+use yani_transmute::uncertainty::{DataUncertainty, Source};
+use yani_transmute::{
+    transmute_material_shielded, MultigroupSpectrum, Shielding, TransmutationResults, TransmuteStep,
+};
+
+/// Three groups: thermal, epithermal, fast.
+const GROUPS: [f64; 4] = [1.0e-5, 0.625, 1.0e5, 2.0e7];
+const FLUX: [f64; 3] = [1.0e12, 5.0e12, 1.0e14];
+/// Enough chord through solid iron for its keV resonances to bite, which on
+/// this structure is a few percent on capture.
+const CHORD_CM: f64 = 2.0;
+/// Small enough that the ensemble mean sits far closer to its own nominal than
+/// the shielded and dilute answers sit to each other.
+const RELATIVE_SIGMA: f64 = 0.01;
+const REPLICAS: usize = 64;
+/// The product of Fe56 capture, so the nuclide the shielding moves.
+const PRODUCT: &str = "Fe57";
+
+fn chain() -> Arc<HashMap<String, yani::ChainNuclide>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../yani/tests/transmutation-endf-b8.1-sfr.arrow");
+    Arc::new(yani::parse_chain_arrow(&path).expect("parse chain"))
+}
+
+fn iron(data: &str) -> Material {
+    let mut m = Material::new(
+        HashMap::from([("Fe56".to_string(), 1.0)]),
+        "atom",
+        "sum",
+        None,
+    )
+    .expect("Fe56 material");
+    m.density = Some(7.87);
+    m.set_temperature("294");
+    m.read_nuclear_data(
+        &HashMap::from([("Fe56".to_string(), data.to_string())]),
+        None,
+    )
+    .expect("read Fe56");
+    m
+}
+
+fn run(data: &str, shielding: Option<&Shielding>, with_sigma: bool) -> TransmutationResults {
+    let total: f64 = FLUX.iter().sum();
+    let spectra = vec![MultigroupSpectrum {
+        boundaries: GROUPS.to_vec(),
+        masses: FLUX.iter().map(|f| f / total).collect(),
+        relative_std_dev: with_sigma.then(|| vec![RELATIVE_SIGMA; FLUX.len()]),
+    }];
+    let steps = vec![TransmuteStep {
+        dt: 86400.0,
+        irradiation: Some((0, total)),
+    }];
+    let request = DataUncertainty {
+        seed: 1,
+        samples: Some(REPLICAS),
+        // Only the flux, so nothing here needs MF=33 covariance and the
+        // ensemble's spread is the flux sigma alone.
+        sources: vec![Source::FluxSpectrum],
+    };
+    transmute_material_shielded(
+        &mut iron(data),
+        &spectra,
+        &steps,
+        chain(),
+        &Default::default(),
+        Default::default(),
+        with_sigma.then_some(&request),
+        shielding,
+    )
+    .expect("transmute")
+}
+
+/// The ensemble mean of the product's density after the irradiation step.
+fn ensemble_mean(results: &TransmutationResults, id: u32) -> f64 {
+    let samples = results
+        .uncertainty
+        .get(&id)
+        .expect("an ensemble was recorded")
+        .samples_at(0, PRODUCT);
+    assert_eq!(samples.len(), REPLICAS, "every replica must be recorded");
+    samples.iter().sum::<f64>() / samples.len() as f64
+}
+
+fn density(results: &TransmutationResults, id: u32) -> f64 {
+    results
+        .get_nuclide_density(id, PRODUCT, 1)
+        .expect("the product exists after irradiation")
+}
+
+/// The terms themselves, against the collapse they are supposed to decompose.
+///
+/// This is the direct form of the first half, and the sharp one: the ensemble
+/// can only see the terms through the shape of its perturbation, which on this
+/// fixture is a 3% difference inside a 1% sigma. The sums are exact.
+#[test]
+fn the_per_group_terms_carry_the_weighting_the_run_asked_for() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let material = iron(&data);
+    let chain = chain();
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let total: f64 = FLUX.iter().sum();
+    let masses: Vec<f64> = FLUX.iter().map(|f| f / total).collect();
+
+    let mut checked = 0;
+    for request in [None, Some(&shielding)] {
+        let (rates, _, _) = compute_multigroup_reaction_rates_shielded(
+            &material, &chain, &masses, &GROUPS, 1.0, request,
+        );
+        let terms = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, request);
+        assert!(!rates.is_empty(), "the spectrum must produce rates");
+        for (nuclide, per_kind) in &rates {
+            for (kind, &rate) in per_kind {
+                let summed: f64 = terms[nuclide][kind].iter().sum();
+                assert!(
+                    (summed - rate).abs() <= 1.0e-12 * rate.abs(),
+                    "{nuclide} {kind}: the collapse gives {rate}, its terms sum to {summed}"
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert!(
+        checked > 6,
+        "expected several reactions under each weighting, got {checked}"
+    );
+
+    // And the two weightings are genuinely different, so the check above is
+    // not passing twice on the same numbers.
+    let dilute = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, None);
+    let shielded = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, Some(&shielding));
+    let sum = |t: &yani_transmute::flux_uncertainty::PerGroupRates| -> f64 {
+        t["Fe56"]["(n,gamma)"].iter().sum()
+    };
+    assert!(
+        sum(&shielded) < sum(&dilute) * 0.99,
+        "shielded terms must sum below dilute ones: {:e} against {:e}",
+        sum(&shielded),
+        sum(&dilute)
+    );
+}
+
+#[test]
+fn a_shielded_run_perturbs_its_shielded_rates() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let id = iron(&data).material_id.unwrap_or(0);
+
+    let dilute = density(&run(&data, None, false), id);
+    let shielded = density(&run(&data, Some(&shielding), false), id);
+
+    // Without a gap between the two answers the rest of this test cannot fail,
+    // so it is asserted rather than assumed.
+    let gap = (dilute - shielded) / shielded;
+    assert!(
+        gap > 0.02,
+        "shielding must move {PRODUCT} for this test to discriminate: \
+         dilute {dilute:e}, shielded {shielded:e}, gap {:.3}%",
+        gap * 100.0
+    );
+
+    let mean = ensemble_mean(&run(&data, Some(&shielding), true), id);
+
+    // The perturbation is symmetric and the rate is linear in the flux, so the
+    // ensemble spreads around its own nominal. A tenth of the gap is far wider
+    // than the sampling error at this sigma and far narrower than the gap.
+    let off_shielded = (mean - shielded).abs() / shielded;
+    assert!(
+        off_shielded < gap / 10.0,
+        "the ensemble must spread around the shielded nominal it came from: \
+         mean {mean:e} is {:.3}% off shielded {shielded:e}, with the dilute \
+         answer {dilute:e} a {:.3}% walk away",
+        off_shielded * 100.0,
+        gap * 100.0
+    );
+}
+
+/// The other half, and the one that fails loudest: with every deviate at zero
+/// the replicas must reproduce the nominal inventory exactly.
+#[test]
+fn an_unperturbed_shielded_replica_is_the_nominal_run() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let id = iron(&data).material_id.unwrap_or(0);
+
+    let total: f64 = FLUX.iter().sum();
+    let spectra = vec![MultigroupSpectrum {
+        boundaries: GROUPS.to_vec(),
+        masses: FLUX.iter().map(|f| f / total).collect(),
+        // A flux the caller states is exact still requests the source, so the
+        // per-group terms are built and used, with every deviate zero.
+        relative_std_dev: Some(vec![0.0; FLUX.len()]),
+    }];
+    let steps = vec![TransmuteStep {
+        dt: 86400.0,
+        irradiation: Some((0, total)),
+    }];
+    let request = DataUncertainty {
+        seed: 1,
+        samples: Some(2),
+        sources: vec![Source::FluxSpectrum],
+    };
+    let results = transmute_material_shielded(
+        &mut iron(&data),
+        &spectra,
+        &steps,
+        chain(),
+        &Default::default(),
+        Default::default(),
+        Some(&request),
+        Some(&shielding),
+    )
+    .expect("transmute");
+
+    let nominal = density(&results, id);
+    for (replica, sample) in results
+        .uncertainty
+        .get(&id)
+        .expect("an ensemble was recorded")
+        .samples_at(0, PRODUCT)
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(
+            *sample, nominal,
+            "replica {replica} perturbed nothing and must be the nominal run"
+        );
+    }
+}

--- a/crates/yani-transmute/tests/reaction_rate_spectrum.rs
+++ b/crates/yani-transmute/tests/reaction_rate_spectrum.rs
@@ -1,0 +1,286 @@
+//! An energy-resolved rate must sum to the one-group rate it decomposes
+//! (yani#27).
+//!
+//! `get_reaction_rate_spectrum` exists to say which part of a spectrum drove a
+//! channel, which a collapsed rate cannot: 57 mb of `W186(n,gamma)` against a
+//! spectrum that is 89% fast and 0.7% thermal is either a fast-capture rate or
+//! a resonance-region one, and the two carry different consequences for a
+//! disagreement. The number is only worth reading if it is a decomposition of
+//! the rate the solve actually used, so that is what these check, on both the
+//! dilute and the shielded weighting.
+//!
+//! Self-skips when the nuclear-data fixtures are missing.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use yamc_materials::Material;
+use yani_transmute::multigroup::compute_multigroup_reaction_rates_shielded;
+use yani_transmute::{reaction_rate_spectrum, Shielding};
+
+/// Total flux magnitude, so the rates are not all at unit flux.
+const SOURCE_RATE: f64 = 3.0e13;
+
+fn chain() -> HashMap<String, yani::ChainNuclide> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../yani/tests/transmutation-endf-b8.1-sfr.arrow");
+    yani::parse_chain_arrow(&path).expect("parse chain")
+}
+
+fn iron(data: &str) -> Material {
+    let mut m = Material::new(
+        HashMap::from([("Fe56".to_string(), 1.0)]),
+        "atom",
+        "sum",
+        None,
+    )
+    .expect("Fe56 material");
+    m.density = Some(7.87);
+    m.set_temperature("294");
+    m.read_nuclear_data(
+        &HashMap::from([("Fe56".to_string(), data.to_string())]),
+        None,
+    )
+    .expect("read Fe56");
+    m
+}
+
+fn ccfe_709() -> Vec<f64> {
+    yamc_nuclide::group_structures::get_group_structure("CCFE-709")
+        .expect("CCFE-709")
+        .to_vec()
+}
+
+/// A flux per unit lethargy, so every decade carries some and the resonance
+/// region is not empty. The top group takes a 14 MeV spike on top of it, which
+/// is the shape an activation spectrum has.
+fn broad_flux(boundaries: &[f64]) -> Vec<f64> {
+    let n = boundaries.len() - 1;
+    let mut flux: Vec<f64> = (0..n)
+        .map(|g| (boundaries[g + 1] / boundaries[g]).ln())
+        .collect();
+    let spike = boundaries
+        .iter()
+        .position(|&e| e > 1.4e7)
+        .expect("CCFE-709 reaches past 14 MeV")
+        - 1;
+    flux[spike] += 20.0;
+    flux
+}
+
+/// Every channel the collapse produced, with its rate and its per-group terms.
+fn checked_against_collapse(
+    material: &Material,
+    chain: &HashMap<String, yani::ChainNuclide>,
+    flux: &[f64],
+    boundaries: &[f64],
+    shielding: Option<&Shielding>,
+) -> usize {
+    let (rates, _, _) = compute_multigroup_reaction_rates_shielded(
+        material,
+        chain,
+        flux,
+        boundaries,
+        SOURCE_RATE,
+        shielding,
+    );
+    assert!(!rates.is_empty(), "the spectrum must produce rates");
+
+    let mut checked = 0;
+    for (nuclide, per_kind) in &rates {
+        for (kind, &rate) in per_kind {
+            let terms = reaction_rate_spectrum(
+                material,
+                flux,
+                boundaries,
+                SOURCE_RATE,
+                shielding,
+                nuclide,
+                kind,
+            )
+            .unwrap_or_else(|| panic!("{nuclide} {kind}: no spectrum for a channel with a rate"));
+            assert_eq!(terms.len(), flux.len(), "one term per group");
+            let summed: f64 = terms.iter().sum();
+            assert!(
+                (summed - rate).abs() <= 1.0e-12 * rate.abs(),
+                "{nuclide} {kind}: collapse gives {rate}, the per-group terms sum to {summed}"
+            );
+            checked += 1;
+        }
+    }
+    checked
+}
+
+#[test]
+fn the_terms_sum_to_the_dilute_rate() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let boundaries = ccfe_709();
+    let flux = broad_flux(&boundaries);
+    let checked = checked_against_collapse(&iron(&data), &chain(), &flux, &boundaries, None);
+    assert!(
+        checked > 3,
+        "expected several reactions to check, got {checked}"
+    );
+}
+
+#[test]
+fn the_terms_sum_to_the_shielded_rate() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let material = iron(&data);
+    let chain = chain();
+    let boundaries = ccfe_709();
+    let flux = broad_flux(&boundaries);
+    // Two centimetres of mean chord through solid iron, which is enough for its
+    // keV resonances to depress the flux inside the lump.
+    let shielding = Shielding::new(2.0).expect("a positive chord");
+
+    let checked = checked_against_collapse(&material, &chain, &flux, &boundaries, Some(&shielding));
+    assert!(
+        checked > 3,
+        "expected several reactions to check, got {checked}"
+    );
+
+    // The identity above would also hold if the shielded weighting were being
+    // ignored on both sides, so check that it is not: capture is the channel
+    // the resonances dominate, and shielding must move it.
+    let dilute = reaction_rate_spectrum(
+        &material,
+        &flux,
+        &boundaries,
+        SOURCE_RATE,
+        None,
+        "Fe56",
+        "(n,gamma)",
+    )
+    .expect("dilute capture");
+    let shielded = reaction_rate_spectrum(
+        &material,
+        &flux,
+        &boundaries,
+        SOURCE_RATE,
+        Some(&shielding),
+        "Fe56",
+        "(n,gamma)",
+    )
+    .expect("shielded capture");
+    let (dilute_total, shielded_total): (f64, f64) = (dilute.iter().sum(), shielded.iter().sum());
+    assert!(
+        shielded_total < dilute_total,
+        "shielding must depress capture: dilute {dilute_total}, shielded {shielded_total}"
+    );
+}
+
+#[test]
+fn a_group_with_no_flux_carries_no_rate() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let boundaries = ccfe_709();
+    let n = boundaries.len() - 1;
+    // Flux in three groups and nothing anywhere else, which is the shape a
+    // few-line source has.
+    let carrying = [12usize, 400, n - 2];
+    let mut flux = vec![0.0; n];
+    for (i, &g) in carrying.iter().enumerate() {
+        flux[g] = (i + 1) as f64;
+    }
+
+    let terms = reaction_rate_spectrum(
+        &iron(&data),
+        &flux,
+        &boundaries,
+        SOURCE_RATE,
+        None,
+        "Fe56",
+        "(n,gamma)",
+    )
+    .expect("capture on a three-line spectrum");
+
+    for (g, &term) in terms.iter().enumerate() {
+        if carrying.contains(&g) {
+            assert!(term > 0.0, "group {g} carries flux and must carry rate");
+        } else {
+            assert_eq!(
+                term, 0.0,
+                "group {g} carries no flux and must carry no rate"
+            );
+        }
+    }
+}
+
+#[test]
+fn an_unknown_nuclide_or_channel_is_none() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let material = iron(&data);
+    let boundaries = ccfe_709();
+    let flux = broad_flux(&boundaries);
+    let ask = |nuclide: &str, kind: &str| {
+        reaction_rate_spectrum(
+            &material,
+            &flux,
+            &boundaries,
+            SOURCE_RATE,
+            None,
+            nuclide,
+            kind,
+        )
+    };
+
+    assert!(
+        ask("Fe56", "(n,gamma)").is_some(),
+        "the channel it does have"
+    );
+    assert!(
+        ask("U235", "(n,gamma)").is_none(),
+        "a nuclide it never loaded"
+    );
+    assert!(
+        ask("Fe56", "(n,banana)").is_none(),
+        "a kind that names no MT"
+    );
+    // `(n,n')` has no transport total, so its rate comes from the branching
+    // overlay's MF=10 partials rather than from a group average of this shape.
+    assert!(
+        ask("Fe56", "(n,n')").is_none(),
+        "a kind with no MT to collapse"
+    );
+
+    // No flux is not a small flux: there is no spectrum to resolve onto, and a
+    // vector of zeros would read as a rate resolved rather than as no rate.
+    assert!(
+        reaction_rate_spectrum(
+            &material,
+            &vec![0.0; flux.len()],
+            &boundaries,
+            SOURCE_RATE,
+            None,
+            "Fe56",
+            "(n,gamma)",
+        )
+        .is_none(),
+        "an empty spectrum drives nothing"
+    );
+    assert!(
+        reaction_rate_spectrum(
+            &material,
+            &flux,
+            &boundaries,
+            0.0,
+            None,
+            "Fe56",
+            "(n,gamma)",
+        )
+        .is_none(),
+        "a pulse at zero rate drives nothing"
+    );
+}

--- a/crates/yani-transmute/tests/zero_flux_groups.rs
+++ b/crates/yani-transmute/tests/zero_flux_groups.rs
@@ -125,6 +125,7 @@ fn padding_a_spectrum_with_empty_groups_changes_no_bits() {
         &chain,
         &padded,
         &boundaries,
+        None,
     );
     let mut checked = 0;
     for (nuclide, per_kind) in &wide {

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -4804,6 +4804,62 @@ class TransmutationResults:
             ...     if target == "Mn56"
             ... ]
         """
+    def get_reaction_rate_spectrum(self, material_id: builtins.int, nuclide: builtins.str, kind: builtins.str, step: builtins.int) -> typing.Optional[typing.Any]:
+        r"""
+        One channel's reaction rate over one step, resolved onto the groups of
+        the spectrum that drove it.
+        
+        ``get_reaction_rates`` answers with one number per edge, already
+        collapsed against the whole spectrum. That number cannot say which part
+        of the spectrum made it, and where a cross section spans decades the two
+        readings are different physics: an effective ``W186(n,gamma)`` of 57 mb
+        against a spectrum 89% of which sits in 12-16 MeV and 0.7% of which is
+        below 100 keV is either a fast-capture rate or a resonance-region rate,
+        and only the breakdown says which. A disagreement can then be pinned on
+        resonance processing rather than guessed at, and a covariance grid that
+        stops short of the spectrum can be checked against where the rate
+        actually is.
+        
+        The per-group entries sum to the collapsed rate for the same channel, to
+        floating-point rounding, because both come from the same walk of the
+        same cross sections with the same self-shielding weighting.
+        
+        Nothing is stored for this. The breakdown is re-derived from the
+        spectrum when asked for, which is one reaction over the group structure;
+        keeping it for every channel would be tens of megabytes on a 709-group
+        structure, and a run that never asks should not pay that.
+        
+        Args:
+            material_id: Material ID number.
+            nuclide: The parent the reaction happens on, e.g. ``"W186"``.
+            kind: The reaction, spelled as the chain spells it, e.g.
+                ``"(n,gamma)"``.
+            step: Schedule step index, as ``get_reaction_rates`` takes it.
+        
+        Returns:
+            dict | None: ``boundaries``, the group boundaries [eV] ascending and
+            one longer than the rates, and ``rates``, each group's contribution
+            to the rate [1/s]. None when the material, the step, the nuclide or
+            the channel is unknown; for a step that drove no flux, whether by
+            being a cooldown or by carrying a zero rate; for ``(n,n')``, whose
+            rate comes from the branching overlay's partials rather than from a
+            group average; and for a transport-coupled solve, which scores its
+            rates at the collision energy and keeps no group structure to
+            resolve them onto.
+        
+        Examples:
+            >>> spectrum = results.get_reaction_rate_spectrum(
+            ...     material_id=1, nuclide="W186", kind="(n,gamma)", step=0
+            ... )
+            >>> sum(spectrum["rates"])  # the collapsed rate
+            1.9e-09
+            >>> # where in energy that rate came from
+            >>> below_100_keV = sum(
+            ...     r
+            ...     for lo, r in zip(spectrum["boundaries"], spectrum["rates"])
+            ...     if lo < 1.0e5
+            ... )
+        """
     def get_isomeric_branching(self, material_id: builtins.int, step: builtins.int) -> typing.Optional[typing.Any]:
         r"""
         Flux-weighted isomeric branching at one step.

--- a/packages/yamc-core/tests/unit_tests/test_material_transmute.py
+++ b/packages/yamc-core/tests/unit_tests/test_material_transmute.py
@@ -280,3 +280,81 @@ def test_step_materials_pairs_with_the_rate_index():
     assert dict(steps[-1].nuclides) == dict(
         results.get_final_material(mat_id).nuclides
     )
+
+
+# --- energy-resolved reaction rates (issue #27) -------------------------------
+
+def test_the_rate_spectrum_sums_to_the_collapsed_rate():
+    """The breakdown must decompose the rate the solve used, not resemble it.
+
+    ``get_reaction_rates`` gives one number per edge, already collapsed against
+    the whole spectrum, which cannot say which part of the spectrum made it.
+    This is that number resolved onto the spectrum's own groups, so the two have
+    to agree on the total.
+    """
+    iron = _make_iron()
+    results = iron.transmute(
+        schedule=yamc.PulseSchedule([
+            yamc.Pulse(rate=RATE, duration=DAY, source=_spectrum()),
+        ]),
+    )
+
+    mat_id = iron.id or 0
+    spectrum = results.get_reaction_rate_spectrum(mat_id, "Fe56", "(n,gamma)", 0)
+    assert spectrum is not None, "the seed nuclide's capture channel was driven"
+    assert spectrum["boundaries"] == ENERGY_GROUPS
+    assert len(spectrum["rates"]) == len(ENERGY_GROUPS) - 1
+
+    # The edge rate is the channel rate times the branching, and Fe56(n,gamma)
+    # makes only Fe57, so the one edge carries the whole channel.
+    (_, edge_rate), = results.get_reaction_rates(mat_id, 0)["Fe56"]["(n,gamma)"]
+    assert sum(spectrum["rates"]) == pytest.approx(edge_rate, rel=1e-12)
+
+
+def test_the_rate_spectrum_says_where_in_energy_the_rate_came_from():
+    """The point of the getter: which group drove the rate.
+
+    Capture on Fe56 is a 1/v cross section, and this spectrum puts 1e12 of its
+    1.06e14 in the thermal group. That group nonetheless carries most of the
+    capture rate, which is exactly the attribution a one-group rate hides.
+    """
+    iron = _make_iron()
+    results = iron.transmute(
+        schedule=yamc.PulseSchedule([
+            yamc.Pulse(rate=RATE, duration=DAY, source=_spectrum()),
+        ]),
+    )
+
+    rates = results.get_reaction_rate_spectrum(
+        iron.id or 0, "Fe56", "(n,gamma)", 0
+    )["rates"]
+    thermal, epithermal, fast = rates
+    assert thermal > fast, (
+        "0.9% of the flux is thermal and Fe56 capture is 1/v, so the thermal "
+        f"group must still out-drive the fast one: {rates}"
+    )
+    assert epithermal > 0.0
+
+
+def test_no_rate_spectrum_where_there_is_no_rate():
+    """Absences are reported rather than answered with an invented spectrum."""
+    iron = _make_iron()
+    results = iron.transmute(
+        schedule=yamc.PulseSchedule([
+            yamc.Pulse(rate=RATE, duration=DAY, source=_spectrum()),
+            yamc.Cooldown(duration=DAY),
+        ]),
+    )
+
+    mat_id = iron.id or 0
+
+    def ask(*args):
+        return results.get_reaction_rate_spectrum(*args)
+
+    # A cooldown drives no reactions, and step 2 does not exist.
+    assert ask(mat_id, "Fe56", "(n,gamma)", 1) is None
+    assert ask(mat_id, "Fe56", "(n,gamma)", 2) is None
+    # A nuclide the material never loaded, and a kind that names no MT.
+    assert ask(mat_id, "U235", "(n,gamma)", 0) is None
+    assert ask(mat_id, "Fe56", "(n,banana)", 0) is None
+    assert ask(9999, "Fe56", "(n,gamma)", 0) is None

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -2204,6 +2204,62 @@ class TransmutationResults:
             ...     if target == "Mn56"
             ... ]
         """
+    def get_reaction_rate_spectrum(self, material_id: builtins.int, nuclide: builtins.str, kind: builtins.str, step: builtins.int) -> typing.Optional[typing.Any]:
+        r"""
+        One channel's reaction rate over one step, resolved onto the groups of
+        the spectrum that drove it.
+        
+        ``get_reaction_rates`` answers with one number per edge, already
+        collapsed against the whole spectrum. That number cannot say which part
+        of the spectrum made it, and where a cross section spans decades the two
+        readings are different physics: an effective ``W186(n,gamma)`` of 57 mb
+        against a spectrum 89% of which sits in 12-16 MeV and 0.7% of which is
+        below 100 keV is either a fast-capture rate or a resonance-region rate,
+        and only the breakdown says which. A disagreement can then be pinned on
+        resonance processing rather than guessed at, and a covariance grid that
+        stops short of the spectrum can be checked against where the rate
+        actually is.
+        
+        The per-group entries sum to the collapsed rate for the same channel, to
+        floating-point rounding, because both come from the same walk of the
+        same cross sections with the same self-shielding weighting.
+        
+        Nothing is stored for this. The breakdown is re-derived from the
+        spectrum when asked for, which is one reaction over the group structure;
+        keeping it for every channel would be tens of megabytes on a 709-group
+        structure, and a run that never asks should not pay that.
+        
+        Args:
+            material_id: Material ID number.
+            nuclide: The parent the reaction happens on, e.g. ``"W186"``.
+            kind: The reaction, spelled as the chain spells it, e.g.
+                ``"(n,gamma)"``.
+            step: Schedule step index, as ``get_reaction_rates`` takes it.
+        
+        Returns:
+            dict | None: ``boundaries``, the group boundaries [eV] ascending and
+            one longer than the rates, and ``rates``, each group's contribution
+            to the rate [1/s]. None when the material, the step, the nuclide or
+            the channel is unknown; for a step that drove no flux, whether by
+            being a cooldown or by carrying a zero rate; for ``(n,n')``, whose
+            rate comes from the branching overlay's partials rather than from a
+            group average; and for a transport-coupled solve, which scores its
+            rates at the collision energy and keeps no group structure to
+            resolve them onto.
+        
+        Examples:
+            >>> spectrum = results.get_reaction_rate_spectrum(
+            ...     material_id=1, nuclide="W186", kind="(n,gamma)", step=0
+            ... )
+            >>> sum(spectrum["rates"])  # the collapsed rate
+            1.9e-09
+            >>> # where in energy that rate came from
+            >>> below_100_keV = sum(
+            ...     r
+            ...     for lo, r in zip(spectrum["boundaries"], spectrum["rates"])
+            ...     if lo < 1.0e5
+            ... )
+        """
     def get_isomeric_branching(self, material_id: builtins.int, step: builtins.int) -> typing.Optional[typing.Any]:
         r"""
         Flux-weighted isomeric branching at one step.


### PR DESCRIPTION
Asked for in fusion-neutronics/yani#27.

## What it adds

`TransmutationResults.get_reaction_rate_spectrum(material_id, nuclide, kind, step)`, returning the group boundaries in eV and each group's contribution to the rate in 1/s. The entries sum to the rate `get_reaction_rates` reports for the same channel.

```python
capture = results.get_reaction_rate_spectrum(
    material_id=mid, nuclide="W186", kind="(n,gamma)", step=0
)
sum(capture["rates"])            # the collapsed rate
```

Rust side: `yani_transmute::reaction_rate_spectrum`, plus `RateSpectrum` and `CollapseInputs` on the results.

## What it answers

`get_reaction_rates` already gives one number per edge, but it is collapsed against the whole spectrum, and on a cross section that spans decades that number cannot say which part of the spectrum made it. Run on the two tungsten campaigns of the FNS decay-heat benchmark, TENDL-2025 at 294 K:

| campaign | FNS position | sigma_eff | below 1 keV | above 1 MeV | strongest group |
|---|---|---|---|---|---|
| `2000exp_5min` | 3 | 57.3 mb | **90.5%** | 4.5% | 18.2-19.1 eV, 55.7% of the rate |
| `1996exp_7hour` | 7 | 3.5 mb | 8.5% | **69.2%** | 14.2-14.4 MeV, 17.6% of the rate |

The 57.3 mb reproduces the figure quoted in yani#27 exactly. What the breakdown adds is that the same channel is a resonance-region rate in one campaign and a fast rate in the other: the two campaigns sit at different irradiation positions, and their sub-100 keV tails differ by a factor of eight. So the issue's shape residual is attributable on the 5-minute campaign and, on the 7-hour one, is largely not a resonance-region question at all. A single band-localised cross-section error cannot produce one common W187 scale across both: the only band with enough weight at position 3 is 1 eV to 1 keV, and an error there large enough to move position 3 by -8.3% moves position 7 by about -1%.

Two secondary uses, both from the issue: it gives per group what `rate_fraction_covered` gives as one number, so a covariance grid that stops short of the spectrum can be checked against where the rate actually is; and on a shielded run it says which groups the depression moved, which `strongest_factor` gives only as a worst case.

## How it is built

Nothing is stored. The collapse already forms `sigma_g * phi_g` group by group and folds each term into a scalar; keeping every term for every channel is the rate map times the group count, tens of MB on a 709-group structure, which is why `per_group_reaction_rates` is built only when flux uncertainty asks for it (#559). So the breakdown is re-derived for the one channel asked about, and what the results now carry instead is the spectra the collapse ran against: two vectors per distinct spectrum, a few KB.

The walk is shared rather than reimplemented. `Collapse::walk_channel` is now the one definition of what `sigma_g` means for a group, and both the collapse and the breakdown drive it, so they cannot disagree about the shielded average and the sum cannot quietly stop being the rate. The material-and-spectrum gather it needs moved into `CollapseSetup` for the same reason. `compute_multigroup_reaction_rates_shielded` is behaviour-preserving through it: the bit-identity test in `tests/zero_flux_groups.rs` and the per-step golden in `test_material_transmute.py` both still pass.

## Tests

`crates/yani-transmute/tests/reaction_rate_spectrum.rs`: the terms sum to the collapsed rate on the dilute path and on the shielded one, for every channel Fe56 drives on CCFE-709; a zero-flux group carries exactly zero; the shielded total is below the dilute one, so the shielded weighting is being exercised rather than ignored on both sides; and unknown nuclide, unmapped kind, empty spectrum and zero rate all return `None`.

Unit tests in `results.rs` for the two absences that need no fixtures: a transport-coupled solve, which keeps no group structure, and a decay-only step.

`test_material_transmute.py`: end to end through the bindings, the sum against the edge rate, the thermal group out-driving the fast one on Fe56 capture as a 1/v cross section should, and the `None` cases.

`cargo fmt`, `cargo clippy --all-targets`, `cargo test -p yani-transmute`, `pytest` and `scripts/check_public_surface.py` all pass. Stubs regenerated with `scripts/build_stubs.py`.

## Noticed while in here, not fixed

Two things adjacent to this code, both left alone deliberately:

- `flux_uncertainty::perturb_rates` assigns the perturbed rate from the per-group terms rather than scaling the nominal one, and those terms come from `per_group_reaction_rates`, which takes no `shielding` argument and is dilute-only. Combining `self_shielding_chord`/`self_shielding_shape` with a `flux_std_dev`-bearing pulse therefore replaces each replica's shielded rate with the dilute one even at zero perturbation. Reachable in one `Material.transmute` call and untested.
- `self_shielding.rs` documents `would_shield` as "an indicator, not the correction and not a strict bound", while the Python docstring, the stubs and the yani docs call it an upper bound. The code sides with the Rust doc: the indicator uses a fixed 1/cm escape cross section and only the one partial reaction, so for a longer chord the true suppression is stronger.
