### PR TITLE
Refuse an energy grid that cannot be indexed logarithmically

### DIFF
--- a/crates/yamc-convert/src/fast_xs.rs
+++ b/crates/yamc-convert/src/fast_xs.rs
@@ -144,6 +144,29 @@ pub fn write_fast_xs(data: &IncidentNeutron, dir: &Path) -> Result<(), Box<dyn E
         if energy.is_empty() {
             continue;
         }
+        // A grid that is present but has no positive extent cannot be indexed
+        // logarithmically, and nothing downstream would notice. `ln(0.0)` is
+        // negative infinity, so `inv_log_delta` comes out
+        // `1.0 / ((-inf) - (-inf))`, NaN. The loader's index validation checks
+        // only that the entries are in range and non-decreasing, which a
+        // NaN-probed scan satisfies, and `FastXSGrid::lookup` casts its NaN bin
+        // to `usize`, which saturates to 0 in Rust. Every energy would take bin
+        // 0's bracket, for the whole grid, with no error anywhere.
+        //
+        // Refused rather than skipped, unlike the empty grid above: an ENDF
+        // evaluation legitimately reaches here with no grid at all, but a grid
+        // that is present and degenerate is corrupt input, and no real
+        // evaluation has one.
+        let (first, last) = (energy[0], energy[energy.len() - 1]);
+        if !(first > 0.0 && last > first && last.is_finite()) {
+            return Err(format!(
+                "{}'s energy grid at {temperature} runs from {first:e} to \
+                 {last:e} eV, which cannot be indexed logarithmically. The \
+                 grid has to start above zero and end above where it starts.",
+                data.name(),
+            )
+            .into());
+        }
         let n_energy = energy.len();
 
         // The per-MT columns, split by whether the reaction is a fission or

--- a/crates/yamc-convert/tests/section_values_fast_xs.rs
+++ b/crates/yamc-convert/tests/section_values_fast_xs.rs
@@ -14,9 +14,8 @@
 //! asserted below), and `entry::convert_neutron_transport` declines an ACE
 //! source, so `write_fast_xs` is called here directly rather than through the
 //! entry point. `synthetic-urr.ace.xz` reaches it too, with a grid of four
-//! zeros, and what it produces is pinned in
-//! `a_grid_with_no_positive_extent_is_written_rather_than_refused` as a
-//! suspected defect rather than as correct behaviour.
+//! zeros, and its refusal is asserted in
+//! `a_grid_with_no_positive_extent_is_refused`.
 //!
 //! # Where the input is CONSTRUCTED rather than parsed
 //!
@@ -446,62 +445,48 @@ fn the_log_lookup_index_is_the_last_grid_point_at_or_below_every_bin() {
     assert_i32_slice_eq("log_grid_index", &index, &expected);
 }
 
-/// PINS A SUSPECTED DEFECT rather than endorsing it.
+/// The refusal that closed the defect this test used to pin.
 ///
-/// `write_fast_xs` refuses an EMPTY grid (`fast_xs.rs:144-146`) and accepts a
-/// grid with no positive extent, which is what `synthetic-urr.ace.xz` parses to:
-/// four zeros. The accelerator it then writes is poisoned. `log_e_min` is
-/// `ln(0.0)`, negative infinity (`fast_xs.rs:77`), and `inv_log_delta` is
-/// `1.0 / ((-inf) - (-inf))`, NaN (`fast_xs.rs:79-80`).
+/// `write_fast_xs` used to refuse only an EMPTY grid and accept a grid with no
+/// positive extent, which is what `synthetic-urr.ace.xz` parses to: four zeros.
+/// The accelerator it wrote was poisoned. `log_e_min` was `ln(0.0)`, negative
+/// infinity, and `inv_log_delta` was `1.0 / ((-inf) - (-inf))`, NaN.
 ///
-/// Nothing downstream catches it. `log_grid_index_u32`
-/// (`nuclide_arrow.rs:714-753`) checks only that the entries are in range and
-/// non-decreasing, and all 8001 of them are, so the file loads.
-/// `FastXSGrid::lookup` then computes `((ln E - (-inf)) * NaN) as usize`, and a
-/// NaN cast to `usize` saturates to 0 in Rust, so every energy would silently
-/// take bin 0's bracket.
-///
-/// The assertions below therefore state what the writer DOES today, not what it
-/// should do. When it learns to refuse a grid with no positive extent, replace
-/// them with the refusal, in the shape of the two in
-/// `the_fast_xs_row_set_is_the_temperatures_that_have_a_grid`.
+/// Nothing downstream caught it, which is what made it worth closing.
+/// `log_grid_index_u32` (`nuclide_arrow.rs:714-753`) checks only that the
+/// entries are in range and non-decreasing, and all 8001 of them were, so the
+/// file loaded. `FastXSGrid::lookup` then computes
+/// `((ln E - (-inf)) * NaN) as usize`, and a NaN cast to `usize` saturates to 0
+/// in Rust, so every energy silently took bin 0's bracket for the whole grid.
+/// No error, no warning, and the transport kept running.
 #[test]
-fn a_grid_with_no_positive_extent_is_written_rather_than_refused() {
+fn a_grid_with_no_positive_extent_is_refused() {
     let data = ace_nuclide(URR_ACE);
     let temperatures = data.temperatures();
     let grid = &data.energy[&temperatures[0]];
     assert_f64_slice_eq("the fixture's own grid", grid, &[0.0; 4]);
 
     let dir = scratch();
-    write_fast_xs(&data, dir.path())
-        .expect("a grid of zeros is accepted today, which is what this test pins");
-    let batch = section(dir.path(), "fast_xs.arrow");
-    assert_eq!(batch.num_rows(), 1, "the degenerate grid is not skipped");
-
-    let log_e_min = f64_at(&batch, "log_e_min", 0);
+    let refused = write_fast_xs(&data, dir.path())
+        .expect_err("a grid with no positive extent cannot be indexed logarithmically");
+    let message = refused.to_string();
     assert!(
-        log_e_min.is_infinite() && log_e_min.is_sign_negative(),
-        "log_e_min is ln(0.0), so negative infinity, not {log_e_min}"
+        message.contains("cannot be indexed logarithmically"),
+        "the refusal must name why the grid was rejected: {message}"
     );
     assert!(
-        f64_at(&batch, "inv_log_delta", 0).is_nan(),
-        "inv_log_delta is 1 / ((-inf) - (-inf)), so NaN"
+        message.contains(&data.name()),
+        "the refusal must name the nuclide, so a directory-wide conversion \
+         says which file to look at: {message}"
     );
-
-    // Every probe energy is NaN, so `energy[at + 1] <= e` is false at every bin
-    // and the scan never advances; only the top-entry override moves anything.
-    let index = i32_list(&batch, "log_grid_index", 0);
-    assert_eq!(index.len(), LOG_BINS + 1);
     assert!(
-        index[..LOG_BINS].iter().all(|&v| v == 0),
-        "the scan cannot advance past a NaN probe"
+        message.contains(&temperatures[0]),
+        "the refusal must name the temperature, since a nuclide's other \
+         temperatures may be fine: {message}"
     );
-    assert_eq!(
-        index[LOG_BINS],
-        (grid.len() - 1) as i32,
-        "the top entry is set rather than derived, so it is the one entry that \
-         is not zero: in range and non-decreasing, which is all the loader \
-         checks before accepting the file"
+    assert!(
+        absent(dir.path(), "fast_xs.arrow"),
+        "a refused conversion must leave no file behind for a later pass to read"
     );
 }
 


### PR DESCRIPTION
Closes #11.

`write_fast_xs` refused an EMPTY energy grid but accepted a degenerate one. `crates/endf/fixtures/synthetic-urr.ace.xz` parses to a 294K grid of four zeros, and the writer returned `Ok` having written `log_e_min = -inf` (`ln(0.0)`) and `inv_log_delta = NaN` (`1.0 / ((-inf) - (-inf))`).

## Why nothing caught it

The loader's index validation (`log_grid_index_u32`, `nuclide_arrow.rs:714-753`) checks only that every entry is in range and non-decreasing. All 8001 entries satisfied both, so the file loaded. `FastXSGrid::lookup` then computes the bin as `((ln E - log_e_min) * inv_log_delta) as usize`, and a NaN cast to `usize` saturates to 0 in Rust, so every energy silently took bin 0's bracket for the whole grid. No error, no warning, and the transport kept running.

## The change

Require the grid to start above zero and end finitely above where it starts:

```rust
let (first, last) = (energy[0], energy[energy.len() - 1]);
if !(first > 0.0 && last > first && last.is_finite()) {
```

The condition is written positively so it also rejects a NaN or infinite endpoint, which poisons `inv_log_delta` the same way (an infinite `log_e_max` gives `inv_log_delta = 0.0`, and again every lookup lands in bin 0).

Refused rather than skipped, unlike the empty grid immediately above it. That distinction is deliberate and is in the comment: an ENDF evaluation legitimately reaches this writer with no grid at all, because `IncidentNeutron::from_endf` never fills `data.energy`, but a grid that is present and degenerate is corrupt input. The error names the nuclide and the temperature, since a nuclide's other temperatures may be fine.

## Reachability

Only through a fixture today. No real ACE table has a non-positive energy grid, so this is a robustness hole rather than a live data bug, and every real evaluation passes the guard unchanged. It is worth closing because the failure mode was invisible.

## Tests

`a_grid_with_no_positive_extent_is_written_rather_than_refused` pinned the old behaviour and said in its own doc comment that it was recording a suspected defect rather than endorsing it, with instructions to replace it with the refusal once the writer learned to reject the grid. It is now `a_grid_with_no_positive_extent_is_refused`, asserting the refusal names the reason, the nuclide and the temperature, and that no `fast_xs.arrow` is left behind for a later pass to read. The module doc reference to the old name is updated.

`cargo test --workspace` and `cargo clippy --workspace --lib --bins --tests --examples -- -D warnings` are clean. Two failures in `yamc --lib` `transmute::tests` (`an_unrated_nuclide_ranks_as_a_scatterer`, `the_peak_is_barns_not_the_ev_barn_tables`) reproduce on an unmodified `main` and are unrelated to this branch.