### PR TITLE
Drop the project URLs from the yamc-core wheel

### DIFF
--- a/packages/yamc-core/pyproject.toml
+++ b/packages/yamc-core/pyproject.toml
@@ -20,13 +20,6 @@ license = "MIT"
 license-files = ["LICENSE", "THIRD-PARTY-LICENSES.html"]
 dependencies = []
 
-[project.urls]
-Homepage = "https://github.com/fusion-neutronics/yamc"
-Documentation = "https://fusion-neutronics.github.io/yamc/"
-Repository = "https://github.com/fusion-neutronics/yamc"
-Issues = "https://github.com/fusion-neutronics/yamc/issues"
-Discussions = "https://github.com/fusion-neutronics/yamc/discussions"
-
 [project.optional-dependencies]
 cad = ["cadquery>=2.8.0", "numpy"]
 viz = ["h5py", "numpy"]


### PR DESCRIPTION
`packages/yamc-core/pyproject.toml` declared five `[project.urls]`. Four pointed at `fusion-neutronics/yamc` and one at `fusion-neutronics.github.io/yamc/`, so they were dead links on the published page for yamc-core 0.9.0.

`yamc` is the front door and is where the links belong. yani-core already declares none.

Now a plain seven-line deletion, with no replacement comment. Nothing in the repo reads this metadata, and `maturin sdist` still builds: PKG-INFO is Name `yamc-core`, Version `0.9.0`, with no `Project-URL` or `Home-page` field.