### PR TITLE
Parse the branching evaluations in parallel too

### DIFF
--- a/crates/yani-convert/src/branching.rs
+++ b/crates/yani-convert/src/branching.rs
@@ -446,6 +446,20 @@ pub struct BranchingExtractor {
     metastable: std::collections::BTreeSet<String>,
 }
 
+/// What one evaluation contributed, before it is merged into an extractor.
+///
+/// Exists so the per-evaluation work, which is independent of every other
+/// evaluation's, can run off to the side and be merged back afterwards. Merging
+/// in the order the files were read leaves the result identical to reading them
+/// one at a time, which matters because the rows, the flagged levels and the
+/// partial-sum lines are all ordered.
+#[derive(Debug, Clone, Default)]
+pub struct BranchingPartial {
+    rows: Vec<BranchingRow>,
+    stats: BranchingStats,
+    metastable: std::collections::BTreeSet<String>,
+}
+
 impl BranchingExtractor {
     /// `decay` is read only for the isomer table, so metastable evaluations
     /// suffice.
@@ -463,19 +477,28 @@ impl BranchingExtractor {
 
     /// Add one neutron evaluation's rows.
     pub fn add(&mut self, material: &Material) {
+        let partial = self.extract_one(material);
+        self.absorb(partial);
+    }
+
+    /// One evaluation's contribution, worked out without touching the
+    /// accumulator, so callers can do this for many evaluations at once and
+    /// [`Self::absorb`] the results in file order afterwards.
+    pub fn extract_one(&self, material: &Material) -> BranchingPartial {
         let (mt2type, isomers, tol_ev, linearize_tol) = (
             &self.mt2type,
             &self.isomers,
             self.tol_ev,
             self.linearize_tol,
         );
-        let (rows, stats, metastable) = (&mut self.rows, &mut self.stats, &mut self.metastable);
+        let mut out = BranchingPartial::default();
+        let (rows, stats, metastable) = (&mut out.rows, &mut out.stats, &mut out.metastable);
 
         // The evaluation names itself in MF=1/451, which is the same route
         // Chain::from_endf takes, so parent names match the reactions
         // subsection rather than a filename convention.
         let Some(meta) = material.mf1_mt451() else {
-            return;
+            return out;
         };
         let parent = endf::gnds_name(
             (meta.za / 1000) as u32,
@@ -561,6 +584,29 @@ impl BranchingExtractor {
         if emitted_any {
             stats.parents_with_data += 1;
         }
+        out
+    }
+
+    /// Merge one evaluation's contribution.
+    ///
+    /// Call order is the row order, so a caller that extracted out of order
+    /// must absorb in the order the files were read to get the same answer.
+    /// `merged_duplicate_groups` and `metastable_targets` are not merged here
+    /// because [`Self::finish`] is what sets them.
+    pub fn absorb(&mut self, partial: BranchingPartial) {
+        self.rows.extend(partial.rows);
+        self.metastable.extend(partial.metastable);
+        let stats = partial.stats;
+        self.stats.parents += stats.parents;
+        self.stats.parents_with_data += stats.parents_with_data;
+        self.stats.linearized_curves += stats.linearized_curves;
+        for (route, n) in stats.level_routes {
+            *self.stats.level_routes.entry(route).or_insert(0) += n;
+        }
+        self.stats.flagged_levels.extend(stats.flagged_levels);
+        self.stats
+            .partial_sum_mismatches
+            .extend(stats.partial_sum_mismatches);
     }
 
     /// The rows and statistics, with duplicate target groups merged.

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -898,10 +898,34 @@ pub fn convert_branching_files(
     // because the driver scopes the call to the parents of a reactions
     // subsection, a few hundred rather than a few thousand evaluations, which
     // is a convention rather than a promise.
-    let mut extractor = branching::BranchingExtractor::new(&decay, tol_ev, linearize_tol);
-    for path in neutron_files {
+    //
+    // In parallel, one evaluation at a time per worker, absorbed afterwards in
+    // file order. Each evaluation's rows depend on nothing but that evaluation
+    // and the isomer table, and absorbing in order leaves the rows, the flagged
+    // levels and the partial-sum lines exactly as reading the files one at a
+    // time left them.
+    let extractor = branching::BranchingExtractor::new(&decay, tol_ev, linearize_tol);
+    let extract = |path: &String| -> Result<branching::BranchingPartial, String> {
         let material = Material::from_file(path).map_err(|e| format!("{path}: {e}"))?;
-        extractor.add(&material);
+        Ok(extractor.extract_one(&material))
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let partials: Vec<branching::BranchingPartial> = {
+        use rayon::prelude::*;
+        neutron_files
+            .par_iter()
+            .map(extract)
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    #[cfg(target_arch = "wasm32")]
+    let partials: Vec<branching::BranchingPartial> = neutron_files
+        .iter()
+        .map(extract)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut extractor = extractor;
+    for partial in partials {
+        extractor.absorb(partial);
     }
     let (rows, stats) = extractor.finish();
     let dir = out.join("branching");

--- a/crates/yani-convert/tests/round_trip.rs
+++ b/crates/yani-convert/tests/round_trip.rs
@@ -727,3 +727,42 @@ fn streaming_the_neutron_files_writes_the_same_tree_as_holding_them() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Extracting evaluations one at a time and absorbing them in file order gives
+/// exactly what adding them one at a time gives.
+///
+/// That equivalence is what lets `convert_branching_files` parse in parallel.
+/// The rows, the flagged levels and the partial-sum lines are all ordered, and
+/// the counters are sums, so a merge that lost the order or forgot a statistic
+/// would change the written subsection without changing anything else.
+#[test]
+fn absorbing_partials_in_file_order_matches_adding_one_at_a_time() {
+    use yani_convert::branching::{BranchingExtractor, DEFAULT_LINEARIZE_TOL};
+
+    let decay = materials(DECAY);
+    let neutron = materials(NEUTRON);
+    let build = || BranchingExtractor::new(&decay, 3000.0, DEFAULT_LINEARIZE_TOL);
+
+    let mut sequential = build();
+    for material in &neutron {
+        sequential.add(material);
+    }
+
+    // What the parallel driver does: every evaluation worked out against the
+    // same isomer table, then merged in the order the files were read.
+    let base = build();
+    let partials: Vec<_> = neutron.iter().map(|m| base.extract_one(m)).collect();
+    let mut merged = base;
+    for partial in partials {
+        merged.absorb(partial);
+    }
+
+    let (rows_one_at_a_time, stats_one_at_a_time) = sequential.finish();
+    let (rows_merged, stats_merged) = merged.finish();
+    assert!(
+        !rows_one_at_a_time.is_empty(),
+        "the fixtures produced no branching rows, so this proves nothing"
+    );
+    assert_eq!(rows_merged, rows_one_at_a_time);
+    assert_eq!(stats_merged, stats_one_at_a_time);
+}


### PR DESCRIPTION
Follow-up to #60, and **based on that branch** rather than on main, since it builds directly on the `BranchingExtractor` introduced there. I'll retarget it to main once #60 lands.

#60 left the branching pass sequential on purpose: its rows, `flagged_levels` and `partial_sum_mismatches` all accumulate in file order, and its counters are sums, so it needed an ordered reduction rather than the map merge the reactions pass could use.

## What changed

`BranchingExtractor` splits into its read-only half (the isomer table and the tolerances) and its accumulating half:

* `extract_one(&self, &Material) -> BranchingPartial` does one evaluation's work against nothing but the isomer table, so it takes `&self` and can run on many threads at once
* `absorb(&mut self, BranchingPartial)` merges one in, in call order
* `add` is those two in sequence, so the existing API is unchanged

The driver extracts across a rayon pool and absorbs in file order, which is what makes the result identical rather than merely equivalent.

## Measured

TENDL-2017's 2813 evaluations against the ENDF/B-8.1 decay sublibrary, both paths in one binary so the comparison is like for like:

| | wall | rows |
|---|---|---|
| sequential | 38.8 s | 41,399 |
| parallel | **2.7 s** | 41,399 |

Rows and statistics compare equal, over all 41,399 rows.

Peak rises from roughly 320 MB, one evaluation at a time, to 1.29 GB with 32 in flight. Same trade the reactions pass made in #60, and still three orders of magnitude below where this started.

## Test

`absorbing_partials_in_file_order_matches_adding_one_at_a_time` extracts the fixtures both ways and compares rows and statistics. It fails if a merge loses the order or forgets a statistic, which is the failure that would otherwise reorder a published subsection silently. The existing branching tests (row content, level routes, flagged levels, manifest merge, partial sums) all still pass.

`cargo fmt --check --all` and `cargo clippy --lib --tests -- -D warnings` are clean.