### PR TITLE
Bump EXPECTED_DATA_VERSION to the 2026-09-02 republish

### DIFF
--- a/crates/yamc-nuclide/src/storage/url_cache.rs
+++ b/crates/yamc-nuclide/src/storage/url_cache.rs
@@ -448,22 +448,29 @@ static EMBEDDED_INDEX: Lazy<HashMap<&'static str, HashSet<&'static str>>> = Lazy
 /// fails, by design (see `download_and_cache`).
 #[cfg(feature = "download")]
 const EXPECTED_DATA_VERSION: &[(&str, &str)] = &[
-    // The 2026-08-21 republish, which is the first one to stamp anything and
-    // which restamped every library in the same run, so they share a value
-    // rather than drifting per library. Confirmed against the origin before
-    // pinning, because the warning above is real: an entry no published data
-    // carries invalidates every cache on first load and then fails.
+    // The 2026-09-02 republish, which restamped every library in the same run,
+    // so they share a value rather than drifting per library. Confirmed against
+    // the origin before pinning, because the warning above is real: an entry no
+    // published data carries invalidates every cache on first load and then
+    // fails.
     //
     // Swept over neutron for all six, photon for the three that publish it, and
-    // all four transmutation subsections; every one reads "2026-08-21".
-    // jeff-4.0 publishes no photon data at all (404 on element.arrow, not an
-    // unstamped directory), so there is nothing to pin for it there.
-    ("tendl-2025", "2026-08-21"),
-    ("tendl-2017", "2026-08-21"),
-    ("fendl-3.2d", "2026-08-21"),
-    ("endf-b8.1", "2026-08-21"),
-    ("jeff-4.0", "2026-08-21"),
-    ("jendl-5.0", "2026-08-21"),
+    // every transmutation subsection each library provides (four for endf-b8.1
+    // / jeff-4.0 / jendl-5.0, two for the TENDLs, none for fendl-3.2d); all 25
+    // published paths read "2026-09-02". jeff-4.0 publishes no photon data at
+    // all (404 on element.arrow, not an unstamped directory), so there is
+    // nothing to pin for it there.
+    //
+    // This pin has to move with a republish. The previous value was
+    // "2026-08-21", and leaving it behind does not serve stale data: it fails
+    // every fresh download outright, because the stamp the origin now carries
+    // no longer matches what this build expects.
+    ("tendl-2025", "2026-09-02"),
+    ("tendl-2017", "2026-09-02"),
+    ("fendl-3.2d", "2026-09-02"),
+    ("endf-b8.1", "2026-09-02"),
+    ("jeff-4.0", "2026-09-02"),
+    ("jendl-5.0", "2026-09-02"),
 ];
 
 /// The `data_version` this build expects for `source`, if it pins one.


### PR DESCRIPTION
## What

Bumps the six `EXPECTED_DATA_VERSION` pins in `crates/yamc-nuclide/src/storage/url_cache.rs`
from `2026-08-21` to `2026-09-02`, matching the republish on Cloudflare R2.

## Why

Every fresh download fails the comparison in `download_and_cache`:

```
'endf-b8.1' was downloaded fresh and still reports data_version "2026-09-02",
but this build of yamc expects "2026-08-21". The published data has not been
stamped with the version this yamc release pins, so either the publish or
EXPECTED_DATA_VERSION in url_cache.rs is wrong.
```

The error message is right, and it is the publish side that moved. This is not a
"serves stale data" problem: the pin exists to evict caches a republish
invalidated, so a value the origin no longer carries rejects the data outright.
It took out all four Python CI matrix jobs (ubuntu and macos, Python 3.10 and
3.14).

## Verified against the origin, not assumed

The comment on the table warns that an entry no published data carries
invalidates every cache on first load and then fails, so I swept the origin
before pinning. **All 25 published paths read `2026-09-02`:**

| Section | Coverage |
|---|---|
| neutron (`Fe56`) | all six libraries |
| photon (`Fe`) | endf-b8.1, fendl-3.2d, jendl-5.0 |
| transmutation | 4 subsections each for endf-b8.1 / jeff-4.0 / jendl-5.0, `branching` + `reactions` for both TENDLs, none for fendl-3.2d |

Uniform across the republish, as `2026-08-21` was, so the six entries keep a
shared value rather than drifting per library. jeff-4.0 still publishes no photon
data (404 on `element.arrow`, not an unstamped directory), so there is still
nothing to pin for it there.

`cargo fmt --check` clean and all 216 `yamc-nuclide` tests pass with
`--features download-tls`, including `every_pinned_keyword_is_a_real_keyword`.

## One thing this may not fix

The same CI run also failed `regression_tests/test_transmutation.py::Co58` with
`4/71 products exceed 0.5% (max=2.55%)`. Those are genuine numeric differences,
not missing products (a missing product scores 100%), so they look like the new
evaluations actually moving the answer rather than a knock-on of the failed
load. If it survives this PR's CI, the reference values need regenerating
against the 2026-09-02 data, and that is a judgement call about the physics
rather than something to fix by loosening the tolerance.

The three other mentions of `2026-08-21` in the tree are prose about that
republish as a historical event, and are left alone.
