### PR TITLE
Perturb the rates a shielded run used, not their dilute twins

### DIFF
--- a/crates/yani-transmute/examples/collapse_golden.rs
+++ b/crates/yani-transmute/examples/collapse_golden.rs
@@ -98,7 +98,7 @@ fn main() {
     let masses: Vec<f64> = flux.iter().map(|f| f / total).collect();
 
     // Per group, so a single group average that moves is visible where it moved.
-    let per_group = per_group_reaction_rates(&material, &chain, &masses, &boundaries);
+    let per_group = per_group_reaction_rates(&material, &chain, &masses, &boundaries, None);
     let mut nuclides: Vec<&String> = per_group.keys().collect();
     nuclides.sort();
     for name in nuclides {

--- a/crates/yani-transmute/src/flux_uncertainty.rs
+++ b/crates/yani-transmute/src/flux_uncertainty.rs
@@ -140,9 +140,17 @@ const FLUX_STREAM: u32 = 0xF10D_5EED;
 
 /// Apply one replica's flux perturbation to a set of unit-flux rates.
 ///
+/// The perturbation is applied as a factor on the rate, not as a replacement
+/// for it: the terms say how the rate is distributed over the bins, and the
+/// rate itself stays the one the collapse produced. So an unperturbed replica
+/// reproduces the nominal rate bit for bit rather than to rounding, and a
+/// weighting the terms do not describe cannot be silently substituted for the
+/// one that drove the nominal run.
+///
 /// Rates with no per-group terms are passed through unchanged, which is what a
 /// nuclide whose cross sections were never collapsed against this spectrum
-/// looks like.
+/// looks like, and so is a channel whose rate comes from the branching overlay
+/// rather than from a group average.
 pub fn perturb_rates(
     rates: &ReactionRates,
     per_group: &PerGroupRates,
@@ -157,14 +165,16 @@ pub fn perturb_rates(
             let Some(rate) = nuclide_rates.get_mut(kind) else {
                 continue;
             };
-            // Sum the same terms the nominal rate is the sum of, weighted. With
-            // every delta zero this reproduces the nominal rate exactly, which
-            // is what keeps an unperturbed replica honest.
-            *rate = terms
+            let nominal: f64 = terms.iter().sum();
+            if nominal <= 0.0 {
+                continue;
+            }
+            let perturbed: f64 = terms
                 .iter()
                 .zip(delta)
                 .map(|(term, d)| term * (1.0 + d))
                 .sum();
+            *rate *= perturbed / nominal;
         }
     }
     out
@@ -211,6 +221,35 @@ mod tests {
         let nominal: f64 = terms.iter().sum();
         let out = perturb_rates(&rates(nominal), &per_group(terms), &[0.0, 0.0, 0.0]);
         assert_eq!(out["Li6"]["(n,t)"], nominal);
+    }
+
+    /// And reproduces it even when the terms describe a different weighting.
+    ///
+    /// The terms are a shape, not a substitute for the rate. Assigning their
+    /// sum instead of scaling by it is how a shielded rate used to be replaced
+    /// by a dilute one at zero perturbation.
+    #[test]
+    fn an_unperturbed_replica_does_not_replace_the_rate_with_the_terms() {
+        // A rate 30% below what the terms sum to, which is roughly what
+        // self-shielding does to a resonance absorber's capture.
+        let shielded = 0.7;
+        let out = perturb_rates(
+            &rates(shielded),
+            &per_group(vec![0.25, 0.5, 0.25]),
+            &[0.0, 0.0, 0.0],
+        );
+        assert_eq!(out["Li6"]["(n,t)"], shielded);
+    }
+
+    /// A term set summing to nothing has no shape to perturb along.
+    #[test]
+    fn a_channel_with_no_rate_in_any_bin_is_left_alone() {
+        let out = perturb_rates(
+            &rates(1.0),
+            &per_group(vec![0.0, 0.0, 0.0]),
+            &[0.5, 0.5, 0.5],
+        );
+        assert_eq!(out["Li6"]["(n,t)"], 1.0);
     }
 
     /// The rate is linear in the flux, so a uniform perturbation scales it.

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -380,6 +380,7 @@ pub fn transmute_material_shielded(
             parts,
             &stepper,
             request,
+            shielding,
         )?;
         results.uncertainty.insert(material_id, ensemble);
         results.uncertainty_info = Some(info);
@@ -685,6 +686,7 @@ fn run_replicas(
     parts: yani::ChainParts,
     stepper: &ForwardEulerStepper,
     request: &DataUncertainty,
+    shielding: Option<&Shielding>,
 ) -> Result<(Ensemble, Info), Box<dyn std::error::Error>> {
     // One fold and one factorization per distinct spectrum, not per replica.
     // The fold is relativized, so the per-step `scale_rates` leaves it correct:
@@ -745,6 +747,7 @@ fn run_replicas(
                         &per_spectrum[idx].2,
                         &spectrum.masses,
                         &spectrum.boundaries,
+                        shielding,
                     ),
                 )));
             }

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -713,6 +713,21 @@ struct Collapse<'a> {
 }
 
 impl Collapse<'_> {
+    /// The reactions loaded for one nuclide at the temperature in use.
+    ///
+    /// Shared so that every consumer of the collapse resolves the temperature
+    /// the same way; a second copy of this is a second chance to read a
+    /// different evaluation than the one the rates came from.
+    fn reactions_for(&self, nuclide_name: &str) -> Option<&HashMap<i32, std::sync::Arc<Reaction>>> {
+        let nuclide_data = self.material.nuclide_data.get(nuclide_name)?;
+        let temperature = if self.material.temperature().is_empty() {
+            crate::default_temperature(nuclide_data)?
+        } else {
+            self.material.temperature().to_string()
+        };
+        nuclide_data.reactions_for_temp(&temperature)
+    }
+
     /// The flux shape one nuclide's group averages are taken under, with what
     /// a report should say about it: `(shape, why not, whether it was)`.
     ///
@@ -814,18 +829,7 @@ impl Collapse<'_> {
             return None;
         }
 
-        // Get nuclide data
-        let nuclide_data = self.material.nuclide_data.get(nuclide_name)?;
-
-        // Get temperature for data lookup
-        let temperature = if self.material.temperature().is_empty() {
-            crate::default_temperature(nuclide_data)?
-        } else {
-            self.material.temperature().to_string()
-        };
-
-        // Get reactions for this temperature
-        let reactions = nuclide_data.reactions_for_temp(&temperature)?;
+        let reactions = self.reactions_for(nuclide_name)?;
 
         let mut out = NuclideCollapse {
             rates: HashMap::new(),
@@ -840,16 +844,7 @@ impl Collapse<'_> {
         out.not_shielded = not_shielded;
         out.shielded = shielded;
 
-        // Get unique reaction types from chain
-        let mut reaction_types: Vec<&str> = chain_nuclide
-            .reactions
-            .iter()
-            .map(|r| r.kind.as_str())
-            .collect();
-        reaction_types.sort();
-        reaction_types.dedup();
-
-        for &rx_type in &reaction_types {
+        for &rx_type in &kinds_of(chain_nuclide) {
             let mt = match reaction_type_to_mt(rx_type) {
                 Some(mt) => mt,
                 None => continue,
@@ -950,6 +945,18 @@ impl Collapse<'_> {
     }
 }
 
+/// The reaction kinds the chain drives on one nuclide, sorted and deduped.
+fn kinds_of(chain_nuclide: &ChainNuclide) -> Vec<&str> {
+    let mut kinds: Vec<&str> = chain_nuclide
+        .reactions
+        .iter()
+        .map(|r| r.kind.as_str())
+        .collect();
+    kinds.sort();
+    kinds.dedup();
+    kinds
+}
+
 /// The nuclide's fission yields, if it has any tabulated.
 fn fy_set_for(chain_nuclide: &ChainNuclide) -> Option<&FissionYieldSet> {
     chain_nuclide
@@ -1008,15 +1015,6 @@ pub fn reaction_rate_spectrum(
         return None;
     }
     let mt = reaction_type_to_mt(kind)?;
-    let nuclide_data = material.nuclide_data.get(nuclide)?;
-    let temperature = if material.temperature().is_empty() {
-        crate::default_temperature(nuclide_data)?
-    } else {
-        material.temperature().to_string()
-    };
-    let reactions = nuclide_data.reactions_for_temp(&temperature)?;
-    let reaction = reactions.get(&mt)?;
-
     let setup = CollapseSetup::new(material, multigroup_flux, shielding)?;
     let context = setup.context(
         material,
@@ -1025,6 +1023,8 @@ pub fn reaction_rate_spectrum(
         source_rate,
         shielding,
     );
+    let reactions = context.reactions_for(nuclide)?;
+    let reaction = reactions.get(&mt)?;
     // The shielded average needs the nuclide's flux shape; the self-shielding
     // indicator does not belong to a rate, so its density is left off and the
     // walk skips that accumulation.
@@ -1043,26 +1043,32 @@ pub fn reaction_rate_spectrum(
 /// The per-group contributions to each reaction rate, for flux uncertainty.
 ///
 /// `out[nuclide][kind][g]` is that group's share of the rate, so the nominal
-/// rate is the sum over `g`. Computed by the same collapse as
-/// [`compute_multigroup_reaction_rates`] and against the same cross sections,
-/// so the sums agree with the rates it returns.
+/// rate is the sum over `g`. Every group average comes from
+/// [`Collapse::walk_channel`], the same walk
+/// [`compute_multigroup_reaction_rates_shielded`] collapses with and under the
+/// same `shielding`, so the terms sum to the rate that run produced rather than
+/// to a differently weighted one.
 ///
 /// Separate rather than an extra return value because it is only ever wanted
 /// when flux uncertainty is requested: it is the rate map times the group
 /// count, which on a 709-group structure is tens of MB, and the default path
-/// should not pay that (issue #559).
+/// should not pay that (issue #559). [`reaction_rate_spectrum`] is the
+/// one-channel form, for asking rather than for perturbing.
 pub fn per_group_reaction_rates(
     material: &Material,
     chain: &HashMap<String, ChainNuclide>,
     multigroup_flux: &[f64],
     group_boundaries: &[f64],
+    shielding: Option<&Shielding>,
 ) -> crate::flux_uncertainty::PerGroupRates {
     let mut out: crate::flux_uncertainty::PerGroupRates = HashMap::new();
     let n_groups = multigroup_flux.len();
-    let total_flux: f64 = multigroup_flux.iter().sum();
-    if n_groups == 0 || total_flux <= 0.0 {
+    let Some(setup) = CollapseSetup::new(material, multigroup_flux, shielding) else {
         return out;
-    }
+    };
+    // Unit source rate: these decompose the unit-flux rates the replicas
+    // perturb, and the step's magnitude is applied to both alike afterwards.
+    let context = setup.context(material, multigroup_flux, group_boundaries, 1.0, shielding);
 
     // Per nuclide and independent, exactly as the collapse it mirrors is, and
     // merged into a map keyed by a name that appears once -- so the order the
@@ -1072,40 +1078,26 @@ pub fn per_group_reaction_rates(
         if chain_nuclide.reactions.is_empty() {
             return None;
         }
-        let nuclide_data = material.nuclide_data.get(nuclide_name)?;
-        let temperature = if material.temperature().is_empty() {
-            crate::default_temperature(nuclide_data)?
-        } else {
-            material.temperature().to_string()
-        };
-        let reactions = nuclide_data.reactions_for_temp(&temperature)?;
-
-        let mut kinds: Vec<&str> = chain_nuclide
-            .reactions
-            .iter()
-            .map(|r| r.kind.as_str())
-            .collect();
-        kinds.sort();
-        kinds.dedup();
+        let reactions = context.reactions_for(nuclide_name)?;
+        let (shape, _, _) = context.shape_for(nuclide_name, reactions);
 
         let mut per_kind: HashMap<String, Vec<f64>> = HashMap::new();
-        for kind in kinds {
+        for kind in kinds_of(chain_nuclide) {
             let Some(mt) = reaction_type_to_mt(kind) else {
                 continue;
             };
             let Some(reaction) = reactions.get(&mt) else {
                 continue;
             };
-            let terms: Vec<f64> = (0..n_groups)
-                .map(|g| {
-                    let sigma_g =
-                        group_averaged_xs(reaction, group_boundaries[g], group_boundaries[g + 1]);
-                    // The same 1e-24 barn-to-cm^2 factor the rate carries, so
-                    // these sum to the rate rather than to something
-                    // proportional to it.
-                    sigma_g * multigroup_flux[g] * 1.0e-24
-                })
-                .collect();
+            // A group the walk skips carries no flux, so its term is exactly
+            // zero and the vector is sized to the whole structure regardless:
+            // the perturbation indexes it by the caller's own bin.
+            let mut terms = vec![0.0; n_groups];
+            context.walk_channel(reaction, shape.as_ref(), None, |g, sigma_g, phi| {
+                // The same 1e-24 barn-to-cm^2 factor the rate carries, so these
+                // sum to the rate rather than to something proportional to it.
+                terms[g] = sigma_g * phi * 1.0e-24;
+            });
             if terms.iter().any(|t| *t > 0.0) {
                 per_kind.insert(kind.to_string(), terms);
             }

--- a/crates/yani-transmute/tests/flux_uncertainty_under_shielding.rs
+++ b/crates/yani-transmute/tests/flux_uncertainty_under_shielding.rs
@@ -1,0 +1,261 @@
+//! A flux perturbation must move the rates the run actually used.
+//!
+//! The flux replicas are built from the per-group terms of the collapse, and
+//! those terms used to be computed dilute whatever the run asked for, then
+//! ASSIGNED to the rate. So a run that combined a self-shielding chord with a
+//! per-bin flux sigma had every replica's rate quietly replaced by the dilute
+//! one, even at zero perturbation, and the ensemble drifted off the nominal it
+//! is supposed to spread around.
+//!
+//! Both halves are checked: that the terms are shielded when the run is, and
+//! that the perturbation is a factor on the rate rather than a substitute for
+//! it.
+//!
+//! Self-skips when the nuclear-data fixtures are missing.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use yamc_materials::Material;
+use yani_transmute::multigroup::{
+    compute_multigroup_reaction_rates_shielded, per_group_reaction_rates,
+};
+use yani_transmute::uncertainty::{DataUncertainty, Source};
+use yani_transmute::{
+    transmute_material_shielded, MultigroupSpectrum, Shielding, TransmutationResults, TransmuteStep,
+};
+
+/// Three groups: thermal, epithermal, fast.
+const GROUPS: [f64; 4] = [1.0e-5, 0.625, 1.0e5, 2.0e7];
+const FLUX: [f64; 3] = [1.0e12, 5.0e12, 1.0e14];
+/// Enough chord through solid iron for its keV resonances to bite, which on
+/// this structure is a few percent on capture.
+const CHORD_CM: f64 = 2.0;
+/// Small enough that the ensemble mean sits far closer to its own nominal than
+/// the shielded and dilute answers sit to each other.
+const RELATIVE_SIGMA: f64 = 0.01;
+const REPLICAS: usize = 64;
+/// The product of Fe56 capture, so the nuclide the shielding moves.
+const PRODUCT: &str = "Fe57";
+
+fn chain() -> Arc<HashMap<String, yani::ChainNuclide>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../yani/tests/transmutation-endf-b8.1-sfr.arrow");
+    Arc::new(yani::parse_chain_arrow(&path).expect("parse chain"))
+}
+
+fn iron(data: &str) -> Material {
+    let mut m = Material::new(
+        HashMap::from([("Fe56".to_string(), 1.0)]),
+        "atom",
+        "sum",
+        None,
+    )
+    .expect("Fe56 material");
+    m.density = Some(7.87);
+    m.set_temperature("294");
+    m.read_nuclear_data(
+        &HashMap::from([("Fe56".to_string(), data.to_string())]),
+        None,
+    )
+    .expect("read Fe56");
+    m
+}
+
+fn run(data: &str, shielding: Option<&Shielding>, with_sigma: bool) -> TransmutationResults {
+    let total: f64 = FLUX.iter().sum();
+    let spectra = vec![MultigroupSpectrum {
+        boundaries: GROUPS.to_vec(),
+        masses: FLUX.iter().map(|f| f / total).collect(),
+        relative_std_dev: with_sigma.then(|| vec![RELATIVE_SIGMA; FLUX.len()]),
+    }];
+    let steps = vec![TransmuteStep {
+        dt: 86400.0,
+        irradiation: Some((0, total)),
+    }];
+    let request = DataUncertainty {
+        seed: 1,
+        samples: Some(REPLICAS),
+        // Only the flux, so nothing here needs MF=33 covariance and the
+        // ensemble's spread is the flux sigma alone.
+        sources: vec![Source::FluxSpectrum],
+    };
+    transmute_material_shielded(
+        &mut iron(data),
+        &spectra,
+        &steps,
+        chain(),
+        &Default::default(),
+        Default::default(),
+        with_sigma.then_some(&request),
+        shielding,
+    )
+    .expect("transmute")
+}
+
+/// The ensemble mean of the product's density after the irradiation step.
+fn ensemble_mean(results: &TransmutationResults, id: u32) -> f64 {
+    let samples = results
+        .uncertainty
+        .get(&id)
+        .expect("an ensemble was recorded")
+        .samples_at(0, PRODUCT);
+    assert_eq!(samples.len(), REPLICAS, "every replica must be recorded");
+    samples.iter().sum::<f64>() / samples.len() as f64
+}
+
+fn density(results: &TransmutationResults, id: u32) -> f64 {
+    results
+        .get_nuclide_density(id, PRODUCT, 1)
+        .expect("the product exists after irradiation")
+}
+
+/// The terms themselves, against the collapse they are supposed to decompose.
+///
+/// This is the direct form of the first half, and the sharp one: the ensemble
+/// can only see the terms through the shape of its perturbation, which on this
+/// fixture is a 3% difference inside a 1% sigma. The sums are exact.
+#[test]
+fn the_per_group_terms_carry_the_weighting_the_run_asked_for() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let material = iron(&data);
+    let chain = chain();
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let total: f64 = FLUX.iter().sum();
+    let masses: Vec<f64> = FLUX.iter().map(|f| f / total).collect();
+
+    let mut checked = 0;
+    for request in [None, Some(&shielding)] {
+        let (rates, _, _) = compute_multigroup_reaction_rates_shielded(
+            &material, &chain, &masses, &GROUPS, 1.0, request,
+        );
+        let terms = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, request);
+        assert!(!rates.is_empty(), "the spectrum must produce rates");
+        for (nuclide, per_kind) in &rates {
+            for (kind, &rate) in per_kind {
+                let summed: f64 = terms[nuclide][kind].iter().sum();
+                assert!(
+                    (summed - rate).abs() <= 1.0e-12 * rate.abs(),
+                    "{nuclide} {kind}: the collapse gives {rate}, its terms sum to {summed}"
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert!(
+        checked > 6,
+        "expected several reactions under each weighting, got {checked}"
+    );
+
+    // And the two weightings are genuinely different, so the check above is
+    // not passing twice on the same numbers.
+    let dilute = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, None);
+    let shielded = per_group_reaction_rates(&material, &chain, &masses, &GROUPS, Some(&shielding));
+    let sum = |t: &yani_transmute::flux_uncertainty::PerGroupRates| -> f64 {
+        t["Fe56"]["(n,gamma)"].iter().sum()
+    };
+    assert!(
+        sum(&shielded) < sum(&dilute) * 0.99,
+        "shielded terms must sum below dilute ones: {:e} against {:e}",
+        sum(&shielded),
+        sum(&dilute)
+    );
+}
+
+#[test]
+fn a_shielded_run_perturbs_its_shielded_rates() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let id = iron(&data).material_id.unwrap_or(0);
+
+    let dilute = density(&run(&data, None, false), id);
+    let shielded = density(&run(&data, Some(&shielding), false), id);
+
+    // Without a gap between the two answers the rest of this test cannot fail,
+    // so it is asserted rather than assumed.
+    let gap = (dilute - shielded) / shielded;
+    assert!(
+        gap > 0.02,
+        "shielding must move {PRODUCT} for this test to discriminate: \
+         dilute {dilute:e}, shielded {shielded:e}, gap {:.3}%",
+        gap * 100.0
+    );
+
+    let mean = ensemble_mean(&run(&data, Some(&shielding), true), id);
+
+    // The perturbation is symmetric and the rate is linear in the flux, so the
+    // ensemble spreads around its own nominal. A tenth of the gap is far wider
+    // than the sampling error at this sigma and far narrower than the gap.
+    let off_shielded = (mean - shielded).abs() / shielded;
+    assert!(
+        off_shielded < gap / 10.0,
+        "the ensemble must spread around the shielded nominal it came from: \
+         mean {mean:e} is {:.3}% off shielded {shielded:e}, with the dilute \
+         answer {dilute:e} a {:.3}% walk away",
+        off_shielded * 100.0,
+        gap * 100.0
+    );
+}
+
+/// The other half, and the one that fails loudest: with every deviate at zero
+/// the replicas must reproduce the nominal inventory exactly.
+#[test]
+fn an_unperturbed_shielded_replica_is_the_nominal_run() {
+    let Some(data) = yamc_test_cache::nuclide("Fe56") else {
+        eprintln!("skipping: Fe56 fixture missing");
+        return;
+    };
+    let shielding = Shielding::new(CHORD_CM).expect("a positive chord");
+    let id = iron(&data).material_id.unwrap_or(0);
+
+    let total: f64 = FLUX.iter().sum();
+    let spectra = vec![MultigroupSpectrum {
+        boundaries: GROUPS.to_vec(),
+        masses: FLUX.iter().map(|f| f / total).collect(),
+        // A flux the caller states is exact still requests the source, so the
+        // per-group terms are built and used, with every deviate zero.
+        relative_std_dev: Some(vec![0.0; FLUX.len()]),
+    }];
+    let steps = vec![TransmuteStep {
+        dt: 86400.0,
+        irradiation: Some((0, total)),
+    }];
+    let request = DataUncertainty {
+        seed: 1,
+        samples: Some(2),
+        sources: vec![Source::FluxSpectrum],
+    };
+    let results = transmute_material_shielded(
+        &mut iron(&data),
+        &spectra,
+        &steps,
+        chain(),
+        &Default::default(),
+        Default::default(),
+        Some(&request),
+        Some(&shielding),
+    )
+    .expect("transmute");
+
+    let nominal = density(&results, id);
+    for (replica, sample) in results
+        .uncertainty
+        .get(&id)
+        .expect("an ensemble was recorded")
+        .samples_at(0, PRODUCT)
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(
+            *sample, nominal,
+            "replica {replica} perturbed nothing and must be the nominal run"
+        );
+    }
+}

--- a/crates/yani-transmute/tests/zero_flux_groups.rs
+++ b/crates/yani-transmute/tests/zero_flux_groups.rs
@@ -125,6 +125,7 @@ fn padding_a_spectrum_with_empty_groups_changes_no_bits() {
         &chain,
         &padded,
         &boundaries,
+        None,
     );
     let mut checked = 0;
     for (nuclide, per_kind) in &wide {


### PR DESCRIPTION
The latent bug noted at the end of #44. Based on #44 rather than main, because the fix routes the per-group terms through `Collapse::walk_channel`, which that PR introduces; GitHub will retarget this to main when #44 merges.

## The bug

Two things combined into one silent substitution.

`per_group_reaction_rates` took no `shielding` argument and averaged each group with `group_averaged_xs`, whose flux-shape argument is hard-coded `None`. Its terms were therefore always dilute, while the nominal collapse beside it (`material_transmute.rs:305`) was shielded whenever the caller gave a chord.

`perturb_rates` then **assigned** the weighted sum of those terms to the rate instead of scaling the rate by it (`flux_uncertainty.rs:163`). Its own comment claimed a zero deviate reproduces the nominal rate exactly; that held only on the dilute path.

So combining `self_shielding_chord` or `self_shielding_shape` with a pulse carrying `flux_std_dev`, both reachable in a single `Material.transmute` call, replaced every replica's rate with the dilute one even at zero perturbation. The ensemble spread around an answer the run had already rejected, and the reported sigma was a spread about the wrong centre. Nothing covered the combination: `Shielding` appears in no uncertainty test.

Measured on the iron fixture (Fe56, 3 groups, 2 cm chord, 1% per-bin sigma, 64 replicas), the ensemble mean of Fe57 sat 2.9% off the shielded nominal and 0.1% from the dilute one.

## The fix

- `per_group_reaction_rates` takes the shielding request and builds its terms through `Collapse::walk_channel`, the same walk the collapse uses, so the terms sum to the rate that run produced under either weighting.
- On the way it stops carrying its own copy of the temperature-and-reactions lookup and the chain's kind list. Both now live on `Collapse`, shared with `collapse_nuclide`, which is what keeps a second weighting from reappearing.
- `perturb_rates` scales rather than assigns. The terms are a shape; the rate stays the collapse's own. An unperturbed replica is now the nominal run bit for bit rather than to rounding, and a future mismatch cannot replace a rate again.

## Tests

`crates/yani-transmute/tests/flux_uncertainty_under_shielding.rs`, three tests, each verified against the bug as shipped by reverting each half in turn:

| test | shielded terms reverted | scaling reverted | both |
|---|---|---|---|
| terms carry the run's weighting | FAIL | pass | FAIL |
| unperturbed shielded replica is the nominal run | pass | FAIL | FAIL |
| shielded run perturbs its shielded rates | pass | FAIL | FAIL |

With both reverted the third reports exactly the symptom: `mean 1.0410e-7 is 2.888% off shielded 1.0118e-7, with the dilute answer 1.0401e-7 a 2.791% walk away`.

The first test is the sharp one: it compares the terms against `compute_multigroup_reaction_rates_shielded` directly under both weightings, and separately asserts the two weightings differ, so it cannot pass twice on the same numbers. The ensemble can only see the terms through the shape of its perturbation, which on this fixture is a 3% difference inside a 1% sigma, so it is not the place to test them.

Two unit tests in `flux_uncertainty.rs` cover the scaling on its own: a rate 30% below what its terms sum to survives a zero perturbation, and a channel with no rate in any bin is left alone.

`cargo fmt`, `cargo clippy --all-targets`, `cargo test -p yani-transmute` (13 targets) and the Python uncertainty suite all pass. The dilute path is untouched, and `an_unperturbed_replica_reproduces_the_nominal_rate` still holds, now by construction rather than by luck.
