### PR TITLE
Order isomeric branching by production, not by rate

### DIFF
--- a/crates/yani-python/src/transmutation_results.rs
+++ b/crates/yani-python/src/transmutation_results.rs
@@ -782,38 +782,51 @@ impl PyTransmutationResults {
     /// section or to a branching ratio, which are different data and different
     /// fixes.
     ///
+    /// Channels come back ordered by production, the channel's rate times its
+    /// parent's atom density at the start of the step. A rate on its own is per
+    /// atom of the parent, so ordering on it promotes whatever sits on a trace
+    /// isotope: on an FNS tungsten foil ``W180(n,2n)`` has the highest per-atom
+    /// rate of any channel in the foil, and W180 is 0.12% of it, so by what it
+    /// made the channel falls to fifth, two orders of magnitude below the
+    /// ``W186(n,2n)`` carrying most of that foil's decay heat.
+    ///
     /// Args:
     ///     material_id: Material ID number.
     ///     step: Schedule step index, the same index ``get_reaction_rates``
     ///         takes, which is one less than the composition getters' step.
     ///
     /// Returns:
-    ///     dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
-    ///     reaction kind -> [(target, fraction)], fractions summing to one and
-    ///     ordered with the largest first. Empty for a decay-only step, and
-    ///     None if the material or the step is unknown.
+    ///     list[dict] | None: one entry per splitting channel, most produced
+    ///     first, each with ``parent``, ``reaction``, ``production`` and
+    ///     ``split``. ``split`` is [(target, fraction)] summing to one and
+    ///     ordered with the largest share first. Empty for a decay-only step,
+    ///     and None if the material or the step is unknown. A parent absent
+    ///     from the step's starting composition has production 0.0 and sorts
+    ///     last rather than being dropped.
     ///
     /// Examples:
-    ///     >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
-    ///     {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+    ///     >>> results.get_isomeric_branching(material_id=1, step=0)[0]
+    ///     {'parent': 'W186', 'reaction': '(n,2n)', 'production': 9.35e-14,
+    ///      'split': [('W185_m1', 0.535), ('W185', 0.465)]}
     fn get_isomeric_branching(
         &self,
         py: Python<'_>,
         material_id: u32,
         step: usize,
     ) -> Option<Py<PyAny>> {
-        let split = self.inner.get_isomeric_branching(material_id, step)?;
-        let out = PyDict::new(py);
-        for (parent, kinds) in &split {
-            let per_kind = PyDict::new(py);
-            for (kind, targets) in kinds {
-                let list = PyList::empty(py);
-                for (target, fraction) in targets {
-                    list.append((target.as_str(), fraction)).unwrap();
-                }
-                per_kind.set_item(kind.as_str(), list).unwrap();
+        let channels = self.inner.get_isomeric_branching(material_id, step)?;
+        let out = PyList::empty(py);
+        for channel in &channels {
+            let row = PyDict::new(py);
+            row.set_item("parent", channel.parent.as_str()).unwrap();
+            row.set_item("reaction", channel.reaction.as_str()).unwrap();
+            row.set_item("production", channel.production).unwrap();
+            let split = PyList::empty(py);
+            for (target, fraction) in &channel.split {
+                split.append((target.as_str(), fraction)).unwrap();
             }
-            out.set_item(parent.as_str(), per_kind).unwrap();
+            row.set_item("split", split).unwrap();
+            out.append(row).unwrap();
         }
         Some(out.into_any().unbind())
     }

--- a/crates/yani-transmute/src/results.rs
+++ b/crates/yani-transmute/src/results.rs
@@ -116,12 +116,32 @@ pub struct RateSpectrum {
     pub rates: Vec<f64>,
 }
 
-/// Flux-weighted isomeric branching: `parent -> kind -> [(target, fraction)]`.
+/// One channel that lands in more than one final state, and how much of it the
+/// material made.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IsomericChannel {
+    /// The nuclide the reaction happened on.
+    pub parent: String,
+    /// The reaction kind, `"(n,2n)"` and the like.
+    pub reaction: String,
+    /// `(target, fraction)`, summing to one, largest share first.
+    pub split: Vec<(String, f64)>,
+    /// The channel's rate times the parent's atom density at the start of the
+    /// step: what this channel actually made, in the material's own units.
+    ///
+    /// The rate alone is per atom of the parent, so it says nothing about how
+    /// much of the parent there is. Ranking on it promotes whatever sits on a
+    /// trace isotope.
+    pub production: f64,
+}
+
+/// Flux-weighted isomeric branching for one material over one step, ordered by
+/// production.
 ///
-/// Named for the same reason [`yani::EdgeRates`] is: it is three levels deep
-/// and appears in a signature, a return and a binding, and spelling it out
-/// three times is three chances to spell it differently.
-pub type IsomericBranching = HashMap<String, HashMap<String, Vec<(String, f64)>>>;
+/// Named for the same reason [`yani::EdgeRates`] is: it appears in a signature,
+/// a return and a binding, and spelling it out three times is three chances to
+/// spell it differently.
+pub type IsomericBranching = Vec<IsomericChannel>;
 
 /// One way a product is made: the steps, and the share of it arriving this way.
 #[derive(Debug, Clone, PartialEq)]
@@ -310,6 +330,19 @@ impl TransmutationResults {
     /// at 1.0 buries the ones that do. [`Self::get_reaction_rates`] has the
     /// unnormalised edges if the rest is wanted.
     ///
+    /// Ordered by production, the channel's rate times its parent's atom
+    /// density at the start of the step, largest first. Rate alone is per atom
+    /// of the parent and ranking on it promotes whatever sits on a trace
+    /// isotope: on an FNS tungsten foil `W180(n,2n)` has the highest per-atom
+    /// rate of any channel in the foil and W180 is 0.12% of it, so weighted by
+    /// what it made the channel falls to fifth, two orders of magnitude below
+    /// the `W186(n,2n)` that carries most of that foil's decay heat. This is
+    /// the same trap `rate_fraction_covered_total` was fixed for.
+    ///
+    /// A parent absent from the step's starting composition has production
+    /// zero, so it sorts last rather than being dropped: its split is still
+    /// the honest answer for the reactions that did happen on it.
+    ///
     /// This is what says whether a disagreement belongs to a cross section or
     /// to a branching ratio, which are different data and different fixes.
     ///
@@ -322,7 +355,14 @@ impl TransmutationResults {
         step: usize,
     ) -> Option<IsomericBranching> {
         let edges = self.get_reaction_rates(material_id, step)?;
-        let mut out: IsomericBranching = HashMap::new();
+        // The composition the rates were driven against: step `s` of the
+        // schedule runs from composition `s`, which is why this is not
+        // `step + 1`.
+        let densities = self
+            .get_material(material_id, step)
+            .map(|m| m.get_atoms_per_barn_cm().unwrap_or_default())
+            .unwrap_or_default();
+        let mut out: IsomericBranching = Vec::new();
         for (parent, kinds) in edges {
             for (kind, targets) in kinds {
                 // A channel naming no single product (fission) has no split to
@@ -349,11 +389,23 @@ impl TransmutationResults {
                         .unwrap_or(std::cmp::Ordering::Equal)
                         .then_with(|| a.0.cmp(&b.0))
                 });
-                out.entry(parent.clone())
-                    .or_default()
-                    .insert(kind.clone(), split);
+                out.push(IsomericChannel {
+                    parent: parent.clone(),
+                    reaction: kind.clone(),
+                    split,
+                    production: total * densities.get(parent).copied().unwrap_or(0.0),
+                });
             }
         }
+        // Most produced first; ties by parent then reaction, so the order is
+        // stable run to run and does not depend on the edge map's walk.
+        out.sort_by(|a, b| {
+            b.production
+                .partial_cmp(&a.production)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.parent.cmp(&b.parent))
+                .then_with(|| a.reaction.cmp(&b.reaction))
+        });
         Some(out)
     }
 
@@ -821,16 +873,84 @@ mod tests {
         results.add_step(7, material("after"));
 
         let split = results.get_isomeric_branching(7, 0).expect("step 0");
-        let w186 = &split["W186"];
         assert!(
-            !w186.contains_key("(n,gamma)"),
+            !split.iter().any(|c| c.reaction == "(n,gamma)"),
             "a channel with one product has no branching to report"
         );
+        let w186 = split
+            .iter()
+            .find(|c| c.parent == "W186" && c.reaction == "(n,2n)")
+            .expect("the channel that splits");
         // Largest share first, so the state the channel mostly makes leads.
-        assert_eq!(w186["(n,2n)"][0].0, "W185");
-        assert!((w186["(n,2n)"][0].1 - 0.75).abs() < 1e-12);
-        assert_eq!(w186["(n,2n)"][1].0, "W185_m1");
-        assert!((w186["(n,2n)"][1].1 - 0.25).abs() < 1e-12);
+        assert_eq!(w186.split[0].0, "W185");
+        assert!((w186.split[0].1 - 0.75).abs() < 1e-12);
+        assert_eq!(w186.split[1].0, "W185_m1");
+        assert!((w186.split[1].1 - 0.25).abs() < 1e-12);
+    }
+
+    /// A foil that is almost all W186 with a trace of W180, the abundances that
+    /// make the ordering below mean something.
+    fn tungsten_foil() -> Material {
+        let mut m = Material::new(
+            HashMap::from([("W186".to_string(), 0.9988), ("W180".to_string(), 0.0012)]),
+            "atom",
+            "g/cm3",
+            Some(19.3),
+        )
+        .expect("build a material");
+        m.name = Some("foil".to_string());
+        m
+    }
+
+    /// Channels come back ordered by what they made, not by their rate.
+    ///
+    /// A rate is per atom of its parent, so ranking on it promotes whatever
+    /// sits on a trace isotope: on the FNS tungsten foil `W180(n,2n)` has the
+    /// highest per-atom rate in the foil and W180 is 0.12% of it (issue #6).
+    #[test]
+    fn isomeric_branching_orders_by_production_not_by_rate() {
+        let mut results = TransmutationResults::new(vec![1.0], vec![1.0e14]);
+        results.add_initial(7, tungsten_foil());
+
+        let mut irradiation = EdgeRates::new();
+        // The higher rate, on the isotope there is almost none of.
+        irradiation.insert(
+            "W180".to_string(),
+            HashMap::from([(
+                "(n,2n)".to_string(),
+                vec![
+                    (Some("W179".to_string()), 4.0e-12),
+                    (Some("W179_m1".to_string()), 2.0e-12),
+                ],
+            )]),
+        );
+        // The lower rate, on almost all of the foil.
+        irradiation.insert(
+            "W186".to_string(),
+            HashMap::from([(
+                "(n,2n)".to_string(),
+                vec![
+                    (Some("W185".to_string()), 3.0e-12),
+                    (Some("W185_m1".to_string()), 1.0e-12),
+                ],
+            )]),
+        );
+        results.add_step_rates(7, irradiation);
+        results.add_step(7, tungsten_foil());
+
+        let split = results.get_isomeric_branching(7, 0).expect("step 0");
+        let order: Vec<&str> = split.iter().map(|c| c.parent.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["W186", "W180"],
+            "ordered on rate alone this comes back W180 first, on 0.12% of the foil"
+        );
+        assert!(
+            split[0].production > 100.0 * split[1].production,
+            "W186 made {} against W180's {}",
+            split[0].production,
+            split[1].production
+        );
     }
 
     /// A decay-only step splits nothing, and says so rather than being absent.

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -4897,20 +4897,32 @@ class TransmutationResults:
         section or to a branching ratio, which are different data and different
         fixes.
         
+        Channels come back ordered by production, the channel's rate times its
+        parent's atom density at the start of the step. A rate on its own is per
+        atom of the parent, so ordering on it promotes whatever sits on a trace
+        isotope: on an FNS tungsten foil ``W180(n,2n)`` has the highest per-atom
+        rate of any channel in the foil, and W180 is 0.12% of it, so by what it
+        made the channel falls to fifth, two orders of magnitude below the
+        ``W186(n,2n)`` carrying most of that foil's decay heat.
+        
         Args:
             material_id: Material ID number.
             step: Schedule step index, the same index ``get_reaction_rates``
                 takes, which is one less than the composition getters' step.
         
         Returns:
-            dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
-            reaction kind -> [(target, fraction)], fractions summing to one and
-            ordered with the largest first. Empty for a decay-only step, and
-            None if the material or the step is unknown.
+            list[dict] | None: one entry per splitting channel, most produced
+            first, each with ``parent``, ``reaction``, ``production`` and
+            ``split``. ``split`` is [(target, fraction)] summing to one and
+            ordered with the largest share first. Empty for a decay-only step,
+            and None if the material or the step is unknown. A parent absent
+            from the step's starting composition has production 0.0 and sorts
+            last rather than being dropped.
         
         Examples:
-            >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
-            {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+            >>> results.get_isomeric_branching(material_id=1, step=0)[0]
+            {'parent': 'W186', 'reaction': '(n,2n)', 'production': 9.35e-14,
+             'split': [('W185_m1', 0.535), ('W185', 0.465)]}
         """
     def get_production_routes(self, material_id: builtins.int, product: builtins.str, step: builtins.int, reaction_depth: builtins.int = 1, decay_depth: builtins.int = 3) -> typing.Optional[typing.Any]:
         r"""

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -2297,20 +2297,32 @@ class TransmutationResults:
         section or to a branching ratio, which are different data and different
         fixes.
         
+        Channels come back ordered by production, the channel's rate times its
+        parent's atom density at the start of the step. A rate on its own is per
+        atom of the parent, so ordering on it promotes whatever sits on a trace
+        isotope: on an FNS tungsten foil ``W180(n,2n)`` has the highest per-atom
+        rate of any channel in the foil, and W180 is 0.12% of it, so by what it
+        made the channel falls to fifth, two orders of magnitude below the
+        ``W186(n,2n)`` carrying most of that foil's decay heat.
+        
         Args:
             material_id: Material ID number.
             step: Schedule step index, the same index ``get_reaction_rates``
                 takes, which is one less than the composition getters' step.
         
         Returns:
-            dict[str, dict[str, list[tuple[str, float]]]] | None: parent ->
-            reaction kind -> [(target, fraction)], fractions summing to one and
-            ordered with the largest first. Empty for a decay-only step, and
-            None if the material or the step is unknown.
+            list[dict] | None: one entry per splitting channel, most produced
+            first, each with ``parent``, ``reaction``, ``production`` and
+            ``split``. ``split`` is [(target, fraction)] summing to one and
+            ordered with the largest share first. Empty for a decay-only step,
+            and None if the material or the step is unknown. A parent absent
+            from the step's starting composition has production 0.0 and sorts
+            last rather than being dropped.
         
         Examples:
-            >>> results.get_isomeric_branching(material_id=1, step=0)["W186"]
-            {'(n,2n)': [('W185_m1', 0.535), ('W185', 0.465)]}
+            >>> results.get_isomeric_branching(material_id=1, step=0)[0]
+            {'parent': 'W186', 'reaction': '(n,2n)', 'production': 9.35e-14,
+             'split': [('W185_m1', 0.535), ('W185', 0.465)]}
         """
     def get_production_routes(self, material_id: builtins.int, product: builtins.str, step: builtins.int, reaction_depth: builtins.int = 1, decay_depth: builtins.int = 3) -> typing.Optional[typing.Any]:
         r"""


### PR DESCRIPTION
Fixes #6.

`get_isomeric_branching` returned `parent -> kind -> [(target, fraction)]` in nested hash maps, so the channels came back in no order and a consumer ranking them had to pick one. The obvious pick is wrong: an edge rate is per atom of its parent, so ranking on rate promotes whatever sits on a trace isotope.

The issue's measurement, FNS tungsten foil on TENDL-2025:

| ordered by rate | abundance | | ordered by production | abundance |
|---|---|---|---|---|
| **W180 (n,2n)** 5.95e-12 | **0.12%** | | W184 (n,2n) 1.06e-13 | 30.64% |
| W184 (n,2n) 5.48e-12 | 30.64% | | W186 (n,2n) 9.35e-14 | 28.43% |
| W186 (n,2n) 5.20e-12 | 28.43% | | W182 (n,gamma) 3.74e-15 | 26.50% |

W180 has the highest per-atom rate in the foil and there is almost none of it, so a table ordered on rate leads with a channel contributing essentially nothing, above the `W186(n,2n)` that carries most of that foil's decay heat.

## What changed

The return is a flat list of channels ordered by production, rate times the parent's atom density at the start of the step, each carrying that production beside its split:

```rust
pub struct IsomericChannel {
    pub parent: String,
    pub reaction: String,
    pub split: Vec<(String, f64)>,   // (target, fraction), largest share first
    pub production: f64,
}
pub type IsomericBranching = Vec<IsomericChannel>;
```

Flat rather than an ordered map on purpose. The issue notes that a consumer's correction is currently 51 lines across three functions, most of it multiplying by density and re-sorting; returning the production removes both halves rather than only the ordering half.

The density comes from the composition the rates were driven against, `get_material(material_id, step)`, which is the step's own starting composition and not `step + 1`. A parent absent from it has production 0.0 and sorts last rather than being dropped: its split is still the honest answer for whatever did react.

Ties break on parent then reaction, so the order is stable run to run and does not depend on a hash map's walk.

## Python

```python
>>> results.get_isomeric_branching(material_id=1, step=0)[0]
{'parent': 'W186', 'reaction': '(n,2n)', 'production': 9.35e-14,
 'split': [('W185_m1', 0.535), ('W185', 0.465)]}
```

A list of dicts in place of the nested dict. Stubs regenerated for both packages; the only stub diff is this docstring.

## Tests

`isomeric_branching_normalises_splits_and_omits_single_product_channels` keeps its assertions through the new shape. A new `isomeric_branching_orders_by_production_not_by_rate` builds a foil that is 99.88% W186 and 0.12% W180, gives W180 the higher per-atom rate, and asserts the order comes back W186 first with more than 100x the production. On the old ordering that test would read W180 first.

`cargo test -p yani-transmute` passes, `cargo fmt --check --all` and `cargo clippy --lib --tests -- -D warnings` are clean.