### PR TITLE
Stop holding neutron sublibraries in memory, and parse them in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,6 +5948,7 @@ dependencies = [
  "endf",
  "lzma-rs",
  "nuclear-data-schema",
+ "rayon",
  "serde_json",
  "yani",
 ]

--- a/crates/endf/src/chain.rs
+++ b/crates/endf/src/chain.rs
@@ -822,6 +822,54 @@ impl Nuclide {
     }
 }
 
+/// Every channel's Q value, by target nuclide name and then by MT.
+///
+/// This is the whole of what [`Chain::from_endf`] takes from the neutron
+/// sublibrary, which is why it takes this rather than the evaluations
+/// themselves: filled one file at a time, a caller never holds more than one
+/// [`Material`]. Holding them all is what made a TENDL chain build peak at
+/// 39 GB and get killed on a 45 GB machine, all of it to harvest the few
+/// hundred KB of scalars in here (issue #53).
+pub type QValues = BTreeMap<String, BTreeMap<i32, f64>>;
+
+/// Record one neutron evaluation's channel Q values into `into`.
+///
+/// QI is the Q of the channel actually populated; QM, the mass-difference Q,
+/// is not the same thing and a few evaluations give it with the opposite sign.
+///
+/// An evaluation with no MF=1 MT=451 header cannot be named, so it contributes
+/// nothing rather than failing, which is how the rest of the chain builder
+/// treats it too.
+pub fn collect_q_values(material: &Material, into: &mut QValues) {
+    let Some(meta) = material.mf1_mt451() else {
+        return;
+    };
+    let (z, a) = (meta.za / 1000, meta.za % 1000);
+    let name = gnds_name(z as u32, a as u32, meta.liso as u32);
+    let entry = into.entry(name).or_default();
+    for &(mf, mt) in material.section_data.keys() {
+        if mf == 3 {
+            if let Some(section) = material.mf3(mt) {
+                entry.insert(mt, section.qi);
+            }
+        }
+    }
+}
+
+/// The Q values of a neutron set already in memory.
+///
+/// For a caller that holds the evaluations anyway, such as a test over a
+/// handful of fixtures. A caller reading a sublibrary off disk should drive
+/// [`collect_q_values`] over the files instead, so its peak is one evaluation
+/// rather than all of them.
+pub fn q_values(neutron: &[Material]) -> QValues {
+    let mut out = QValues::new();
+    for material in neutron {
+        collect_q_values(material, &mut out);
+    }
+    out
+}
+
 /// A depletion chain: every nuclide, and the paths between them.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Chain {
@@ -929,39 +977,24 @@ impl Chain {
         self.nuclides.is_empty()
     }
 
-    /// Build a chain from decay, fission product yield and neutron
-    /// evaluations.
+    /// Build a chain from decay and fission product yield evaluations, and the
+    /// Q values of the neutron set.
     ///
     /// `reactions` names the transmutation reactions to follow; pass
     /// [`DEFAULT_REACTIONS`] for the usual set. Fission is always followed
     /// where an evaluation has it.
+    ///
+    /// The neutron half arrives as [`QValues`] rather than as [`Material`]s
+    /// because that is all of it this reads, and because a whole neutron
+    /// sublibrary held in memory does not fit on an ordinary machine. Build the
+    /// map with [`q_values`] from a slice, or with [`collect_q_values`] one
+    /// file at a time.
     pub fn from_endf(
         decay: &[Material],
         fpy: &[Material],
-        neutron: &[Material],
+        q_values: &QValues,
         reactions: &[&str],
     ) -> Result<Chain> {
-        // What each target's neutron evaluation says each channel's Q value
-        // is. QI is the Q of the channel actually populated; QM, the
-        // mass-difference Q, is not the same thing and a few evaluations give
-        // it with the opposite sign.
-        let mut q_values: BTreeMap<String, BTreeMap<i32, f64>> = BTreeMap::new();
-        for material in neutron {
-            let Some(meta) = material.mf1_mt451() else {
-                continue;
-            };
-            let (z, a) = (meta.za / 1000, meta.za % 1000);
-            let name = gnds_name(z as u32, a as u32, meta.liso as u32);
-            let entry = q_values.entry(name).or_default();
-            for &(mf, mt) in material.section_data.keys() {
-                if mf == 3 {
-                    if let Some(section) = material.mf3(mt) {
-                        entry.insert(mt, section.qi);
-                    }
-                }
-            }
-        }
-
         let mut decay_data: BTreeMap<String, Decay> = BTreeMap::new();
         for material in decay {
             let data = Decay::from_material(material)?;

--- a/crates/endf/src/lib.rs
+++ b/crates/endf/src/lib.rs
@@ -52,7 +52,7 @@ pub use ace::{get_table, get_tables, tables_from_str, MetastableScheme, Table, T
 pub use angle_energy::{
     AngleEnergy, CorrelatedAngleEnergy, KalbachMann, NBodyPhaseSpace, UncorrelatedAngleEnergy,
 };
-pub use chain::{Chain, Nuclide, ReactionInfo, REACTIONS};
+pub use chain::{collect_q_values, q_values, Chain, Nuclide, QValues, ReactionInfo, REACTIONS};
 pub use data::{gnds_name, zam, EV_PER_MEV, K_BOLTZMANN};
 pub use decay::{Decay, DecayMode, FissionProductYields, FissioningNuclide, ProductYield};
 pub use error::{Error, Result};

--- a/crates/endf/tests/golden.rs
+++ b/crates/endf/tests/golden.rs
@@ -2240,8 +2240,8 @@ fn check(golden_path: &Path) -> usize {
                 .collect()
         };
         let reactions: Vec<&str> = g.chain_reactions.iter().map(String::as_str).collect();
-        let chain =
-            endf::Chain::from_endf(&read(&g.decay), &[], &read(&g.neutron), &reactions).unwrap();
+        let q_values = endf::chain::q_values(&read(&g.neutron));
+        let chain = endf::Chain::from_endf(&read(&g.decay), &[], &q_values, &reactions).unwrap();
         let mut d = Dump::default();
         dump_chain(&mut d, "chain", &chain);
         compare(&name, &d.map, &g.values);

--- a/crates/endf/tests/public_api.rs
+++ b/crates/endf/tests/public_api.rs
@@ -14,8 +14,8 @@
 use std::path::{Path, PathBuf};
 
 use endf::{
-    tables_from_str, AngleEnergy, Chain, Decay, FissionProductYields, IncidentNeutron,
-    IncidentPhoton, Interpretation, Material, MetastableScheme, ProbabilityTables,
+    q_values, tables_from_str, AngleEnergy, Chain, Decay, FissionProductYields, IncidentNeutron,
+    IncidentPhoton, Interpretation, Material, MetastableScheme, ProbabilityTables, QValues,
     RadionuclideProduction, Tabulated1D,
 };
 
@@ -146,7 +146,7 @@ fn a_chain_can_be_built_from_materials() {
         .collect();
     let neutron = vec![Material::from_str(&read_text("n-049_In-115_trimmed.endf.xz")).unwrap()];
 
-    let chain = Chain::from_endf(&decay, &[], &neutron, &["(n,gamma)"]).unwrap();
+    let chain = Chain::from_endf(&decay, &[], &q_values(&neutron), &["(n,gamma)"]).unwrap();
     assert!(!chain.nuclides.is_empty());
 }
 
@@ -155,7 +155,7 @@ fn a_chain_can_be_built_from_materials() {
 #[test]
 fn placeholder_decay_energies_are_labelled_and_fillable() {
     let decay = vec![Material::from_str(&read_text("dec-050_Sn_111.endf.xz")).unwrap()];
-    let mut chain = Chain::from_endf(&decay, &[], &[], &[]).unwrap();
+    let mut chain = Chain::from_endf(&decay, &[], &QValues::new(), &[]).unwrap();
     let sn111 = chain.get("Sn111").unwrap();
     assert_eq!(
         sn111.decay_energy_source.as_deref(),
@@ -194,7 +194,7 @@ fn placeholder_decay_energies_are_labelled_and_fillable() {
         }
     );
     let evaluated = vec![Material::from_str(&read_text("dec-049_In_116m1.endf.xz")).unwrap()];
-    let chain = Chain::from_endf(&evaluated, &[], &[], &[]).unwrap();
+    let chain = Chain::from_endf(&evaluated, &[], &QValues::new(), &[]).unwrap();
     assert_eq!(
         chain
             .get("In116_m1")

--- a/crates/yani-convert/Cargo.toml
+++ b/crates/yani-convert/Cargo.toml
@@ -20,6 +20,14 @@ arrow-schema = "53"
 arrow-ipc = { version = "53", features = ["lz4"] }
 serde_json = "1.0"
 
+# Split on target the way `yani-transmute/Cargo.toml` splits it, and for the
+# same reason: rayon has no thread pool on wasm32, and nothing that builds for
+# the browser should have to care that this crate parses in parallel. The
+# per-file work is written once and only the driver line is `#[cfg]`-ed, so the
+# sequential and parallel forms cannot drift apart.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rayon = "1.10"
+
 # Tests only. `yani` is here so the round trip crosses the boundary that
 # matters: this crate writes the files and yani's own reader takes them back,
 # rather than a reader that shares this writer's assumptions. lzma-rs reads the

--- a/crates/yani-convert/src/branching.rs
+++ b/crates/yani-convert/src/branching.rs
@@ -427,29 +427,55 @@ fn partial_sum(
     worst
 }
 
-/// Extract branching rows for each parent's neutron evaluation.
+/// Accumulates branching rows, one neutron evaluation at a time.
 ///
-/// `neutron` and `decay` are the parsed evaluations; the decay files are read
-/// only for the isomer table, so metastable evaluations suffice.
-pub fn extract_branching(
-    neutron: &[Material],
-    decay: &[Material],
+/// The work is per-evaluation once the isomer table is built, so a caller
+/// reading a sublibrary off disk can add each file and drop it instead of
+/// holding the set. That matters for the same reason it did in
+/// `Chain::from_endf` (issue #53): the 552 parents this is usually scoped to
+/// are about 7 GB parsed, and the scoping is a convention of the driver rather
+/// than anything this enforces, so an unscoped call is the 39 GB that used to
+/// be fatal. [`extract_branching`] is this driven over a slice.
+pub struct BranchingExtractor {
+    mt2type: BTreeMap<i64, String>,
+    isomers: endf::radionuclide_production::IsomerTable,
     tol_ev: f64,
     linearize_tol: f64,
-) -> Result<(Vec<BranchingRow>, BranchingStats), Box<dyn Error>> {
-    let mt2type = mt_to_type();
-    let isomers = endf::radionuclide_production::isomer_table_from_materials(decay);
+    rows: Vec<BranchingRow>,
+    stats: BranchingStats,
+    metastable: std::collections::BTreeSet<String>,
+}
 
-    let mut rows = Vec::new();
-    let mut stats = BranchingStats::default();
-    let mut metastable: std::collections::BTreeSet<String> = Default::default();
+impl BranchingExtractor {
+    /// `decay` is read only for the isomer table, so metastable evaluations
+    /// suffice.
+    pub fn new(decay: &[Material], tol_ev: f64, linearize_tol: f64) -> BranchingExtractor {
+        BranchingExtractor {
+            mt2type: mt_to_type(),
+            isomers: endf::radionuclide_production::isomer_table_from_materials(decay),
+            tol_ev,
+            linearize_tol,
+            rows: Vec::new(),
+            stats: BranchingStats::default(),
+            metastable: Default::default(),
+        }
+    }
 
-    for material in neutron {
+    /// Add one neutron evaluation's rows.
+    pub fn add(&mut self, material: &Material) {
+        let (mt2type, isomers, tol_ev, linearize_tol) = (
+            &self.mt2type,
+            &self.isomers,
+            self.tol_ev,
+            self.linearize_tol,
+        );
+        let (rows, stats, metastable) = (&mut self.rows, &mut self.stats, &mut self.metastable);
+
         // The evaluation names itself in MF=1/451, which is the same route
         // Chain::from_endf takes, so parent names match the reactions
         // subsection rather than a filename convention.
         let Some(meta) = material.mf1_mt451() else {
-            continue;
+            return;
         };
         let parent = endf::gnds_name(
             (meta.za / 1000) as u32,
@@ -480,7 +506,7 @@ pub fn extract_branching(
                     a,
                     s.lfs,
                     Some(s.excitation_energy()),
-                    &isomers,
+                    isomers,
                     tol_ev,
                 );
                 let liso = resolved.liso;
@@ -537,10 +563,31 @@ pub fn extract_branching(
         }
     }
 
-    let (rows, merged) = merge_duplicates(rows);
-    stats.merged_duplicate_groups = merged;
-    stats.metastable_targets = metastable.into_iter().collect();
-    Ok((rows, stats))
+    /// The rows and statistics, with duplicate target groups merged.
+    pub fn finish(mut self) -> (Vec<BranchingRow>, BranchingStats) {
+        let (rows, merged) = merge_duplicates(self.rows);
+        self.stats.merged_duplicate_groups = merged;
+        self.stats.metastable_targets = self.metastable.into_iter().collect();
+        (rows, self.stats)
+    }
+}
+
+/// Extract branching rows for each parent's neutron evaluation.
+///
+/// For a caller that holds the evaluations anyway. One reading them off disk
+/// should drive [`BranchingExtractor`] over the files instead, so its peak is
+/// one evaluation rather than the sublibrary.
+pub fn extract_branching(
+    neutron: &[Material],
+    decay: &[Material],
+    tol_ev: f64,
+    linearize_tol: f64,
+) -> Result<(Vec<BranchingRow>, BranchingStats), Box<dyn Error>> {
+    let mut extractor = BranchingExtractor::new(decay, tol_ev, linearize_tol);
+    for material in neutron {
+        extractor.add(material);
+    }
+    Ok(extractor.finish())
 }
 
 /// Write the `branching/` subsection.

--- a/crates/yani-convert/src/branching.rs
+++ b/crates/yani-convert/src/branching.rs
@@ -446,6 +446,20 @@ pub struct BranchingExtractor {
     metastable: std::collections::BTreeSet<String>,
 }
 
+/// What one evaluation contributed, before it is merged into an extractor.
+///
+/// Exists so the per-evaluation work, which is independent of every other
+/// evaluation's, can run off to the side and be merged back afterwards. Merging
+/// in the order the files were read leaves the result identical to reading them
+/// one at a time, which matters because the rows, the flagged levels and the
+/// partial-sum lines are all ordered.
+#[derive(Debug, Clone, Default)]
+pub struct BranchingPartial {
+    rows: Vec<BranchingRow>,
+    stats: BranchingStats,
+    metastable: std::collections::BTreeSet<String>,
+}
+
 impl BranchingExtractor {
     /// `decay` is read only for the isomer table, so metastable evaluations
     /// suffice.
@@ -463,19 +477,28 @@ impl BranchingExtractor {
 
     /// Add one neutron evaluation's rows.
     pub fn add(&mut self, material: &Material) {
+        let partial = self.extract_one(material);
+        self.absorb(partial);
+    }
+
+    /// One evaluation's contribution, worked out without touching the
+    /// accumulator, so callers can do this for many evaluations at once and
+    /// [`Self::absorb`] the results in file order afterwards.
+    pub fn extract_one(&self, material: &Material) -> BranchingPartial {
         let (mt2type, isomers, tol_ev, linearize_tol) = (
             &self.mt2type,
             &self.isomers,
             self.tol_ev,
             self.linearize_tol,
         );
-        let (rows, stats, metastable) = (&mut self.rows, &mut self.stats, &mut self.metastable);
+        let mut out = BranchingPartial::default();
+        let (rows, stats, metastable) = (&mut out.rows, &mut out.stats, &mut out.metastable);
 
         // The evaluation names itself in MF=1/451, which is the same route
         // Chain::from_endf takes, so parent names match the reactions
         // subsection rather than a filename convention.
         let Some(meta) = material.mf1_mt451() else {
-            return;
+            return out;
         };
         let parent = endf::gnds_name(
             (meta.za / 1000) as u32,
@@ -561,6 +584,29 @@ impl BranchingExtractor {
         if emitted_any {
             stats.parents_with_data += 1;
         }
+        out
+    }
+
+    /// Merge one evaluation's contribution.
+    ///
+    /// Call order is the row order, so a caller that extracted out of order
+    /// must absorb in the order the files were read to get the same answer.
+    /// `merged_duplicate_groups` and `metastable_targets` are not merged here
+    /// because [`Self::finish`] is what sets them.
+    pub fn absorb(&mut self, partial: BranchingPartial) {
+        self.rows.extend(partial.rows);
+        self.metastable.extend(partial.metastable);
+        let stats = partial.stats;
+        self.stats.parents += stats.parents;
+        self.stats.parents_with_data += stats.parents_with_data;
+        self.stats.linearized_curves += stats.linearized_curves;
+        for (route, n) in stats.level_routes {
+            *self.stats.level_routes.entry(route).or_insert(0) += n;
+        }
+        self.stats.flagged_levels.extend(stats.flagged_levels);
+        self.stats
+            .partial_sum_mismatches
+            .extend(stats.partial_sum_mismatches);
     }
 
     /// The rows and statistics, with duplicate target groups merged.

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -779,16 +779,44 @@ pub fn convert_transmutation_files(
     let fpy = read(fpy_files)?;
     let decay_fill = read(decay_fill_files)?;
 
-    // Read one at a time and dropped, rather than collected like the others. A
+    // Read and dropped one at a time, rather than collected like the others. A
     // chain wants nothing from a neutron evaluation but its channels' Q values,
     // and holding the parsed set to get them peaked at 39 GB over TENDL's 2848
     // files, which is more than an ordinary machine has: it was killed three
-    // times on a 45 GB one (issue #53). Streamed, the peak is one evaluation,
-    // and the largest single TENDL file is 40 MB.
-    let mut q_values = QValues::new();
-    for path in neutron_files {
+    // times on a 45 GB one (issue #53).
+    //
+    // One map per file, in parallel, merged in file order afterwards. The files
+    // are independent, and merging in order leaves the result identical to a
+    // sequential read, including which of two evaluations of the same nuclide
+    // wins. Only the evaluations in flight are held, so the peak is set by the
+    // core count rather than by the size of the sublibrary, and parsing is what
+    // the pass spends effectively all of its time on: 41 s of the 41.4 s a
+    // TENDL-2017 reactions build took on one core.
+    let read_q = |path: &String| -> Result<QValues, String> {
         let material = Material::from_file(path).map_err(|e| format!("{path}: {e}"))?;
-        collect_q_values(&material, &mut q_values);
+        let mut out = QValues::new();
+        collect_q_values(&material, &mut out);
+        Ok(out)
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let per_file: Vec<QValues> = {
+        use rayon::prelude::*;
+        neutron_files
+            .par_iter()
+            .map(read_q)
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    #[cfg(target_arch = "wasm32")]
+    let per_file: Vec<QValues> = neutron_files
+        .iter()
+        .map(read_q)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut q_values = QValues::new();
+    for map in per_file {
+        for (nuclide, channels) in map {
+            q_values.entry(nuclide).or_default().extend(channels);
+        }
     }
 
     // Every reaction the chain builder knows, not endf::chain::DEFAULT_REACTIONS.

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -863,10 +863,19 @@ pub fn convert_branching_files(
             .map(|p| Material::from_file(p).map_err(|e| format!("{p}: {e}").into()))
             .collect()
     };
-    let neutron = read(neutron_files)?;
     let decay = read(decay_files)?;
 
-    let (rows, stats) = branching::extract_branching(&neutron, &decay, tol_ev, linearize_tol)?;
+    // Streamed, like the Q values above and for the same reason (issue #53).
+    // The branching pass gets away with holding its neutron set today only
+    // because the driver scopes the call to the parents of a reactions
+    // subsection, a few hundred rather than a few thousand evaluations, which
+    // is a convention rather than a promise.
+    let mut extractor = branching::BranchingExtractor::new(&decay, tol_ev, linearize_tol);
+    for path in neutron_files {
+        let material = Material::from_file(path).map_err(|e| format!("{path}: {e}"))?;
+        extractor.add(&material);
+    }
+    let (rows, stats) = extractor.finish();
     let dir = out.join("branching");
     branching::write_branching(&rows, &dir)?;
     write_provenance(

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -38,7 +38,7 @@ use arrow_ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow_ipc::CompressionType;
 use arrow_schema::{ArrowError, Schema};
 
-use endf::chain::Chain;
+use endf::chain::{collect_q_values, Chain, QValues};
 use endf::decay::DecayInconsistency;
 use endf::{Decay, Material};
 
@@ -510,16 +510,21 @@ pub struct Provenance {
     pub created_utc: String,
 }
 
-/// The evaluations a chain is built from.
+/// What a chain is built from: two sublibraries of evaluations, and the Q
+/// values read out of a third.
 ///
 /// Grouped because they always travel together and because which of them is
 /// required depends on the subsections being written, which is easier to say
 /// about one value than about three parameters.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Inputs<'a> {
     pub decay: &'a [Material],
     pub fpy: &'a [Material],
-    pub neutron: &'a [Material],
+    /// The neutron set as Q values rather than as evaluations, because that is
+    /// all a chain reads of it and because a caller whose neutron sublibrary
+    /// does not fit in memory can fill the map one file at a time.
+    /// [`convert_transmutation_files`] does exactly that.
+    pub q_values: &'a QValues,
     /// Decay evaluations from a second library, read only to replace the
     /// placeholder average decay energies in `decay` (see
     /// `endf::chain::Chain::fill_placeholder_decay_energies`). Empty for no
@@ -546,14 +551,14 @@ pub fn convert_transmutation(
     out: &Path,
     provenance: &Provenance,
 ) -> Result<Chain, Box<dyn Error>> {
-    let (decay, fpy, neutron) = (inputs.decay, inputs.fpy, inputs.neutron);
+    let (decay, fpy, q_values) = (inputs.decay, inputs.fpy, inputs.q_values);
     let Provenance {
         library,
         decay_library,
         data_version,
         created_utc,
     } = provenance;
-    let mut chain = Chain::from_endf(decay, fpy, neutron, reactions)?;
+    let mut chain = Chain::from_endf(decay, fpy, q_values, reactions)?;
     if let Some(path) = branch_ratios {
         apply_branch_ratios(&mut chain, path)?;
     }
@@ -772,8 +777,19 @@ pub fn convert_transmutation_files(
     }
     let decay = read(decay_files)?;
     let fpy = read(fpy_files)?;
-    let neutron = read(neutron_files)?;
     let decay_fill = read(decay_fill_files)?;
+
+    // Read one at a time and dropped, rather than collected like the others. A
+    // chain wants nothing from a neutron evaluation but its channels' Q values,
+    // and holding the parsed set to get them peaked at 39 GB over TENDL's 2848
+    // files, which is more than an ordinary machine has: it was killed three
+    // times on a 45 GB one (issue #53). Streamed, the peak is one evaluation,
+    // and the largest single TENDL file is 40 MB.
+    let mut q_values = QValues::new();
+    for path in neutron_files {
+        let material = Material::from_file(path).map_err(|e| format!("{path}: {e}"))?;
+        collect_q_values(&material, &mut q_values);
+    }
 
     // Every reaction the chain builder knows, not endf::chain::DEFAULT_REACTIONS.
     // That short list is six names, and defaulting to it silently drops 2554 of
@@ -813,7 +829,7 @@ pub fn convert_transmutation_files(
         &Inputs {
             decay: &decay,
             fpy: &fpy,
-            neutron: &neutron,
+            q_values: &q_values,
             decay_fill: &decay_fill,
             decay_fill_library,
         },

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -898,10 +898,34 @@ pub fn convert_branching_files(
     // because the driver scopes the call to the parents of a reactions
     // subsection, a few hundred rather than a few thousand evaluations, which
     // is a convention rather than a promise.
-    let mut extractor = branching::BranchingExtractor::new(&decay, tol_ev, linearize_tol);
-    for path in neutron_files {
+    //
+    // In parallel, one evaluation at a time per worker, absorbed afterwards in
+    // file order. Each evaluation's rows depend on nothing but that evaluation
+    // and the isomer table, and absorbing in order leaves the rows, the flagged
+    // levels and the partial-sum lines exactly as reading the files one at a
+    // time left them.
+    let extractor = branching::BranchingExtractor::new(&decay, tol_ev, linearize_tol);
+    let extract = |path: &String| -> Result<branching::BranchingPartial, String> {
         let material = Material::from_file(path).map_err(|e| format!("{path}: {e}"))?;
-        extractor.add(&material);
+        Ok(extractor.extract_one(&material))
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let partials: Vec<branching::BranchingPartial> = {
+        use rayon::prelude::*;
+        neutron_files
+            .par_iter()
+            .map(extract)
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    #[cfg(target_arch = "wasm32")]
+    let partials: Vec<branching::BranchingPartial> = neutron_files
+        .iter()
+        .map(extract)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut extractor = extractor;
+    for partial in partials {
+        extractor.absorb(partial);
     }
     let (rows, stats) = extractor.finish();
     let dir = out.join("branching");

--- a/crates/yani-convert/tests/decay_fill.rs
+++ b/crates/yani-convert/tests/decay_fill.rs
@@ -40,7 +40,7 @@ fn convert(name: &str, fill: &[Material]) -> (std::path::PathBuf, serde_json::Va
         &yani_convert::Inputs {
             decay: &decay,
             fpy: &[],
-            neutron: &[],
+            q_values: &endf::chain::QValues::new(),
             decay_fill: fill,
             decay_fill_library: if fill.is_empty() { "" } else { "jendl-5.0" },
         },

--- a/crates/yani-convert/tests/decay_inconsistencies.rs
+++ b/crates/yani-convert/tests/decay_inconsistencies.rs
@@ -36,7 +36,7 @@ fn inconsistent_records_are_listed_by_kind() {
         &yani_convert::Inputs {
             decay: &decay,
             fpy: &[],
-            neutron: &[],
+            q_values: &endf::chain::QValues::new(),
             decay_fill: &[],
             decay_fill_library: "",
         },

--- a/crates/yani-convert/tests/round_trip.rs
+++ b/crates/yani-convert/tests/round_trip.rs
@@ -77,7 +77,8 @@ fn convert(name: &str) -> Converted {
     let fpy = materials(FPY);
     let neutron = materials(NEUTRON);
 
-    let chain = Chain::from_endf(&decay, &fpy, &neutron, &endf::chain::DEFAULT_REACTIONS)
+    let q_values = endf::chain::q_values(&neutron);
+    let chain = Chain::from_endf(&decay, &fpy, &q_values, &endf::chain::DEFAULT_REACTIONS)
         .expect("chain builds from the fixtures");
     let sources = yani_convert::decay_sources(&decay).expect("decay sources read");
 
@@ -229,11 +230,12 @@ fn convert_transmutation_writes_a_complete_directory() {
     let dir = std::env::temp_dir().join(format!("yani-convert-full-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
 
+    let q_values = endf::chain::q_values(&neutron);
     let chain = yani_convert::convert_transmutation(
         &yani_convert::Inputs {
             decay: &decay,
             fpy: &fpy,
-            neutron: &neutron,
+            q_values: &q_values,
             decay_fill: &[],
             decay_fill_library: "",
         },
@@ -302,7 +304,7 @@ fn convert_transmutation_writes_a_complete_directory() {
         &yani_convert::Inputs {
             decay: &decay,
             fpy: &fpy,
-            neutron: &neutron,
+            q_values: &q_values,
             decay_fill: &[],
             decay_fill_library: "",
         },
@@ -607,6 +609,121 @@ fn a_single_subsection_can_be_written_without_the_other_inputs() {
         .map(String::as_str)
         .collect();
     assert_eq!(listed, vec!["reactions"], "manifest lists {listed:?}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Streaming the neutron files writes exactly what holding them all wrote.
+///
+/// [`yani_convert::convert_transmutation_files`] reads each neutron evaluation,
+/// takes its channels' Q values and drops it, so that a sublibrary far larger
+/// than memory can be converted: TENDL's 2848 files parse to about 39 GB held
+/// all at once, which was killed three times on a 45 GB machine (issue #53).
+/// That is only a safe trade if the result is unchanged, so this drives the
+/// same fixtures down both routes and compares the trees byte for byte.
+#[test]
+fn streaming_the_neutron_files_writes_the_same_tree_as_holding_them() {
+    let dir = std::env::temp_dir().join(format!("yani-convert-stream-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch directory");
+
+    let write = |blobs: &[&[u8]], stem: &str| -> Vec<String> {
+        blobs
+            .iter()
+            .enumerate()
+            .map(|(i, b)| {
+                let p = dir.join(format!("{stem}{i}.endf"));
+                std::fs::write(&p, text(b)).expect("write fixture");
+                p.to_string_lossy().into_owned()
+            })
+            .collect()
+    };
+    let decay_files = write(DECAY, "d");
+    let fpy_files = write(FPY, "f");
+    let neutron_files = write(NEUTRON, "n");
+
+    // Named explicitly rather than left to default, because the two entry
+    // points default differently: the files route takes every reaction the
+    // chain builder knows, and the in-memory route takes what it is given.
+    let reactions: Vec<String> = endf::chain::DEFAULT_REACTIONS
+        .iter()
+        .map(|r| r.to_string())
+        .collect();
+    let subsections: Vec<String> = ["decay", "reactions", "fission_yields"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let streamed = dir.join("streamed");
+    yani_convert::convert_transmutation_files(
+        &decay_files,
+        &fpy_files,
+        &neutron_files,
+        &[],
+        "",
+        Some(&reactions),
+        None,
+        Some(&subsections),
+        &streamed,
+        &provenance(),
+    )
+    .expect("streamed conversion succeeds");
+
+    let held = dir.join("held");
+    let decay = materials(DECAY);
+    let fpy = materials(FPY);
+    let neutron = materials(NEUTRON);
+    let q_values = endf::chain::q_values(&neutron);
+    yani_convert::convert_transmutation(
+        &yani_convert::Inputs {
+            decay: &decay,
+            fpy: &fpy,
+            q_values: &q_values,
+            decay_fill: &[],
+            decay_fill_library: "",
+        },
+        &endf::chain::DEFAULT_REACTIONS,
+        None,
+        &["decay", "reactions", "fission_yields"],
+        &held,
+        &provenance(),
+    )
+    .expect("in-memory conversion succeeds");
+
+    let files = |root: &std::path::Path| -> Vec<String> {
+        let mut out = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            for entry in std::fs::read_dir(&d).expect("read output directory") {
+                let path = entry.expect("directory entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else {
+                    let rel = path.strip_prefix(root).expect("under root");
+                    out.push(rel.to_string_lossy().into_owned());
+                }
+            }
+        }
+        out.sort();
+        out
+    };
+
+    let written = files(&streamed);
+    assert_eq!(
+        written,
+        files(&held),
+        "the two routes wrote different sets of files"
+    );
+    assert!(
+        written.len() >= 6,
+        "only {} files written, too few to prove anything: {written:?}",
+        written.len()
+    );
+    for rel in &written {
+        let a = std::fs::read(streamed.join(rel)).expect("streamed file");
+        let b = std::fs::read(held.join(rel)).expect("held file");
+        assert_eq!(a, b, "{rel} differs between the streamed and held routes");
+    }
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/yani-convert/tests/round_trip.rs
+++ b/crates/yani-convert/tests/round_trip.rs
@@ -727,3 +727,42 @@ fn streaming_the_neutron_files_writes_the_same_tree_as_holding_them() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Extracting evaluations one at a time and absorbing them in file order gives
+/// exactly what adding them one at a time gives.
+///
+/// That equivalence is what lets `convert_branching_files` parse in parallel.
+/// The rows, the flagged levels and the partial-sum lines are all ordered, and
+/// the counters are sums, so a merge that lost the order or forgot a statistic
+/// would change the written subsection without changing anything else.
+#[test]
+fn absorbing_partials_in_file_order_matches_adding_one_at_a_time() {
+    use yani_convert::branching::{BranchingExtractor, DEFAULT_LINEARIZE_TOL};
+
+    let decay = materials(DECAY);
+    let neutron = materials(NEUTRON);
+    let build = || BranchingExtractor::new(&decay, 3000.0, DEFAULT_LINEARIZE_TOL);
+
+    let mut sequential = build();
+    for material in &neutron {
+        sequential.add(material);
+    }
+
+    // What the parallel driver does: every evaluation worked out against the
+    // same isomer table, then merged in the order the files were read.
+    let base = build();
+    let partials: Vec<_> = neutron.iter().map(|m| base.extract_one(m)).collect();
+    let mut merged = base;
+    for partial in partials {
+        merged.absorb(partial);
+    }
+
+    let (rows_one_at_a_time, stats_one_at_a_time) = sequential.finish();
+    let (rows_merged, stats_merged) = merged.finish();
+    assert!(
+        !rows_one_at_a_time.is_empty(),
+        "the fixtures produced no branching rows, so this proves nothing"
+    );
+    assert_eq!(rows_merged, rows_one_at_a_time);
+    assert_eq!(stats_merged, stats_one_at_a_time);
+}


### PR DESCRIPTION
Fixes #53.

Three commits: the reactions path stops holding the neutron sublibrary, the branching path stops holding it too, and what is left, the parsing, runs in parallel.

## The change

`Chain::from_endf` took the neutron sublibrary as `&[Material]` and used it in one place, the loop recording each channel's QI. Every caller therefore held the whole parsed set to hand it over: for TENDL that is 2848 evaluations and 13 GB of ENDF text, about 39 GB resident, to harvest a few hundred KB of scalars. It now takes a `QValues` map that a caller fills one file at a time.

`convert_branching_files` had the same shape. It gets away with it today only because the driver scopes the call to the parents of an existing reactions subsection, a few hundred evaluations rather than a few thousand, which is a convention of the driver rather than anything the function promised. The per-evaluation work moved into `BranchingExtractor`, fed one file at a time.

With nothing held, parsing is the entire cost, so it is now one map per file across a rayon pool, merged in file order.

## Measured

TENDL-2017's 2813 neutron evaluations with the ENDF/B-8.1 decay (3821) and nfy (31) sublibraries, writing the reactions subsection:

| | peak RSS | wall |
|---|---|---|
| before | 38.9 to 39.1 GB | killed at ~4.5 min, three times |
| streamed | 342,824 kB | 38.0 s |
| streamed and parallel | 1,373,264 kB | **3.3 s** |

Where the time went, per phase, on one core:

```
neutron parse and Q values   41.0 s      (2.7 s across 32 cores)
decay parse, 3821 files       0.2 s
chain build, 3820 nuclides    0.1 s
write reactions               0.0 s
```

So the parse was all of it, and the peak rises to 1.31 GiB because 32 evaluations are in flight rather than one. User time roughly doubles, 39 s to 82 s, on allocator contention.

The branching pass, run **unscoped over all 2813 evaluations**, which is the call that could not be made on this machine before:

```
peak RSS 317,400 kB, wall 41.6 s, 2813 parents, 2338 with data
```

The "before" numbers are the kernel's: this step was OOM-killed on 2026-09-04 at 39.1, 38.9 and 39.0 GB, each time at the end of a 25 to 33 hour library build, and the run that completed on 2026-09-05 survived only because 32 GB of swap had been added 40 minutes earlier.

## Verified

The `reactions.arrow` written by both the streamed and the streamed-and-parallel paths is byte-identical (md5 `d4e7549a88be8476b1cfa3cab898b02d`) to the one the old code wrote on 2026-09-05 over the same 2813 evaluations. That includes the ordered merge choosing the same winner where two evaluations name one nuclide.

* the chain goldens pass unchanged, which is what pins the values;
* a new round-trip test drives one fixture set down both `convert_transmutation_files` and `convert_transmutation`, then asserts the two output trees hold the same files with the same bytes;
* the existing branching tests, row content, level routes, flagged levels and manifest merge, cover the extractor refactor: rows and statistics accumulate in the same file order as before;
* `cargo test -p endf -p yani-convert`, `cargo fmt --check --all` and `cargo clippy --lib --tests -- -D warnings` are clean.

## API changes

Pre-1.0, so clean renames with the callers updated rather than shimmed:

* `Chain::from_endf(decay, fpy, neutron: &[Material], reactions)` becomes `from_endf(decay, fpy, q_values: &QValues, reactions)`.
* `yani_convert::Inputs::neutron` becomes `Inputs::q_values`, and `Inputs` loses its `Default` derive, since a reference to a map has none. Nothing constructed it that way.
* New in `endf::chain`, re-exported at the crate root beside `Chain`: `QValues`, `collect_q_values` for the one-at-a-time case, `q_values` for a caller holding a slice.
* New in `yani_convert::branching`: `BranchingExtractor`. `extract_branching` keeps its signature and is now implemented in terms of it.
* rayon is a target-gated dependency, as in `yani-transmute` and for the same reason: no thread pool on wasm32. Only the driver line is `cfg`-ed, so the two forms cannot drift.

The Python entry points are unaffected: both go through the paths-based functions.

## Follow-up

The branching parse is still sequential, and its 41.6 s is the same parse-bound shape the reactions path had, so it would take the same 15x. It needs an ordered reduction rather than a merge, because its rows, `flagged_levels` and counters accumulate in file order, so it is left for its own change.
