### PR TITLE
Fold nothing above an evaluation's last energy point, and refuse a spectrum that reaches past it

### DIFF
--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -302,6 +302,29 @@ pub fn transmute_material_shielded(
     let mut shielding_info = ShieldingInfo::default();
     let mut per_spectrum: Vec<PerSpectrum> = Vec::with_capacity(spectra.len());
     for s in spectra {
+        // Where an evaluation ends the cross section is unknown, and the fold
+        // treats it as zero. A sliver of flux there is a rounding matter; more
+        // than that and every rate on the nuclide would be understated by data
+        // that does not exist, so the run stops and says which nuclide and how
+        // much rather than answering as if it knew.
+        let above = crate::multigroup::spectrum_above_evaluation(
+            &current_material,
+            &s.masses,
+            &s.boundaries,
+        );
+        if let Some((name, top, fraction)) = above
+            .iter()
+            .find(|(_, _, fraction)| *fraction > crate::multigroup::ABOVE_EVALUATION_TOLERANCE)
+        {
+            return Err(format!(
+                "{:.3}% of the spectrum lies above {top:.4e} eV, the last energy point in \
+                 {name}'s evaluation. No cross section exists there, so the rates on {name} \
+                 would be understated by that share. Cut the spectrum at the evaluation's \
+                 top energy, or use a library evaluated to higher energy.",
+                fraction * 100.0
+            )
+            .into());
+        }
         let (mut rates, fy_weights, info) = compute_multigroup_reaction_rates_shielded(
             &current_material,
             &chain,

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -291,14 +291,36 @@ pub(crate) fn walk_group(
     // `group_averaged_xs` is reachable with a hand-built `Reaction` and the
     // index below should not be what discovers it.
     let lengths_agree = grid.len() == values.len();
-    let (start, inner) = interior_from(grid, e_lo, e_hi);
+
+    // Above the evaluation's last energy point there is no cross section, and
+    // the walk stops there. `cross_section_at` holds its last value above the
+    // grid, which is right for a lookup at a single energy just past the end
+    // but not for an integral: a CCFE-709 group reaching 1 GeV against an
+    // evaluation that ends at 200 MeV would carry the 200 MeV cross section
+    // across the other 800 MeV. The group keeps its full width in the dilute
+    // average, and the tail keeps its flux in the shielded denominator, so the
+    // averages say what they should: no cross section over that part of the
+    // group. A group that lies entirely above the grid has nothing to walk.
+    let top = grid.last().copied().unwrap_or(e_lo);
+    let e_end = e_hi.min(top);
+    if e_end <= e_lo {
+        if shape.is_some() {
+            terms.shielded_den += 0.5 * (prev_phi + phi_at(e_hi)) * (e_hi - e_lo);
+        }
+        if bound_density.is_some() {
+            terms.bound_den += e_hi - e_lo;
+            terms.bound_width += e_hi - e_lo;
+        }
+        return terms;
+    }
+    let (start, inner) = interior_from(grid, e_lo, e_end);
 
     let points = inner
         .iter()
         .enumerate()
         .map(|(k, &e)| (Some(k), e))
         // The upper edge is not a grid point in general, so it is interpolated.
-        .chain(std::iter::once((None, e_hi)));
+        .chain(std::iter::once((None, e_end)));
     for (offset, e) in points {
         let xs = match offset.filter(|_| lengths_agree) {
             Some(k) => {
@@ -346,8 +368,88 @@ pub(crate) fn walk_group(
         prev_phi = phi;
     }
 
+    // The part of the group above the evaluation: zero cross section, so it
+    // adds to the denominators alone.
+    if e_end < e_hi {
+        let de = e_hi - e_end;
+        if shape.is_some() {
+            terms.shielded_den += 0.5 * (phi_at(e_end) + phi_at(e_hi)) * de;
+        }
+        if bound_density.is_some() {
+            terms.bound_den += de;
+            terms.bound_width += de;
+        }
+    }
+
     terms
 }
+
+/// The share of a spectrum's flux above `top`, with the flux flat inside each
+/// group, which is what the fold assumes.
+pub(crate) fn fraction_above(multigroup_flux: &[f64], group_boundaries: &[f64], top: f64) -> f64 {
+    let total: f64 = multigroup_flux.iter().sum();
+    if total <= 0.0 {
+        return 0.0;
+    }
+    let mut above = 0.0;
+    for (g, &phi) in multigroup_flux.iter().enumerate() {
+        let (lo, hi) = (group_boundaries[g], group_boundaries[g + 1]);
+        if phi <= 0.0 || hi <= top {
+            continue;
+        }
+        above += phi * (hi - lo.max(top)) / (hi - lo);
+    }
+    above / total
+}
+
+/// The spectrum's flux above the last energy each nuclide's evaluation
+/// reaches: `(nuclide, top energy [eV], fraction of the flux)`, for the
+/// nuclides where that fraction is not zero, in name order.
+///
+/// No cross section exists there and [`walk_group`] folds it as zero, which is
+/// the honest value for one group's tail but misstates every rate once a
+/// material part of the spectrum is involved. TENDL evaluations end at 200
+/// MeV and ENDF/B's at 20 MeV, and CCFE-709 runs to 1 GeV, so a spectrum with
+/// flux in its top groups can reach this with either library.
+pub fn spectrum_above_evaluation(
+    material: &Material,
+    multigroup_flux: &[f64],
+    group_boundaries: &[f64],
+) -> Vec<(String, f64, f64)> {
+    let mut names: Vec<&String> = material.nuclide_data.keys().collect();
+    names.sort();
+    let mut out = Vec::new();
+    for name in names {
+        let nuclide_data = &material.nuclide_data[name];
+        let temperature = if material.temperature().is_empty() {
+            crate::default_temperature(nuclide_data)
+        } else {
+            Some(material.temperature().to_string())
+        };
+        let Some(temperature) = temperature else {
+            continue;
+        };
+        let Some(reactions) = nuclide_data.reactions_for_temp(&temperature) else {
+            continue;
+        };
+        let top = reactions
+            .values()
+            .filter_map(|r| r.energy.last().copied())
+            .fold(f64::NEG_INFINITY, f64::max);
+        if !top.is_finite() {
+            continue;
+        }
+        let fraction = fraction_above(multigroup_flux, group_boundaries, top);
+        if fraction > 0.0 {
+            out.push((name.clone(), top, fraction));
+        }
+    }
+    out
+}
+
+/// The most of a spectrum that may lie above a nuclide's evaluation before a
+/// transmutation refuses to run on it.
+pub const ABOVE_EVALUATION_TOLERANCE: f64 = 1.0e-3;
 
 /// Compute group-averaged cross section for a single energy group via trapezoidal integration.
 ///
@@ -1194,6 +1296,37 @@ mod tests {
         );
     }
 
+    /// Above the evaluation's last point the cross section is not the last
+    /// value carried on, it is nothing: the group average over the part of a
+    /// group past the grid is zero, and a group entirely past it is zero.
+    #[test]
+    fn the_average_stops_at_the_evaluations_last_point() {
+        let rxn = flat_reaction((1e6, 1e7), 2.0, 16);
+        // Half of this group is above the grid.
+        let avg = group_averaged_xs(&rxn, 5e6, 1.5e7);
+        assert!((avg - 1.0).abs() < 1e-12, "got {avg}");
+        // All of it.
+        assert_eq!(group_averaged_xs(&rxn, 2e7, 3e7), 0.0);
+        // None of it: unchanged.
+        assert!((group_averaged_xs(&rxn, 2e6, 4e6) - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn the_flux_above_an_evaluation_is_counted_flat_within_a_group() {
+        let flux = [1.0, 2.0, 4.0];
+        let edges = [0.0, 1e7, 2e7, 4e7];
+        // Nothing above 4e7.
+        assert_eq!(fraction_above(&flux, &edges, 4e7), 0.0);
+        // The top group only, whole: 4 of 7.
+        assert!((fraction_above(&flux, &edges, 2e7) - 4.0 / 7.0).abs() < 1e-12);
+        // Half of the top group: 2 of 7.
+        assert!((fraction_above(&flux, &edges, 3e7) - 2.0 / 7.0).abs() < 1e-12);
+        // Everything.
+        assert!((fraction_above(&flux, &edges, 0.0) - 1.0).abs() < 1e-12);
+        // No flux at all.
+        assert_eq!(fraction_above(&[0.0, 0.0], &[0.0, 1.0, 2.0], 0.5), 0.0);
+    }
+
     #[test]
     fn test_group_averaged_xs_ramp() {
         // Linear ramp from 0 to 100 barns over 0 to 1e6 eV
@@ -1281,7 +1414,14 @@ mod tests {
         if e_lo >= e_hi {
             return 0.0;
         }
-        let points = scanned_points(&reaction.energy, e_lo, e_hi);
+        // The walk stops at the evaluation's last point and counts nothing
+        // above it, so the reference integrates to there and divides by the
+        // whole width.
+        let e_end = e_hi.min(reaction.energy.last().copied().unwrap_or(e_lo));
+        if e_end <= e_lo {
+            return 0.0;
+        }
+        let points = scanned_points(&reaction.energy, e_lo, e_end);
         let xs: Vec<f64> = points
             .iter()
             .map(|&e| reaction.cross_section_at(e).unwrap_or(0.0))
@@ -1369,11 +1509,19 @@ mod tests {
         rxn.threshold_idx = 0;
         assert_eq!(group_averaged_xs(&rxn, 1.0, 5.0), 3.0);
 
-        // And above the last grid point, flat-clamped to the last value either
-        // way, since `cross_section_at` does not consult the flag up there.
-        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 4.0);
+        // Above the last grid point there is no cross section either way:
+        // `cross_section_at` holds its last value up there for a single
+        // lookup, but an integral over energies the evaluation never reached
+        // counts nothing.
+        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 0.0);
         rxn.threshold_idx = 1;
-        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 4.0);
+        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 0.0);
+        // A group straddling the end integrates to the end and no further:
+        // 4.0 over half the group.
+        assert_eq!(
+            group_averaged_xs(&rxn, 15.0, 25.0),
+            (0.5 * (3.5 + 4.0) * 5.0) / 10.0
+        );
     }
 
     #[test]

--- a/crates/yani-transmute/tests/reaction_rate_spectrum.rs
+++ b/crates/yani-transmute/tests/reaction_rate_spectrum.rs
@@ -185,12 +185,17 @@ fn a_group_with_no_flux_carries_no_rate() {
     let boundaries = ccfe_709();
     let n = boundaries.len() - 1;
     // Flux in three groups and nothing anywhere else, which is the shape a
-    // few-line source has.
-    let carrying = [12usize, 400, n - 2];
+    // few-line source has. The highest of the three is the last group that
+    // lies wholly under 20 MeV, where the ENDF/B-VIII.1 evaluation ends:
+    // CCFE-709 runs on to 1 GeV, and a group past the evaluation's last point
+    // carries flux but no cross section, so it carries no rate by design.
+    let top = boundaries.iter().rposition(|&e| e <= 2.0e7).unwrap() - 1;
+    let carrying = [12usize, 400, top];
     let mut flux = vec![0.0; n];
     for (i, &g) in carrying.iter().enumerate() {
         flux[g] = (i + 1) as f64;
     }
+    flux[n - 2] = 1.0;
 
     let terms = reaction_rate_spectrum(
         &iron(&data),
@@ -206,6 +211,11 @@ fn a_group_with_no_flux_carries_no_rate() {
     for (g, &term) in terms.iter().enumerate() {
         if carrying.contains(&g) {
             assert!(term > 0.0, "group {g} carries flux and must carry rate");
+        } else if g == n - 2 {
+            assert_eq!(
+                term, 0.0,
+                "group {g} lies above the evaluation and must carry no rate"
+            );
         } else {
             assert_eq!(
                 term, 0.0,

--- a/crates/yani-transmute/tests/zero_flux_groups.rs
+++ b/crates/yani-transmute/tests/zero_flux_groups.rs
@@ -68,11 +68,15 @@ fn padding_a_spectrum_with_empty_groups_changes_no_bits() {
 
     // CCFE-709, with flux in three groups spread across the structure and
     // nothing anywhere else -- the shape a monoenergetic or few-line source has.
+    // The highest is the last group wholly under 20 MeV, where the ENDF/B-VIII.1
+    // evaluation ends: a group above it carries no cross section and so no rate,
+    // which would leave the threshold channels with nothing to compare.
     let boundaries = yamc_nuclide::group_structures::get_group_structure("CCFE-709")
         .expect("CCFE-709")
         .to_vec();
     let n = boundaries.len() - 1;
-    let carrying = [12usize, 400, n - 2];
+    let top = boundaries.iter().rposition(|&e| e <= 2.0e7).unwrap() - 1;
+    let carrying = [12usize, 400, top];
     let mut padded = vec![0.0; n];
     for (i, &g) in carrying.iter().enumerate() {
         padded[g] = (i + 1) as f64;


### PR DESCRIPTION
`Reaction::cross_section_at` holds its last value above the grid, which is right for a lookup just past the end and wrong for an integral: the group fold walked a CCFE-709 group that reaches 1 GeV with the 200 MeV cross section carried across the other 800 MeV, and a group lying entirely above the evaluation averaged to the last value rather than to nothing. On the FNS spectra nothing moves (no flux above 16 MeV); on a spectrum with flux in the top groups every threshold channel was overstated by data that does not exist.

- `walk_group` stops at the reaction's last grid point. The group keeps its full width in the dilute average, and the tail keeps its flux in the shielded denominator and its width in the self-shielding indicator. Groups ending within the grid are bit-identical to before.
- `transmute_material` refuses a spectrum with more than 0.1% of its flux above the last energy of any nuclide's evaluation (`ABOVE_EVALUATION_TOLERANCE`), naming the nuclide, the energy and the share. `spectrum_above_evaluation` is public so a caller can ask first.
- Two tests pinned the old carry-forward (a CCFE-709 group near 1 GeV "must carry rate" for Fe56, evaluated to 20 MeV); they now use the last group under 20 MeV and check the one above carries none. New unit tests cover the clamp and the flux-fraction arithmetic.

`cargo test -p yani-transmute`: 155 passed. `cargo check --workspace --all-targets`, clippy and fmt clean. MT5 residual production above 20 MeV is a separate data feature and is not addressed here.
