### PR TITLE
Write VTKHDF from the cad path without numpy

### DIFF
--- a/packages/yamc-core/pyproject.toml
+++ b/packages/yamc-core/pyproject.toml
@@ -28,7 +28,7 @@ Issues = "https://github.com/fusion-neutronics/yamc/issues"
 Discussions = "https://github.com/fusion-neutronics/yamc/discussions"
 
 [project.optional-dependencies]
-cad = ["cadquery>=2.8.0", "numpy"]
+cad = ["cadquery>=2.8.0"]
 viz = ["h5py", "numpy"]
 pandas = ["pandas>=2.2"]
 polars = ["polars>=0.20"]

--- a/packages/yamc-core/python/yamc/cad/vtkhdf_writer.py
+++ b/packages/yamc-core/python/yamc/cad/vtkhdf_writer.py
@@ -1,26 +1,44 @@
-"""VTKHDF v2.1 UnstructuredGrid writer for ParaView visualization."""
+"""VTKHDF v2.1 UnstructuredGrid writer for ParaView visualization.
 
-import numpy as np
+No numpy. Every buffer here is built once and handed straight to h5py, which
+takes an ordinary sequence as long as the dtype is given explicitly, so the
+arrays this used to build were converted twice: the mesh arrives from the Rust
+core as `list[list[...]]` (see `SurfaceMesh.vertices`), numpy copied it, and
+h5py copied it again. Dropping the copy is marginally faster and leaves the
+cad extra with no numpy dependency at all.
+
+The `dtype=` arguments are load-bearing, not decoration. They pin what lands on
+disk, and VTKHDF readers care: without them an int buffer's width would follow
+the platform. Do not remove them.
+"""
 
 VTK_TRIANGLE = 5
 VTK_TETRA = 10
 
 
+def _flatten(rows):
+    """Flatten a sequence of index tuples into one connectivity list."""
+    return [i for row in rows for i in row]
+
+
 def _write_vtkhdf_header(root, n_points, n_cells, n_connectivity_ids):
     """Write the VTKHDF header attributes and metadata datasets."""
-    root.attrs["Version"] = np.array([2, 1], dtype="int64")
-    ascii_type = "UnstructuredGrid".encode("ascii")
     import h5py
+    # `attrs.create` rather than `attrs["Version"] = [2, 1]`: plain assignment
+    # would let h5py pick the integer width, and VTKHDF wants int64.
+    root.attrs.create("Version", [2, 1], dtype="int64")
+    ascii_type = "UnstructuredGrid".encode("ascii")
     root.attrs.create(
         "Type",
         ascii_type,
         dtype=h5py.string_dtype("ascii", len(ascii_type)),
     )
-    root.create_dataset("NumberOfPoints", data=np.array([n_points], dtype="int64"))
-    root.create_dataset("NumberOfCells", data=np.array([n_cells], dtype="int64"))
+    root.create_dataset("NumberOfPoints", data=[n_points], dtype="int64")
+    root.create_dataset("NumberOfCells", data=[n_cells], dtype="int64")
     root.create_dataset(
         "NumberOfConnectivityIds",
-        data=np.array([n_connectivity_ids], dtype="int64"),
+        data=[n_connectivity_ids],
+        dtype="int64",
     )
 
 
@@ -29,9 +47,9 @@ def surface_to_vtkhdf(filename, vertices, triangles, cell_data=None):
 
     Args:
         filename: Output file path.
-        vertices: List of [x, y, z] or numpy array (N, 3).
-        triangles: List of [i, j, k] or numpy array (M, 3).
-        cell_data: Optional dict of name -> array (one value per triangle).
+        vertices: Sequence of [x, y, z] triples, shape (N, 3).
+        triangles: Sequence of [i, j, k] triples, shape (M, 3).
+        cell_data: Optional dict of name -> sequence (one value per triangle).
     """
     try:
         import h5py
@@ -40,27 +58,25 @@ def surface_to_vtkhdf(filename, vertices, triangles, cell_data=None):
             "h5py is required for VTKHDF export. Install with: pip install h5py"
         ) from None
 
-    verts = np.array(vertices, dtype="float64")
-    tris = np.array(triangles, dtype="int64")
-    n_tris = len(tris)
-    n_points = len(verts)
+    n_tris = len(triangles)
+    n_points = len(vertices)
 
-    connectivity = tris.flatten()
-    offsets = np.arange(0, n_tris * 3 + 1, 3, dtype="int64")
-    types = np.full(n_tris, VTK_TRIANGLE, dtype="uint8")
+    connectivity = _flatten(triangles)
+    offsets = list(range(0, n_tris * 3 + 1, 3))
+    types = [VTK_TRIANGLE] * n_tris
 
     with h5py.File(filename, "w") as f:
         root = f.create_group("VTKHDF")
         _write_vtkhdf_header(root, n_points, n_tris, len(connectivity))
-        root.create_dataset("Points", data=verts)
-        root.create_dataset("Connectivity", data=connectivity)
-        root.create_dataset("Offsets", data=offsets)
-        root.create_dataset("Types", data=types)
+        root.create_dataset("Points", data=vertices, dtype="float64")
+        root.create_dataset("Connectivity", data=connectivity, dtype="int64")
+        root.create_dataset("Offsets", data=offsets, dtype="int64")
+        root.create_dataset("Types", data=types, dtype="uint8")
 
         if cell_data:
             cd = root.create_group("CellData")
             for name, data in cell_data.items():
-                cd.create_dataset(name, data=np.array(data))
+                cd.create_dataset(name, data=data)
 
 
 def tet_to_vtkhdf(filename, vertices, tets, cell_data=None):
@@ -68,9 +84,9 @@ def tet_to_vtkhdf(filename, vertices, tets, cell_data=None):
 
     Args:
         filename: Output file path.
-        vertices: numpy array (N, 3) float64.
-        tets: numpy array (M, 4) int.
-        cell_data: Optional dict of name -> array (one value per tet).
+        vertices: Sequence of [x, y, z] triples, shape (N, 3).
+        tets: Sequence of [i, j, k, l] quadruples, shape (M, 4).
+        cell_data: Optional dict of name -> sequence (one value per tet).
     """
     try:
         import h5py
@@ -79,27 +95,25 @@ def tet_to_vtkhdf(filename, vertices, tets, cell_data=None):
             "h5py is required for VTKHDF export. Install with: pip install h5py"
         ) from None
 
-    verts = np.array(vertices, dtype="float64")
-    tets_arr = np.array(tets, dtype="int64")
-    n_tets = len(tets_arr)
-    n_points = len(verts)
+    n_tets = len(tets)
+    n_points = len(vertices)
 
-    connectivity = tets_arr.flatten()
-    offsets = np.arange(0, n_tets * 4 + 1, 4, dtype="int64")
-    types = np.full(n_tets, VTK_TETRA, dtype="uint8")
+    connectivity = _flatten(tets)
+    offsets = list(range(0, n_tets * 4 + 1, 4))
+    types = [VTK_TETRA] * n_tets
 
     with h5py.File(filename, "w") as f:
         root = f.create_group("VTKHDF")
         _write_vtkhdf_header(root, n_points, n_tets, len(connectivity))
-        root.create_dataset("Points", data=verts)
-        root.create_dataset("Connectivity", data=connectivity)
-        root.create_dataset("Offsets", data=offsets)
-        root.create_dataset("Types", data=types)
+        root.create_dataset("Points", data=vertices, dtype="float64")
+        root.create_dataset("Connectivity", data=connectivity, dtype="int64")
+        root.create_dataset("Offsets", data=offsets, dtype="int64")
+        root.create_dataset("Types", data=types, dtype="uint8")
 
         if cell_data:
             cd = root.create_group("CellData")
             for name, data in cell_data.items():
-                cd.create_dataset(name, data=np.array(data))
+                cd.create_dataset(name, data=data)
 
 
 def mixed_to_vtkhdf(filename, vertices, triangles, tets, cell_data=None):
@@ -107,10 +121,10 @@ def mixed_to_vtkhdf(filename, vertices, triangles, tets, cell_data=None):
 
     Args:
         filename: Output file path.
-        vertices: numpy array (N, 3) float64.
-        triangles: numpy array (M_tri, 3) int.
-        tets: numpy array (M_tet, 4) int.
-        cell_data: Optional dict of name -> array (one value per cell,
+        vertices: Sequence of [x, y, z] triples, shape (N, 3).
+        triangles: Sequence of [i, j, k] triples, shape (M_tri, 3).
+        tets: Sequence of [i, j, k, l] quadruples, shape (M_tet, 4).
+        cell_data: Optional dict of name -> sequence (one value per cell,
             triangles first then tets).
     """
     try:
@@ -120,44 +134,32 @@ def mixed_to_vtkhdf(filename, vertices, triangles, tets, cell_data=None):
             "h5py is required for VTKHDF export. Install with: pip install h5py"
         ) from None
 
-    verts = np.array(vertices, dtype="float64")
-    tris = np.array(triangles, dtype="int64") if len(triangles) > 0 else np.empty((0, 3), dtype="int64")
-    tets_arr = np.array(tets, dtype="int64") if len(tets) > 0 else np.empty((0, 4), dtype="int64")
-
-    n_tris = len(tris)
-    n_tets = len(tets_arr)
+    n_tris = len(triangles)
+    n_tets = len(tets)
     n_cells = n_tris + n_tets
-    n_points = len(verts)
+    n_points = len(vertices)
 
-    # Build connectivity, offsets, types for mixed mesh
-    parts = []
-    if n_tris > 0:
-        parts.append(tris.flatten())
-    if n_tets > 0:
-        parts.append(tets_arr.flatten())
-    connectivity = np.concatenate(parts) if parts else np.empty(0, dtype="int64")
+    # Build connectivity, offsets, types for mixed mesh. Tet vertices are
+    # already in `vertices` (the mesh is conformal), so this is a plain append.
+    connectivity = _flatten(triangles) + _flatten(tets)
 
     offsets = [0]
     for _ in range(n_tris):
         offsets.append(offsets[-1] + 3)
     for _ in range(n_tets):
         offsets.append(offsets[-1] + 4)
-    offsets = np.array(offsets, dtype="int64")
 
-    types = np.concatenate([
-        np.full(n_tris, VTK_TRIANGLE, dtype="uint8"),
-        np.full(n_tets, VTK_TETRA, dtype="uint8"),
-    ])
+    types = [VTK_TRIANGLE] * n_tris + [VTK_TETRA] * n_tets
 
     with h5py.File(filename, "w") as f:
         root = f.create_group("VTKHDF")
         _write_vtkhdf_header(root, n_points, n_cells, len(connectivity))
-        root.create_dataset("Points", data=verts)
-        root.create_dataset("Connectivity", data=connectivity)
-        root.create_dataset("Offsets", data=offsets)
-        root.create_dataset("Types", data=types)
+        root.create_dataset("Points", data=vertices, dtype="float64")
+        root.create_dataset("Connectivity", data=connectivity, dtype="int64")
+        root.create_dataset("Offsets", data=offsets, dtype="int64")
+        root.create_dataset("Types", data=types, dtype="uint8")
 
         if cell_data:
             cd = root.create_group("CellData")
             for name, data in cell_data.items():
-                cd.create_dataset(name, data=np.array(data))
+                cd.create_dataset(name, data=data)


### PR DESCRIPTION
Answers "what is numpy for, and can we stop depending on it directly".

## Survey

numpy appears in exactly two shipped modules, both VTKHDF export, 64 call
sites. Everywhere else is tests (16 files) and examples (21), neither shipped.
Both are lazy-imported, so `import yamc` already never needs numpy.

| module | uses | mechanical | changed |
|---|---|---|---|
| `cad/vtkhdf_writer.py` | 26 | all 26 | **yes** |
| `vtkhdf.py` | 38 | 20 | no |

The split: the cad writer only ever *constructs* buffers for h5py
(`array`/`full`/`empty`/`arange`/`concatenate`), and h5py takes a plain
sequence given an explicit `dtype=`. `vtkhdf.py` is different, with 18 uses
doing real vectorised work (`.reshape`, elementwise division by mesh-element
volumes at `:299-301`, `np.where` masking over voxel grids at `:485`/`:489`).
Its import stays regardless, so editing its easy 20 would be churn.

So numpy there was a copy between two other copies: the mesh arrives from Rust
as `list[list[...]]` (`mesh_geometry.rs:213,220`), numpy copied it, h5py copied
it again.

## Verification

**Output is unchanged.** All seven entry points and branches, captured before
and after, identical in dtype and bytes:

| case | result |
|---|---|
| `surface`, `surface_nocd` | identical |
| `tet` | identical |
| `mixed_both`, `mixed_tris_only`, `mixed_tets_only`, `mixed_empty` | identical |

The last three cover the `np.empty((0,3))` / `np.empty((0,4))` guard branches.

Also checked:
- Importing the module no longer pulls numpy into `sys.modules`.
- ndarray inputs still work, and produce output identical to list inputs (the
  old docstrings promised ndarray support, and it is preserved).
- 38 passed in `test_vtkhdf.py`, `test_vtkhdf_export.py`, `test_cad_finalize.py`
  (1 skip, pre-existing: cadquery not installed locally).
- 300k triangles: list version 931 ms vs numpy 1008 ms, peak +38.7 vs +24.3 MB.

## Extras

`cad = ["cadquery>=2.8.0"]` now. numpy was never load-bearing there: cadquery
pulls it in via scipy (`numpy>=2.0.0`) and numba (`numpy>=1.22`), and the only
cad code that imported it also needs h5py, which `cad` does not include.

`viz` keeps numpy, since `vtkhdf.py` imports it directly.

## Not in this PR

`cad` still lacks h5py while `CadToYamc.to_vtkhdf()` needs it, so
`pip install yamc-core[cad]` gives a `to_vtkhdf()` that raises "h5py is
required for VTKHDF export". Real gap, but a separate decision about whether
`cad` is meshing-only with export living in `[viz]`/`[all]`.