### PR TITLE
Bump yani-core to 0.15.0 and yamc-core to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "yamc-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "yani-python"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "endf",
  "pyo3",

--- a/crates/yamc-python/Cargo.toml
+++ b/crates/yamc-python/Cargo.toml
@@ -12,7 +12,7 @@ name = "yamc-python"
 # `cargo set-version -p yamc-python <version>`, which updates Cargo.lock in the
 # same step -- and `verify-versions` refuses a number already on PyPI.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for yamc"

--- a/crates/yani-python/Cargo.toml
+++ b/crates/yani-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "yani-python"
 # transport converter says nothing about the inventory package. Bump it with
 # `cargo set-version -p yani-python <version>`.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for the transmutation stack: materials, nuclides, chains, irradiation schedules and inventories. Shared by the yamc and yani wheels."


### PR DESCRIPTION
Both wheels are already on PyPI at their committed numbers (yani-core 0.14.0, yamc-core 0.9.0), so nothing merged since can ship until the versions name the next release.

Minor bumps rather than patch: both wheels gained API and both changed numbers.

**Shared converter surface** (yamc-core re-exports it from `yani-python`):

- `convert_transmutation` takes `decay_fill_files` and `decay_fill_library`; the decay subsection's `provenance.json` gains `decay_energy_placeholders`, `decay_energy_fill` and `decay_inconsistencies`.
- `convert_branching` returns `level_routes`, `flagged_levels` and `partial_sum_mismatches`.
- Isomer excitation energies come from the decay file header (MF=1 MT=451 ELIS) where it states one, so production levels move from the level-index route to the energy route.

**Behaviour change worth a minor bump on its own:** a group flux is folded to zero above an evaluation's last energy point instead of carrying the last value forward, and a spectrum whose flux reaches past that point is refused with an error naming the nuclide. Anyone folding above 20 MeV gets different numbers.

**yamc-core also carries** the energy-resolved reaction rates, the shielded-rate perturbation fix, `gpu` in the default feature set, and VTKHDF writing without numpy.

Not merging this one: releases and tags are yours. The tag for it would be `yani-core-0.15.0,yamc-core-0.10.0`.

Note for ordering: this touches `Cargo.lock`, as does #60, so whichever lands second may need a trivial rebase. The `yani` repo PR that bumps its pin to 0.15.0 cannot go green until yani-core 0.15.0 is on PyPI.