### PR TITLE
Make core's README about core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,61 @@
-[![Test usage with Python](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-python.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-python.yml)
-[![Test usage with Rust](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-rust.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-rust.yml)
-[![Documentation](https://github.com/fusion-neutronics/yamc/actions/workflows/docs.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/docs.yml)
-<!-- [![Test usage with WASM](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-wasm.yml/badge.svg)](https://github.com/fusion-neutronics/yamc/actions/workflows/ci-wasm.yml) -->
+# core
 
-# YAMC
+The Rust workspace behind [`yamc`](https://github.com/fusion-neutronics/yamc)
+and [`yani`](https://github.com/fusion-neutronics/yani). Everything that
+compiles lives here: 25 crates, the pyo3 bindings, and the two wheels that get
+published to PyPI.
 
-YAMC (Yet Another Monte Carlo) is an open-source Monte Carlo particle transport code for **neutron and photon simulations**, with a focus on **fusion neutronics workflows**.
+**This is not the repository to install from, and not where the user
+documentation lives.** Those are the two public repositories above, which are
+also where issues, discussions and the released docs belong. What is here is
+what only someone with this checkout needs.
 
-It supports constructive solid and mesh-based geometries, coupled neutron-photon transport, transmutation, shutdown dose rate analysis, CAD geometry import, flexible tallies, convenient post processing and support for portable simulations all accessible through a Python API.
+## What it publishes
 
-## Installation
+Two compiled wheels, whose distribution names differ from their import names
+(as `pillow` provides `PIL`):
+
+| built from | distribution | imported as | front door |
+|---|---|---|---|
+| `packages/yamc-core/` | `yamc-core` | `yamc` | `yamc`, pinning `yamc-core==<same version>` |
+| `packages/yani-core/` | `yani-core` | `yani` | `yani`, pinning `yani-core==<same version>` |
+
+A user installs the front door, not the `-core` wheel. The front door is a
+version pin and the documentation; the `-core` wheel is the compiled artefact
+this workspace produces.
+
+The two wheels are alternatives rather than layers. `yamc` is a superset that
+adds transport, geometry and tallies on top of the transmutation stack, and
+installing both puts two extension modules in one process. See
+`packages/yani-core/README.md`.
+
+## Getting started
 
 ```bash
-pip install yamc
+cargo test                       # the Rust workspace
+maturin develop --release        # build and install the yamc extension
+pytest                           # the Python tests
 ```
 
-See the **[documentation](https://fusion-neutronics.github.io/yamc/)** for installation and usage details.
+Full instructions, including the nuclear data the tests need, GPU and MPI
+builds, profiling, the wasm blobs and the release procedure, are in
+**[docs/developer_info.md](docs/developer_info.md)**, which is also the internal
+mkdocs site (`mkdocs build -f mkdocs.yml`). That file has the annotated
+crate-by-crate workspace layout.
 
-Ask questions or get support on the **[GitHub Discussions forum](https://github.com/fusion-neutronics/yamc/discussions)**.
+## Continuous integration
 
-To build, test, and contribute to YAMC, see the **[developer guide](https://fusion-neutronics.github.io/yamc/developer_info.html)**.
+| workflow | what it covers |
+|---|---|
+| [`ci-rust.yml`](.github/workflows/ci-rust.yml) | the Rust workspace across the supported targets |
+| [`ci-python.yml`](.github/workflows/ci-python.yml) | the wheels, the Python test suites and the published stubs |
+| [`ci-wasm.yml`](.github/workflows/ci-wasm.yml) | the wasm32 builds |
+| [`ci-endf-goldens.yml`](.github/workflows/ci-endf-goldens.yml) | the ENDF and ACE converters against pinned goldens |
+| [`licenses.yml`](.github/workflows/licenses.yml) | the third-party license bundle shipped in each wheel |
+| [`docs-mkdocs.yml`](.github/workflows/docs-mkdocs.yml) | this repository's internal site |
+| [`commit-authors.yml`](.github/workflows/commit-authors.yml) | commit authorship on every pull request |
 
-🦀 **Rust core** for high performance across Linux, macOS, and Windows (x86_64 and ARM), with WebAssembly support for browser-based deployment.
-
-🐍 **Python API** where all computation runs in Rust -- Python calls are thin wrappers with no overhead.
+Status badges are deliberately absent. GitHub serves `badge.svg` through an
+image proxy that fetches anonymously, so a badge for a private repository
+returns 404 whether or not the reader is signed in, which makes badges here
+permanently broken images rather than a signal. The Actions tab works normally.


### PR DESCRIPTION
Supersedes #49, which repointed the CI badges. Given that `core` becomes
private and `yamc` and `yani` are the public faces, the badges are not the
problem worth fixing in this file.

## The problem

`README.md` was the public YAMC product pitch: a paragraph on the transport
code, `pip install yamc`, and links to the documentation site and Discussions
forum. All of that describes the front-door repository, and it is already the
README over there.

So the repository containing all the code had no description of itself.
Nothing here said that `core` builds two wheels, that their distribution names
differ from their import names, that a user installs `yamc` rather than
`yamc-core`, or where the developer guide lives. `mkdocs.yml` already draws
this line ("The user-facing sites are built from the public repositories ...
What is left here is what only a person with this checkout needs"); the README
did not.

## What it says now

The four names and how they relate, which is the thing that keeps causing
confusion:

| built from | distribution | imported as | front door |
|---|---|---|---|
| `packages/yamc-core/` | `yamc-core` | `yamc` | `yamc`, pinning `yamc-core==<same version>` |
| `packages/yani-core/` | `yani-core` | `yani` | `yani`, pinning `yani-core==<same version>` |

Then the three build commands, a pointer to
[`docs/developer_info.md`](docs/developer_info.md) for everything real, and a
table of the seven workflows. The product pitch is pointed at, not duplicated.

## Badges are dropped, not repointed

Two independent reasons:

1. Three of the four (ci-python, ci-rust, ci-wasm) named workflows that **do
   not exist** in the repository their URL pointed at. They were broken images
   already, not merely private ones.
2. Repointing them here only works while this repository is public. GitHub
   serves `badge.svg` through an image proxy that fetches anonymously, so a
   private repository's badge returns 404 with or without credentials. I
   measured both: anonymous 404, authenticated 404. Once core is private, any
   badge in this file is a permanently broken image.

The workflows are listed as ordinary links instead, which keep working for
anyone who can read the repository.

## Checks

All eight relative links resolve against the tree. All seven files in
`.github/workflows/` appear in the table. No em dashes.