### PR TITLE
Point the CI badges at the repository that runs them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-[![Test usage with Python](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-python.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-python.yml)
-[![Test usage with Rust](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-rust.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-rust.yml)
+<!-- The CI badges point at `fusion-neutronics/core` because ci-python, ci-rust
+and ci-wasm run here. The Documentation badge points at `fusion-neutronics/yamc`
+on purpose: docs.yml lives in that repo, not this one, so retargeting it here
+would give a 404. It renders blank until that repo is public. -->
+[![Test usage with Python](https://github.com/fusion-neutronics/core/actions/workflows/ci-python.yml/badge.svg)](https://github.com/fusion-neutronics/core/actions/workflows/ci-python.yml)
+[![Test usage with Rust](https://github.com/fusion-neutronics/core/actions/workflows/ci-rust.yml/badge.svg)](https://github.com/fusion-neutronics/core/actions/workflows/ci-rust.yml)
 [![Documentation](https://github.com/fusion-neutronics/yamc/actions/workflows/docs.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/docs.yml)
-<!-- [![Test usage with WASM](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-wasm.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-wasm.yml) -->
+<!-- [![Test usage with WASM](https://github.com/fusion-neutronics/core/actions/workflows/ci-wasm.yml/badge.svg)](https://github.com/fusion-neutronics/core/actions/workflows/ci-wasm.yml) -->
 
 # YAMC
 


### PR DESCRIPTION
Follow-up to #48, which flagged this and left it because it looked like it
needed a decision about which repo is the public face. It does not: the private
`fusion-neutronics/yamc` repo holds only `commit-authors.yml`, `docs.yml` and
`publish.yml`, so the question answers itself per badge.

## What was wrong

The three CI badges loaded their images from
`github.com/fusion-neutronics/yamc/actions/workflows/...` naming `ci-python`,
`ci-rust` and `ci-wasm`. **None of those workflows exist in that repository.**
They run here. So these were broken images pointing at an address that could
never have resolved, independently of the repo being private.

Measured, `.../actions/workflows/<wf>/badge.svg`:

| workflow | `core` | `yamc` |
|---|---|---|
| ci-python.yml | **200** | 404 |
| ci-rust.yml | **200** | 404 |
| ci-wasm.yml | **200** | 404 |
| docs.yml | 404 | 404 (private, but really there) |

## What is deliberately not changed

**The Documentation badge.** `docs.yml` genuinely lives in the front-door repo
and not here, and the table above shows `core/actions/workflows/docs.yml`
returns a real 404. Moving it would swap a badge that is merely private for one
that is permanently broken. It starts rendering when that repo goes public. An
HTML comment above the badges records this so the next person does not
"correct" it.

**The Discussions link** (line 20), for a similar reason: discussions are
enabled on `fusion-neutronics/yamc` and **disabled** on `fusion-neutronics/core`
(`has_discussions=false`), so that link points where the discussions actually
are.

**`pip install yamc` and the docs URL**, per the decision in #48 that the `yamc`
front door is still coming rather than retired. The front-door repo's own README
says `pip install yamc`, so those lines are early, not wrong.