### PR TITLE
Stop calling would_shield a bound

### DIFF
--- a/crates/yani-python/src/transmutation_results.rs
+++ b/crates/yani-python/src/transmutation_results.rs
@@ -517,13 +517,26 @@ impl PyTransmutationResults {
     /// having tried.
     ///
     /// ``would_shield`` is the other direction, and is filled only on a dilute
-    /// run: nuclides whose own resonances could have suppressed a reaction,
-    /// mapped to the strongest suppression each could have seen. It is a bound
-    /// computed from that reaction alone, ignoring the rest of the material and
-    /// the geometry, both of which push the real factor back toward one. So it
-    /// says "this answer may be high, and here is by how much at the very
-    /// most", which is the warning a dilute run of a resonance absorber should
-    /// carry rather than silence.
+    /// run: nuclides whose own resonances are structured enough to have
+    /// suppressed a reaction, each mapped to how strongly.
+    ///
+    /// It is an indicator, not a correction and not a bound. There is no
+    /// geometry in it: the weight is ``1 / (1 + N * sigma_x)`` on that one
+    /// reaction and that nuclide's own density, which fixes the background at
+    /// 1/cm, while the correction proper uses ``1 / chord_cm`` against the
+    /// material's total. So the number scales with how strongly a nuclide's own
+    /// resonances could bite without predicting what a given lump would see,
+    /// and it can sit either side of the real factor: a lump thinner than a
+    /// centimetre of chord shields less, and a material whose other nuclides
+    /// dominate the total at the resonance dips the flux further than this one
+    /// reaction can express.
+    ///
+    /// On the FNS tungsten foil, ``would_shield`` reads 0.634 for W186 while
+    /// the slowing-down correction on the same foil and spectrum saturates at
+    /// 0.730 from a millimetre of chord upward. Read it as "this answer may be
+    /// high, and this is a resonance absorber", which is the warning a dilute
+    /// run should carry rather than silence. Read the size of the effect off a
+    /// shielded run, by asking for one.
     #[getter]
     fn self_shielding_info<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
         let Some(info) = &self.inner.shielding_info else {

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -4509,13 +4509,26 @@ class TransmutationResults:
         having tried.
         
         ``would_shield`` is the other direction, and is filled only on a dilute
-        run: nuclides whose own resonances could have suppressed a reaction,
-        mapped to the strongest suppression each could have seen. It is a bound
-        computed from that reaction alone, ignoring the rest of the material and
-        the geometry, both of which push the real factor back toward one. So it
-        says "this answer may be high, and here is by how much at the very
-        most", which is the warning a dilute run of a resonance absorber should
-        carry rather than silence.
+        run: nuclides whose own resonances are structured enough to have
+        suppressed a reaction, each mapped to how strongly.
+        
+        It is an indicator, not a correction and not a bound. There is no
+        geometry in it: the weight is ``1 / (1 + N * sigma_x)`` on that one
+        reaction and that nuclide's own density, which fixes the background at
+        1/cm, while the correction proper uses ``1 / chord_cm`` against the
+        material's total. So the number scales with how strongly a nuclide's own
+        resonances could bite without predicting what a given lump would see,
+        and it can sit either side of the real factor: a lump thinner than a
+        centimetre of chord shields less, and a material whose other nuclides
+        dominate the total at the resonance dips the flux further than this one
+        reaction can express.
+        
+        On the FNS tungsten foil, ``would_shield`` reads 0.634 for W186 while
+        the slowing-down correction on the same foil and spectrum saturates at
+        0.730 from a millimetre of chord upward. Read it as "this answer may be
+        high, and this is a resonance absorber", which is the warning a dilute
+        run should carry rather than silence. Read the size of the effect off a
+        shielded run, by asking for one.
         """
     @property
     def material_ids(self) -> builtins.list[builtins.int]:

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -1909,13 +1909,26 @@ class TransmutationResults:
         having tried.
         
         ``would_shield`` is the other direction, and is filled only on a dilute
-        run: nuclides whose own resonances could have suppressed a reaction,
-        mapped to the strongest suppression each could have seen. It is a bound
-        computed from that reaction alone, ignoring the rest of the material and
-        the geometry, both of which push the real factor back toward one. So it
-        says "this answer may be high, and here is by how much at the very
-        most", which is the warning a dilute run of a resonance absorber should
-        carry rather than silence.
+        run: nuclides whose own resonances are structured enough to have
+        suppressed a reaction, each mapped to how strongly.
+        
+        It is an indicator, not a correction and not a bound. There is no
+        geometry in it: the weight is ``1 / (1 + N * sigma_x)`` on that one
+        reaction and that nuclide's own density, which fixes the background at
+        1/cm, while the correction proper uses ``1 / chord_cm`` against the
+        material's total. So the number scales with how strongly a nuclide's own
+        resonances could bite without predicting what a given lump would see,
+        and it can sit either side of the real factor: a lump thinner than a
+        centimetre of chord shields less, and a material whose other nuclides
+        dominate the total at the resonance dips the flux further than this one
+        reaction can express.
+        
+        On the FNS tungsten foil, ``would_shield`` reads 0.634 for W186 while
+        the slowing-down correction on the same foil and spectrum saturates at
+        0.730 from a millimetre of chord upward. Read it as "this answer may be
+        high, and this is a resonance absorber", which is the warning a dilute
+        run should carry rather than silence. Read the size of the effect off a
+        shielded run, by asking for one.
         """
     @property
     def material_ids(self) -> builtins.list[builtins.int]:


### PR DESCRIPTION
`self_shielding.rs:225-237` is explicit that `strongest_possible_suppression` is "an indicator, not the correction and not a strict bound" and "not a factor to correct anything by". The Python-facing docstring on `self_shielding_info` said the opposite: that `would_shield` is a bound, and that it says "here is by how much at the very most". That text is mirrored verbatim into both wheels' stubs, so it is what a user reads.

## The code sides with the Rust doc

The indicator's weight is `1 / (1 + N * sigma_x)` (`multigroup.rs:340`) on that one reaction and that nuclide's own density in atoms/barn-cm, which fixes the background at 1/cm. The correction proper uses `1 / chord_cm` (`self_shielding.rs:163`) against the material's total, with in-scattering filling the dips. Nothing ties the two together in either direction:

- a lump thinner than a centimetre of chord shields less than the indicator suggests;
- a material whose other nuclides dominate the total across a resonance dips the flux further than one partial reaction can express.

## Measured

On the FNS tungsten foil (1 g, 19.3 g/cm3) under its position-3 spectrum, TENDL-2025 at 294 K, W186:

| | factor on the (n,gamma) rate |
|---|---|
| `would_shield` | 0.634 |
| `self_shielding_chord=0.1` | 0.750 |
| `self_shielding_chord=1.0` | 0.732 |
| `self_shielding_chord=4.0` | 0.730 |

The old wording promised at most 37% of suppression against an actual 25 to 27% that saturates by a millimetre of chord. Overstating by 1.4x is fine for a screen and wrong for a bound.

## The change

Docstring only, plus the regenerated stubs for both wheels. It now says there is no geometry in the number, that it can sit either side of the real factor and why, gives the tungsten figures, and points at a shielded run for the size of the effect. The Rust doc is left alone, being the one that was already right.

The same claim is in the yani docs (`usage.md`, `why_yani.md`); fusion-neutronics/yani#31 fixes those.
