### PR TITLE
Say which final states an evaluation lists for each reaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "yamc-python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "yani-python"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "endf",
  "pyo3",

--- a/crates/yamc-python/Cargo.toml
+++ b/crates/yamc-python/Cargo.toml
@@ -12,7 +12,7 @@ name = "yamc-python"
 # `cargo set-version -p yamc-python <version>`, which updates Cargo.lock in the
 # same step -- and `verify-versions` refuses a number already on PyPI.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for yamc"

--- a/crates/yamc-python/src/lib.rs
+++ b/crates/yamc-python/src/lib.rs
@@ -141,6 +141,10 @@ fn _core(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(
+        yani_python::convert::radionuclide_production,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
         yani_python::convert::convert_neutron_xs,
         m
     )?)?;

--- a/crates/yani-convert/src/branching.rs
+++ b/crates/yani-convert/src/branching.rs
@@ -260,7 +260,7 @@ pub fn merge_duplicates(rows: Vec<BranchingRow>) -> (Vec<BranchingRow>, usize) {
 /// Built from the chain's own reaction set so the names match the reactions
 /// subsection exactly, plus MT 4 for inelastic isomeric transitions, which the
 /// chain's set omits because it produces no new nuclide.
-fn mt_to_type() -> BTreeMap<i64, String> {
+pub(crate) fn mt_to_type() -> BTreeMap<i64, String> {
     let mut map: BTreeMap<i64, String> = BTreeMap::new();
     for info in endf::chain::REACTIONS.iter() {
         for &mt in info.mts.iter() {

--- a/crates/yani-convert/src/lib.rs
+++ b/crates/yani-convert/src/lib.rs
@@ -25,6 +25,7 @@
 //! nuclide. See [`decay_sources`].
 
 pub mod branching;
+pub mod production;
 
 use std::collections::BTreeMap;
 use std::error::Error;

--- a/crates/yani-convert/src/production.rs
+++ b/crates/yani-convert/src/production.rs
@@ -1,0 +1,141 @@
+//! What final states an evaluation says a reaction can leave its product in.
+//!
+//! A reaction that can leave its product in a metastable state has to say so
+//! in MF=8, one subsection per final state, with each state's cross section in
+//! MF=10 or its share of the reaction in MF=9. An evaluation that lists only
+//! the ground state is not merely less accurate: the isomer is absent from any
+//! network built from it, so no code can produce it, and a measurement that
+//! sees its decay heat cannot be reproduced by any means. TENDL-2017 omitting
+//! the 1706 keV state from `Os190(n,n')` is why both yani and FISPACT-II sit
+//! at a third of the measured heat on the FNS osmium foil, and it is invisible
+//! from the outside: the reaction is present, its cross section is reasonable,
+//! and only the state list is short.
+//!
+//! [`extract_production`] reports that state list so it can be compared across
+//! libraries. It is a read, not a conversion: nothing is written, no decay data
+//! is needed, and the answer is what the file says rather than what a network
+//! made of it would contain.
+//!
+//! Why this is not [`crate::branching`]. That module answers a different
+//! question, how a reaction's rate splits between the isomers of the product,
+//! which needs decay data to turn a level index into an isomeric state and
+//! silently drops any state it cannot resolve. Asking which states exist has
+//! to happen before that mapping, or a state the decay library does not know
+//! about disappears from the answer, and those are exactly the states worth
+//! finding.
+
+use std::error::Error;
+use std::path::Path;
+
+use endf::Material;
+
+use crate::branching::mt_to_type;
+
+/// One final state of one reaction, as the evaluation lists it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductionState {
+    /// Excitation energy above the product's ground state, in eV. From MF=8
+    /// where the evaluation gives it, otherwise `QM - QI`.
+    pub excitation_energy: f64,
+    /// The product's nuclear level index, LFS. Zero is the ground state.
+    ///
+    /// Not an isomeric-state ordinal: two evaluators number the levels of one
+    /// nuclide differently, so `Ir190`'s 377 keV isomer is level 3 in
+    /// ENDF/B-VIII.1 and level 37 in JEFF-4.0 and TENDL-2025. The energy is
+    /// what compares across libraries; this is for finding the record again.
+    pub level_index: i64,
+    /// The product's ground-state name, e.g. `"Ir190"`.
+    ///
+    /// The ground state even for an excited final state, because naming the
+    /// isomer would need decay data to say which isomeric ordinal this level
+    /// is, and this function deliberately reads no decay data. Pair the name
+    /// with `excitation_energy` to identify the state.
+    pub product: String,
+    /// `"cross_section"` for a state given in MF=10, `"yield"` for MF=9.
+    pub source: &'static str,
+}
+
+/// The final states one reaction of one parent can leave its product in.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductionChannel {
+    /// The evaluated nuclide, named as it names itself in MF=1 MT=451.
+    pub parent: String,
+    /// The reaction's MT number, which is what the format states.
+    pub mt: i32,
+    /// The transmutation reaction name, where yani has one for this MT.
+    /// `None` for an MT no chain reaction covers, which is reported rather
+    /// than dropped: an isomer reached only by an unnamed channel is still a
+    /// state the evaluation carries.
+    pub reaction: Option<String>,
+    /// Every final state, ground state included, in level order.
+    pub states: Vec<ProductionState>,
+}
+
+impl ProductionChannel {
+    /// The excited states, which is what a completeness comparison is about.
+    pub fn excited(&self) -> impl Iterator<Item = &ProductionState> {
+        self.states.iter().filter(|s| s.excitation_energy > 0.0)
+    }
+}
+
+/// Read one evaluation's radionuclide production.
+///
+/// Empty for an evaluation with no MF=9 or MF=10 at all, which is the common
+/// case: most reactions cannot leave their product excited, and an evaluation
+/// that says nothing is different from one that lists the ground state alone.
+/// The second is a statement and appears here with a single state; the first
+/// is a silence and does not appear.
+pub fn extract_production(material: &Material) -> Vec<ProductionChannel> {
+    let Some(meta) = material.mf1_mt451() else {
+        return Vec::new();
+    };
+    let parent = endf::gnds_name(
+        (meta.za / 1000) as u32,
+        (meta.za % 1000) as u32,
+        meta.liso as u32,
+    );
+    let names = mt_to_type();
+    let mut out = Vec::new();
+    for (mt, states) in endf::radionuclide_production::radionuclide_production(material) {
+        let mut listed: Vec<ProductionState> = states
+            .iter()
+            .map(|state| ProductionState {
+                excitation_energy: state.excitation_energy(),
+                level_index: state.lfs,
+                product: endf::gnds_name((state.zap / 1000) as u32, (state.zap % 1000) as u32, 0),
+                source: if state.cross_section.is_some() {
+                    "cross_section"
+                } else {
+                    "yield"
+                },
+            })
+            .collect();
+        listed.sort_by_key(|s| s.level_index);
+        out.push(ProductionChannel {
+            parent: parent.clone(),
+            mt,
+            reaction: names.get(&(mt as i64)).cloned(),
+            states: listed,
+        });
+    }
+    out
+}
+
+/// Read the radionuclide production of many evaluations, one at a time.
+///
+/// Streamed rather than parsed into a held set, for the reason issue #53 gives:
+/// a whole neutron sublibrary does not fit in memory, and a survey is the case
+/// that wants every file rather than a scoped few. Channels come back in file
+/// order, so the answer does not depend on how the work was scheduled.
+pub fn production_from_files<P: AsRef<Path>>(
+    paths: &[P],
+) -> Result<Vec<ProductionChannel>, Box<dyn Error>> {
+    let mut out = Vec::new();
+    for path in paths {
+        let display = path.as_ref().display().to_string();
+        let material = Material::from_file(path.as_ref())
+            .map_err(|e| -> Box<dyn Error> { format!("{display}: {e}").into() })?;
+        out.extend(extract_production(&material));
+    }
+    Ok(out)
+}

--- a/crates/yani-convert/tests/production_states.rs
+++ b/crates/yani-convert/tests/production_states.rs
@@ -1,0 +1,83 @@
+//! Which final states an evaluation lists, read without any decay data.
+//!
+//! The fixture is TENDL-2017's Ir191, trimmed. It is here because its (n,2n)
+//! is one of the two channels whose short state list breaks the FNS
+//! benchmark: it lists Ir190's ground state and the 26 keV isomer and not the
+//! 377 keV one, which is the state that carries the measured heat. So this
+//! test documents a real library gap as well as exercising the read.
+
+use endf::Material;
+
+macro_rules! fixture {
+    ($name:literal) => {
+        include_bytes!(concat!("../../endf/fixtures/", $name))
+    };
+}
+
+fn material(compressed: &[u8]) -> Material {
+    let mut out = Vec::new();
+    lzma_rs::xz_decompress(&mut &compressed[..], &mut out).expect("fixture decompresses");
+    Material::from_str(&String::from_utf8(out).expect("fixture is UTF-8")).expect("fixture parses")
+}
+
+#[test]
+fn the_states_a_reaction_lists_are_reported_in_level_order() {
+    let ir191 = material(fixture!("n-077_Ir_191_trimmed.endf.xz"));
+    let channels = yani_convert::production::extract_production(&ir191);
+    assert!(!channels.is_empty());
+    for channel in &channels {
+        assert_eq!(channel.parent, "Ir191");
+        assert!(
+            channel
+                .states
+                .windows(2)
+                .all(|w| w[0].level_index <= w[1].level_index),
+            "MT{} states are out of level order",
+            channel.mt
+        );
+    }
+
+    let n2n = channels
+        .iter()
+        .find(|c| c.mt == 16)
+        .expect("the fixture keeps MF=8/10 for MT=16");
+    assert_eq!(n2n.reaction.as_deref(), Some("(n,2n)"));
+    // Ground state and the 26 keV isomer. Ir190 also has a 377 keV isomer,
+    // which JEFF-4.0, ENDF/B-VIII.1, JENDL-5.0 and TENDL-2025 all list and
+    // this evaluation does not. That absence is the finding: nothing else
+    // about the channel looks wrong.
+    let energies: Vec<f64> = n2n.states.iter().map(|s| s.excitation_energy).collect();
+    assert_eq!(energies.len(), 2, "{energies:?}");
+    assert_eq!(energies[0], 0.0);
+    assert!((energies[1] - 26_100.0).abs() < 100.0, "{energies:?}");
+    assert!(n2n.excited().count() == 1);
+
+    // The product is named at its ground state even for the excited entry,
+    // since naming the isomer would need decay data this read never touches.
+    assert!(n2n.states.iter().all(|s| s.product == "Ir190"));
+    assert!(n2n.states.iter().all(|s| s.source == "cross_section"));
+}
+
+#[test]
+fn a_yield_channel_is_labelled_as_one() {
+    let ir191 = material(fixture!("n-077_Ir_191_trimmed.endf.xz"));
+    let channels = yani_convert::production::extract_production(&ir191);
+    let capture = channels
+        .iter()
+        .find(|c| c.mt == 102)
+        .expect("the fixture keeps MF=9 for MT=102");
+    assert_eq!(capture.reaction.as_deref(), Some("(n,gamma)"));
+    assert!(
+        capture.states.iter().all(|s| s.source == "yield"),
+        "capture is given as MF=9 yields here"
+    );
+    assert!(capture.excited().count() >= 1);
+}
+
+/// An evaluation with no MF=1 MT=451 cannot name its parent, so it reports
+/// nothing rather than guessing a name from the filename.
+#[test]
+fn a_decay_evaluation_has_no_production_to_report() {
+    let decay = material(fixture!("dec-049_In_116m1.endf.xz"));
+    assert!(yani_convert::production::extract_production(&decay).is_empty());
+}

--- a/crates/yani-python/Cargo.toml
+++ b/crates/yani-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "yani-python"
 # transport converter says nothing about the inventory package. Bump it with
 # `cargo set-version -p yani-python <version>`.
 # See .github/workflows/ci-python.yml and docs/developer_info.md.
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for the transmutation stack: materials, nuclides, chains, irradiation schedules and inventories. Shared by the yamc and yani wheels."

--- a/crates/yani-python/src/convert.rs
+++ b/crates/yani-python/src/convert.rs
@@ -525,3 +525,88 @@ pub fn convert_photon(
     })
     .map_err(|e| PyRuntimeError::new_err(e.to_string()))
 }
+
+/// List the final states each reaction of an evaluation can leave its product
+/// in.
+///
+/// A reaction that can leave its product in a metastable state says so in
+/// MF=8, one subsection per final state. An evaluation that lists only the
+/// ground state is not merely less accurate: the isomer is absent from any
+/// network built from it, so no code can make it, and a measurement that sees
+/// its decay heat cannot be reproduced by any means. TENDL-2017 omits the
+/// 1706 keV state from ``Os190(n,n')``, which is why the FNS osmium foil comes
+/// out at a third of the measured heat with that library, in yani and in
+/// FISPACT-II alike. Nothing about the reaction looks wrong from outside: it
+/// is present, its cross section is reasonable, and only the state list is
+/// short. So comparing the state lists of several libraries is how such a gap
+/// is found, and this is the read that makes the comparison possible.
+///
+/// A read, not a conversion. Nothing is written, no decay data is involved,
+/// and the answer is what the files say rather than what a network built from
+/// them would hold.
+///
+/// Parameters
+/// ----------
+/// neutron_files : list[str]
+///     Neutron evaluations. Read one at a time rather than held, so a whole
+///     sublibrary is a valid argument.
+///
+/// Returns
+/// -------
+/// list[dict]
+///     One entry per (parent, reaction) carrying MF=9 or MF=10, in file order,
+///     each with ``parent``, ``mt``, ``reaction`` (the transmutation reaction
+///     name, or ``None`` for an MT no chain reaction covers) and ``states``.
+///     Each state has ``excitation_energy_eV``, ``level_index``, ``product``
+///     and ``source``.
+///
+///     ``product`` is the product's **ground-state** name even for an excited
+///     state, because naming the isomer needs decay data to say which
+///     isomeric ordinal a level is; pair it with ``excitation_energy_eV``.
+///     ``level_index`` is the evaluation's own LFS and is not comparable
+///     between libraries: Ir190's 377 keV isomer is level 3 in ENDF/B-VIII.1
+///     and level 37 in JEFF-4.0. ``source`` is ``"cross_section"`` for MF=10
+///     or ``"yield"`` for MF=9.
+///
+/// Examples
+/// --------
+///     >>> [c for c in yani.radionuclide_production(["n-Os190.tendl"])
+///     ...  if c["mt"] == 4][0]["states"]
+///     [{'excitation_energy_eV': 0.0, 'level_index': 0, 'product': 'Os190',
+///       'source': 'cross_section'}]
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (neutron_files))]
+pub fn radionuclide_production(
+    py: Python<'_>,
+    neutron_files: Vec<String>,
+) -> PyResult<Py<pyo3::types::PyList>> {
+    if neutron_files.is_empty() {
+        return Err(PyValueError::new_err(
+            "neutron_files is required: the production data is in the neutron \
+             evaluations, so there is nothing to read without them",
+        ));
+    }
+    let channels = yani_convert::production::production_from_files(&neutron_files)
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+    let out = pyo3::types::PyList::empty(py);
+    for channel in channels {
+        let entry = pyo3::types::PyDict::new(py);
+        entry.set_item("parent", channel.parent)?;
+        entry.set_item("mt", channel.mt)?;
+        entry.set_item("reaction", channel.reaction)?;
+        let states = pyo3::types::PyList::empty(py);
+        for state in channel.states {
+            let row = pyo3::types::PyDict::new(py);
+            row.set_item("excitation_energy_eV", state.excitation_energy)?;
+            row.set_item("level_index", state.level_index)?;
+            row.set_item("product", state.product)?;
+            row.set_item("source", state.source)?;
+            states.append(row)?;
+        }
+        entry.set_item("states", states)?;
+        out.append(entry)?;
+    }
+    Ok(out.unbind())
+}

--- a/crates/yani-python/src/lib.rs
+++ b/crates/yani-python/src/lib.rs
@@ -103,6 +103,7 @@ pub fn register_classes(py: Python<'_>, m: &Bound<'_, PyModule>, package: &str) 
     // Nuclear-data configuration: which library, and which chain subsections.
     m.add_function(wrap_pyfunction!(convert::convert_transmutation, m)?)?;
     m.add_function(wrap_pyfunction!(convert::convert_branching, m)?)?;
+    m.add_function(wrap_pyfunction!(convert::radionuclide_production, m)?)?;
     m.add_function(wrap_pyfunction!(convert::convert_neutron_xs, m)?)?;
     m.add_function(wrap_pyfunction!(convert::convert_neutron_transport, m)?)?;
     m.add_function(wrap_pyfunction!(convert::convert_photon, m)?)?;

--- a/packages/yamc-core/python/yamc/_core/__init__.pyi
+++ b/packages/yamc-core/python/yamc/_core/__init__.pyi
@@ -95,6 +95,7 @@ __all__ = [
     "mesh_faces_scene_resolved",
     "mesh_to_arrow",
     "mesh_volume_rs",
+    "radionuclide_production",
     "read_element_from_arrow",
     "read_nuclide_from_arrow",
     "reduce_mesh_tally_block",
@@ -5692,6 +5693,58 @@ def mesh_volume_rs(boundary_vertices: typing.Sequence[typing.Sequence[builtins.f
     preserved exactly (tet indices `0..len(boundary_vertices)` reference them,
     `>=` reference the returned interior vertices), and tets are pre-oriented
     to positive volume - so no winding swap or face remapping is needed.
+    """
+
+def radionuclide_production(neutron_files: typing.Sequence[builtins.str]) -> list:
+    r"""
+    List the final states each reaction of an evaluation can leave its product
+    in.
+    
+    A reaction that can leave its product in a metastable state says so in
+    MF=8, one subsection per final state. An evaluation that lists only the
+    ground state is not merely less accurate: the isomer is absent from any
+    network built from it, so no code can make it, and a measurement that sees
+    its decay heat cannot be reproduced by any means. TENDL-2017 omits the
+    1706 keV state from ``Os190(n,n')``, which is why the FNS osmium foil comes
+    out at a third of the measured heat with that library, in yani and in
+    FISPACT-II alike. Nothing about the reaction looks wrong from outside: it
+    is present, its cross section is reasonable, and only the state list is
+    short. So comparing the state lists of several libraries is how such a gap
+    is found, and this is the read that makes the comparison possible.
+    
+    A read, not a conversion. Nothing is written, no decay data is involved,
+    and the answer is what the files say rather than what a network built from
+    them would hold.
+    
+    Parameters
+    ----------
+    neutron_files : list[str]
+        Neutron evaluations. Read one at a time rather than held, so a whole
+        sublibrary is a valid argument.
+    
+    Returns
+    -------
+    list[dict]
+        One entry per (parent, reaction) carrying MF=9 or MF=10, in file order,
+        each with ``parent``, ``mt``, ``reaction`` (the transmutation reaction
+        name, or ``None`` for an MT no chain reaction covers) and ``states``.
+        Each state has ``excitation_energy_eV``, ``level_index``, ``product``
+        and ``source``.
+    
+        ``product`` is the product's **ground-state** name even for an excited
+        state, because naming the isomer needs decay data to say which
+        isomeric ordinal a level is; pair it with ``excitation_energy_eV``.
+        ``level_index`` is the evaluation's own LFS and is not comparable
+        between libraries: Ir190's 377 keV isomer is level 3 in ENDF/B-VIII.1
+        and level 37 in JEFF-4.0. ``source`` is ``"cross_section"`` for MF=10
+        or ``"yield"`` for MF=9.
+    
+    Examples
+    --------
+        >>> [c for c in yani.radionuclide_production(["n-Os190.tendl"])
+        ...  if c["mt"] == 4][0]["states"]
+        [{'excitation_energy_eV': 0.0, 'level_index': 0, 'product': 'Os190',
+          'source': 'cross_section'}]
     """
 
 def read_element_from_arrow(path: builtins.str) -> typing.Any:

--- a/packages/yani-core/python/yani/_core/__init__.pyi
+++ b/packages/yani-core/python/yani/_core/__init__.pyi
@@ -41,6 +41,7 @@ __all__ = [
     "group_structure",
     "group_structure_names",
     "lookup_cross_section_data",
+    "radionuclide_production",
     "read_element_from_arrow",
     "read_nuclide_from_arrow",
     "set_cross_section_data",
@@ -2721,6 +2722,58 @@ def lookup_cross_section_data(nuclide: builtins.str) -> typing.Optional[builtins
     r"""
     Look up the cross-section data path for a single nuclide, applying the global
     default if no per-nuclide entry is set.
+    """
+
+def radionuclide_production(neutron_files: typing.Sequence[builtins.str]) -> list:
+    r"""
+    List the final states each reaction of an evaluation can leave its product
+    in.
+    
+    A reaction that can leave its product in a metastable state says so in
+    MF=8, one subsection per final state. An evaluation that lists only the
+    ground state is not merely less accurate: the isomer is absent from any
+    network built from it, so no code can make it, and a measurement that sees
+    its decay heat cannot be reproduced by any means. TENDL-2017 omits the
+    1706 keV state from ``Os190(n,n')``, which is why the FNS osmium foil comes
+    out at a third of the measured heat with that library, in yani and in
+    FISPACT-II alike. Nothing about the reaction looks wrong from outside: it
+    is present, its cross section is reasonable, and only the state list is
+    short. So comparing the state lists of several libraries is how such a gap
+    is found, and this is the read that makes the comparison possible.
+    
+    A read, not a conversion. Nothing is written, no decay data is involved,
+    and the answer is what the files say rather than what a network built from
+    them would hold.
+    
+    Parameters
+    ----------
+    neutron_files : list[str]
+        Neutron evaluations. Read one at a time rather than held, so a whole
+        sublibrary is a valid argument.
+    
+    Returns
+    -------
+    list[dict]
+        One entry per (parent, reaction) carrying MF=9 or MF=10, in file order,
+        each with ``parent``, ``mt``, ``reaction`` (the transmutation reaction
+        name, or ``None`` for an MT no chain reaction covers) and ``states``.
+        Each state has ``excitation_energy_eV``, ``level_index``, ``product``
+        and ``source``.
+    
+        ``product`` is the product's **ground-state** name even for an excited
+        state, because naming the isomer needs decay data to say which
+        isomeric ordinal a level is; pair it with ``excitation_energy_eV``.
+        ``level_index`` is the evaluation's own LFS and is not comparable
+        between libraries: Ir190's 377 keV isomer is level 3 in ENDF/B-VIII.1
+        and level 37 in JEFF-4.0. ``source`` is ``"cross_section"`` for MF=10
+        or ``"yield"`` for MF=9.
+    
+    Examples
+    --------
+        >>> [c for c in yani.radionuclide_production(["n-Os190.tendl"])
+        ...  if c["mt"] == 4][0]["states"]
+        [{'excitation_energy_eV': 0.0, 'level_index': 0, 'product': 'Os190',
+          'source': 'cross_section'}]
     """
 
 def read_element_from_arrow(path: builtins.str) -> typing.Any:


### PR DESCRIPTION
Nothing exposed the list of final states an evaluation carries for a reaction, and that list is where two of this benchmark's worst disagreements live.

**Why it matters.** A reaction that can leave its product in a metastable state says so in MF=8, one subsection per final state. An evaluation that lists only the ground state is not merely less accurate: the isomer is absent from any network built from it, so no code can make it, and a measurement that sees its decay heat cannot be reproduced by any means. Surveying the FNS foils across the libraries on disk:

| Channel | JEFF-4.0 | ENDF/B-VIII.1 | JENDL-5.0 | TENDL-2017 | TENDL-2025 |
|---|---|---|---|---|---|
| Os190 (n,n') → Os190m, 1706 keV | yes | no file | yes | **omits** | yes |
| Ir191 (n,2n) → Ir190m2, ~377 keV | yes | yes | yes | **omits** | yes |

Those are exactly the two FNS foils where yani and FISPACT-II both sit at a third of the measured heat with TENDL-2017, and neither code can do anything about it. Nothing about either channel looks wrong from outside: it is present, its cross section is reasonable, only the state list is short.

**What this adds.** `yani_convert::production::extract_production` for one material and `production_from_files` for a streamed set, following the pattern #60 introduced, since a survey is the case that wants a whole sublibrary rather than a scoped few. `yani.radionuclide_production(neutron_files)` returns a list of dicts, one per (parent, reaction) carrying MF=9 or MF=10, each state with `excitation_energy_eV`, `level_index`, `product` and `source`.

**Why not part of `convert_branching`.** That answers a different question: how a rate splits between the isomers of the product. It needs decay data to turn a level index into an isomeric state and drops any state it cannot resolve. Asking which states exist has to happen before that mapping, or a state the decay library does not know about vanishes from the answer, and those are the states worth finding. This read touches no decay data and writes nothing.

Two deliberate limits, both documented in the docstring. `product` is the product's ground-state name even for an excited entry, because naming the isomer needs decay data. `level_index` is the evaluation's own LFS and is not comparable between libraries: Ir190's 377 keV isomer is level 3 in ENDF/B-VIII.1 and 37 in JEFF-4.0 and TENDL-2025, so the energy is what compares.

Versions bumped to yani-core 0.16.0 and yamc-core 0.11.0, since both wheels gain a public function and 0.15.0 / 0.10.0 are the release now publishing.

Tests use the TENDL-2017 Ir191 fixture added in #63, so the test itself documents the gap: it asserts the (n,2n) state list has two entries and not the 377 keV one. 197 endf and yani-convert tests pass, fmt and clippy clean, stubs regenerated for both wheels.

One note for review: `scripts/check_public_surface.py` reports `radionuclide_production` as advertised-but-not-importable when run against an installed extension built before this change. That is staleness rather than a defect. The top-level `__all__` is derived from `dir()` after `from yani._core import *`, so a new export flows through with no edit, and CI rebuilds before running the gate.