### PR TITLE
Fix the two findings from the PR 41 review

### DIFF
--- a/crates/yamc/tests/option_matrix.rs
+++ b/crates/yamc/tests/option_matrix.rs
@@ -406,30 +406,35 @@ mod gpu_guards {
     /// preparation, BEFORE any GPU context -- so this guard runs on any host. It
     /// is not a "decay photons are rejected" check; they are accepted, the decay
     /// data is what is missing here.
-    /// IGNORED: broken in two layers, neither of them this test's fault, and
-    /// both invisible until `gpu` joined the default features and this ran for
-    /// the first time. Tracked in #43.
+    /// IGNORED: this test asks for a state the public API forbids, and then
+    /// two further things go wrong. See #43.
     ///
-    /// 1. It cannot reach what it asserts on. `neutron_csg_model()` uses
-    ///    `build_csg()`, whose "inside the sphere" is `Complement(Above(..))`,
-    ///    and the GPU AABB pass rejects a Complement as unbounded extent, so
-    ///    the run is refused at translate. `build_csg_gpu()` in this very
-    ///    module exists for that reason and its comment names the error.
-    /// 2. Swapping in `build_csg_gpu()` does not fix it, it makes it worse:
-    ///    the run then gets far enough to PANIC in
-    ///    `yamc-gpu/src/photon/xs/photon_xs.rs:121`, on
-    ///    `.expect("at least one material with at least one element")`, because
-    ///    this model carries neutron data only. So the coupled GPU path
-    ///    panics where it should return an error when a material has no photon
-    ///    data, which is a defect in its own right and is the thing this guard
-    ///    would have caught years earlier had it been able to run.
+    /// It sets `use_decay_photons` ALONE. The Python constructor rejects that
+    /// outright ("use_decay_photons=True requires transport_secondary_photons
+    /// =True", `yamc-python/src/simulation/model.rs:277`), so no supported
+    /// caller can produce this model. That matters because `has_photons()`
+    /// (`yamc/src/model.rs:454`) does not count `use_decay_photons`, so with
+    /// only that flag set the model reports "no photons", and
+    /// `ensure_photon_data_for_gpu` returns early WITHOUT running its
+    /// missing-photon-data check. That check exists precisely to turn this into
+    /// a clean message rather than a panic, and its own comment says so.
     ///
-    /// Ignored rather than deleted, and rather than weakened to accept
-    /// whichever error happens to come out first: the assertion is the correct
-    /// one and should survive to be un-ignored once the panic is an error and
-    /// the fixture carries photon data.
+    /// With the invariant respected the guard fires and the error is about
+    /// photon data, which is what the sibling
+    /// `gpu_coupled_requires_photon_data` already asserts. So to test what THIS
+    /// test wants, the model needs photon data PRESENT and decay data absent,
+    /// which means the two-fixture material `gpu_coupled_photon.rs` builds.
+    ///
+    /// And it still could not get there: `neutron_csg_model()` uses
+    /// `build_csg()`, whose "inside the sphere" is `Complement(Above(..))`, and
+    /// the GPU AABB pass rejects a Complement as unbounded extent. That is what
+    /// `build_csg_gpu()` in this module exists for; its comment names the
+    /// error.
+    ///
+    /// Ignored rather than deleted or weakened to accept whichever error
+    /// surfaces first. The assertion is the right one; #43 says what it needs.
     #[test]
-    #[ignore = "cannot reach decay-data prep; see the comment above and #43"]
+    #[ignore = "sets use_decay_photons alone, which the API forbids; see above and #43"]
     fn gpu_decay_photons_require_decay_data() {
         let mut m = neutron_csg_model();
         m.use_decay_photons = true;

--- a/crates/yamc/tests/twin_urr_parity.rs
+++ b/crates/yamc/tests/twin_urr_parity.rs
@@ -71,36 +71,44 @@ fn cache(n: &str) -> String {
 /// One solid W184 sphere cut into `n_mats` concentric shells, each its own
 /// `Material`. Flux is tallied in the outermost shell.
 fn build(comp: &[(&str, f64)], n_mats: usize) -> Option<(Model, Arc<Tally>, TransportSettings)> {
-    if comp
-        .iter()
-        .any(|(n, _)| !std::path::Path::new(&cache(n)).exists())
-    {
+    // Usable, not merely present. Checking the cache DIRECTORY exists is not
+    // the same as it being complete: a partially downloaded entry has
+    // `nuclide.arrow` and no `reactions.arrow`, and used to pass this guard and
+    // then fail inside `read_nuclear_data`, so a half-fetched cache surfaced as
+    // a panic on an unrelated-looking line rather than as a skip. Asking for
+    // the two sections a transport load requires puts that answer here, where
+    // the skip belongs, and lets `mk_mat` below treat any later failure as the
+    // real bug it would be.
+    let usable = |n: &str| {
+        let dir = std::path::PathBuf::from(cache(n));
+        ["nuclide.arrow", "reactions.arrow"]
+            .iter()
+            .all(|f| dir.join(f).is_file())
+    };
+    if comp.iter().any(|(n, _)| !usable(n)) {
         return None;
     }
-    let mk_mat = |id: u32| -> Option<Arc<Material>> {
+    // `expect`, deliberately. Every reason this could fail that is not the
+    // caller's problem has been ruled out by the guard above, so a failure here
+    // is a real regression in material construction and should be loud. The
+    // earlier version swallowed it into a skip, which traded a confusing
+    // failure for a silent one.
+    let mk_mat = |id: u32| -> Arc<Material> {
         let composition: HashMap<String, f64> =
             comp.iter().map(|(n, f)| (n.to_string(), *f)).collect();
         let data: HashMap<String, String> = comp
             .iter()
             .map(|(n, _)| (n.to_string(), cache(n)))
             .collect();
-        let mut m = Material::new(composition, "atom", "g/cm3", Some(DENSITY)).ok()?;
+        let mut m = Material::new(composition, "atom", "g/cm3", Some(DENSITY))
+            .expect("the composition is a literal in this file");
         m.set_material_id(id);
         m.set_temperature("294");
-        m.read_nuclear_data(&data, None).ok()?;
-        Some(Arc::new(m))
+        m.read_nuclear_data(&data, None)
+            .expect("the guard above checked every fixture is complete");
+        Arc::new(m)
     };
-    // `collect::<Option<_>>()?`, not `unwrap()`. The guard above checks that
-    // each nuclide's cache DIRECTORY exists, which is not the same as it being
-    // complete: a partially downloaded entry has `nuclide.arrow` and no
-    // `reactions.arrow`, so it passes the guard and then fails in
-    // `read_nuclear_data`. That turned an absent fixture into a panic pointing
-    // at this line rather than a skip, which is a confusing way to learn your
-    // cache is half fetched. Natural W needs four isotopes and CI fetches only
-    // W184, so the skip is the normal path there anyway.
-    let mats: Vec<Arc<Material>> = (0..n_mats)
-        .map(|i| mk_mat(i as u32 + 1))
-        .collect::<Option<Vec<_>>>()?;
+    let mats: Vec<Arc<Material>> = (0..n_mats).map(|i| mk_mat(i as u32 + 1)).collect();
 
     let mut cells = Vec::new();
     let mut prev: Option<Arc<Surface>> = None;


### PR DESCRIPTION
Follow-up to #41, which merged before these landed. Two test-only changes,
no product code.

## 1. `twin_urr_parity` guarded on the wrong thing

The guard checked that each nuclide's cache DIRECTORY exists, which is not
the same as the data being loadable. A partially downloaded entry has
`nuclide.arrow` and no `reactions.arrow`, so it passed the guard and then
failed inside `read_nuclear_data`.

The existing response to that was to make `mk_mat` fallible and
`collect::<Option<Vec<_>>>()?`, turning an incomplete cache into a skip.
That works, but it decides in the wrong place and overpays: every other way
material construction can fail is swallowed into the same silent skip, so a
genuine regression in `Material::new` or `read_nuclear_data` would surface
as "0 tests run" and nothing else.

Now the guard asks for the two sections a transport load actually needs, and
`mk_mat` is infallible. Incomplete cache still skips, at the point that
decides it; a real failure is loud again.

Verified both directions: with complete fixtures the two tests pass (80 s);
with `W183/reactions.arrow` moved aside the file skips in 0.00 s.

## 2. The `#[ignore]` reason on `gpu_decay_photons_require_decay_data` was
incomplete, and I had overstated the bug behind it

Comment only, the test stays ignored. The old reason named the outer problem
and missed that the state under test is unreachable from the supported API:
the Python constructor rejects `use_decay_photons` without
`transport_secondary_photons` (`yamc-python/src/simulation/model.rs:277`).

That is also a correction to what I filed as #43. I described a live panic
in `extract_photon_material_xs`; it is not reachable from Python, because
the invariant that keeps `has_photons()` true is enforced at the boundary.
What remains is a real but narrower inconsistency: `has_photons()`
(`yamc/src/model.rs:454`) does not count `use_decay_photons`, while
`dispatch.rs:3084` already assumes the implication in a comment, so a
Rust-API caller who sets the flag alone gets no constructor validation and
silently skips the guard. #43 has been updated with the corrected diagnosis
and a revised fix.

The comment now records both layers plus the fixture problem that blocks the
test either way (`build_csg()`'s `Complement(Above(..))`, which the GPU AABB
pass rejects as unbounded).

## Checks

`cargo test --test twin_urr_parity` 2 passed. `cargo test --test
option_matrix` 10 passed, 1 ignored.