### PR TITLE
Remove the unfillable photon heating column and the retired-column list

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -754,7 +754,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
 
       - name: Fetch nuclear-data test fixtures
         run: python3 scripts/fetch_test_fixtures.py
@@ -838,7 +838,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
 
       - name: Fetch nuclear-data test fixtures
         shell: bash
@@ -920,7 +920,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
 
       # Runs on a cache hit too. The cache holds ~/.cache/yamc, and it is this
       # script that puts the tests/*.arrow symlinks into the working tree; the

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
       - name: Fetch nuclear-data test fixtures
         shell: bash
         run: python scripts/fetch_test_fixtures.py
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
       - name: Fetch nuclear-data test fixtures
         run: python3 scripts/fetch_test_fixtures.py
       # Default features only (arrow). GPU device tests are adapter-gated and
@@ -254,7 +254,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
       - name: Fetch nuclear-data test fixtures
         run: python scripts/fetch_test_fixtures.py
 

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
       - name: Fetch nuclear-data test fixtures
         run: python3 scripts/fetch_test_fixtures.py
       - name: Test compile
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/yamc
-          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs') }}
+          key: yamc-test-fixtures-endf-b8.1-${{ hashFiles('crates/yamc-nuclide/src/storage/url_cache.rs', 'crates/nuclear-data-schema/src/lib.rs') }}
       # The native tests drive `YaniSession` against real Arrow fixtures. They
       # skip themselves when the fixtures are absent rather than failing, so
       # without this step the job would pass while asserting nothing.

--- a/crates/nuclear-data-schema/src/lib.rs
+++ b/crates/nuclear-data-schema/src/lib.rs
@@ -111,54 +111,15 @@ pub fn flat_section_for_path(path: &std::path::Path) -> Option<String> {
 ///
 /// `Ok(())` for an unknown section, so a caller can validate opportunistically
 /// without knowing whether a path is declared.
-/// Columns this schema used to declare and no longer does (issue #500).
-///
-/// [`check_batch`] runs on every read, so without this list a build carrying
-/// the current schema could not read one already-published file: every one of
-/// them still holds these columns. Retiring a column is therefore two changes,
-/// and this is the compatibility half. Entries stay until no supported data set
-/// carries them; a name here is accepted and ignored, never read.
-///
-/// Per section rather than global, because a retired name can still be a live
-/// column elsewhere: `energy` is gone from `element.arrow` and is load-bearing
-/// in `fast_xs.arrow` and `urr.arrow`.
-///
-/// Public because the converter's published-file parity tests need it too: a
-/// published file still carries these columns, so "what we write equals what
-/// is published" only holds once the retired names are subtracted. Asserting
-/// that against a second, hand-copied list is how the two drift apart.
-pub fn retired(section: &str) -> &'static [&'static str] {
-    match section {
-        "fast_xs.arrow" => &[
-            "n_energies",
-            "n_scatter_mts",
-            "n_fission_mts",
-            "scatter_mt_to_idx",
-            "fission_mt_to_idx",
-        ],
-        "element.arrow" => &[
-            "energy",
-            "ln_coherent_xs",
-            "ln_incoherent_xs",
-            "ln_photoelectric_xs",
-        ],
-        "nuclide.arrow" => &["metastable", "fissionable"],
-        "reactions.arrow" => &["n_products"],
-        _ => &[],
-    }
-}
-
 pub fn check_batch(section: &str, batch: &Schema) -> Result<(), String> {
     let Some(declared) = self::section(section) else {
         return Ok(());
     };
-    let retired = self::retired(section);
     let mut undeclared: Vec<&str> = batch
         .fields()
         .iter()
         .filter(|f| declared.field_with_name(f.name()).is_err())
         .map(|f| f.name().as_str())
-        .filter(|name| !retired.contains(name))
         .collect();
     undeclared.sort();
     if !undeclared.is_empty() {
@@ -530,7 +491,6 @@ pub fn element() -> Schema {
         f64s("photoelectric_xs", true),
         f64s("pair_production_nuclear_xs", true),
         f64s("pair_production_electron_xs", true),
-        f64s("heating_xs", true),
         f64s("coherent_int_ff_x", true),
         f64s("coherent_int_ff_y", true),
         f64s("coherent_ff_x", true),
@@ -542,7 +502,7 @@ pub fn element() -> Schema {
         f64s("incoherent_ff_x", true),
         f64s("incoherent_ff_y", true),
     ])
-    .with_metadata(meta([("filetype", "data_photon"), ("version", "4.0")]))
+    .with_metadata(meta([("filetype", "data_photon"), ("version", "5.0")]))
 }
 
 /// `fast_xs.arrow`

--- a/crates/yamc-convert/src/photon.rs
+++ b/crates/yamc-convert/src/photon.rs
@@ -28,7 +28,11 @@ use endf::IncidentPhoton;
 use crate::sections::*;
 
 /// The MTs that are whole-atom cross sections rather than per-subshell ones.
-const ELEMENT_MTS: [i32; 6] = [501, 502, 504, 515, 517, 522];
+///
+/// MT 501 is the photoatomic total and is deliberately absent: no column is
+/// built from it, so evaluating it onto the union grid was work thrown away on
+/// every element.
+const ELEMENT_MTS: [i32; 5] = [502, 504, 515, 517, 522];
 
 /// The per-subshell photoionization range, MT 534 (K) to MT 572.
 const SUBSHELL_MTS: std::ops::RangeInclusive<i32> = 534..=572;
@@ -136,7 +140,6 @@ fn write_element(data: &IncidentPhoton, grid: &[f64], dir: &Path) -> Result<(), 
             float_list(&take("photoelectric")),
             float_list(&take("pair_production_nuclear")),
             float_list(&take("pair_production_electron")),
-            float_list(&take("heating")),
             float_list(&int_ff_x),
             float_list(&int_ff_y),
             float_list(&ff_x),

--- a/crates/yamc-convert/tests/section_values_photon.rs
+++ b/crates/yamc-convert/tests/section_values_photon.rs
@@ -12,7 +12,7 @@
 //!
 //! `write_section` builds each batch from a positional `Vec<ArrayRef>` and
 //! Arrow validates the data type and the row count, never the meaning.
-//! `element.arrow` declares seventeen consecutive `list<double>` fields, so
+//! `element.arrow` declares sixteen consecutive `list<double>` fields, so
 //! any permutation among them is type-valid and writes without complaint.
 //! `read_photon_interaction_from_arrow`
 //! (`crates/yamc-element/src/photon_arrow.rs:53`) does read every one of those
@@ -175,7 +175,7 @@ fn eval_on(data: &IncidentPhoton, mt: i32, grid: &[f64]) -> Vec<f64> {
 /// A failure means a photon cross section landed in the wrong slot or on the
 /// wrong grid.
 ///
-/// `element.arrow` declares seventeen consecutive `list<double>` fields, so
+/// `element.arrow` declares sixteen consecutive `list<double>` fields, so
 /// any permutation among them is type-valid and `RecordBatch::try_new`
 /// accepts it. The grid itself is load-bearing and subtle: MT 501 tabulates
 /// 13.6 eV twice for the K edge and `Vec::dedup` collapses the pair, so the
@@ -312,24 +312,11 @@ fn element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid() {
         2_044_000.0
     );
 
-    // MT 525 is absent from this evaluation, so heating is an EMPTY list and
-    // not a null and not 2020 zeros. The reader substitutes a zero vector for
-    // the empty case, so a wrongly-empty heating column loads as zero KERMA
-    // without a word.
-    //
-    // Empty is the right answer here, but it is also the ONLY answer the
-    // writer can give: `ELEMENT_MTS` (photon.rs:31) lists 501, which
-    // `take` never asks for, and omits 525, which it does, so the filter at
-    // photon.rs:94 drops the heating reaction before it can be evaluated.
-    // Handing `write_photon` a constructed element with an MT 525 cross
-    // section still writes an empty column, which is pinned as a suspected
-    // defect by `constructed_mt_525_is_dropped_from_the_heating_column`.
+    // MT 525 is absent from this evaluation, as it is from every ENDF
+    // photoatomic file: MF=23 does not carry it. There is no heating column to
+    // check, and `constructed_mt_525_writes_no_heating_column` pins that even a
+    // constructed MT 525 does not bring one back.
     assert!(!c.data.reactions.contains_key(&525), "H carries no MT 525");
-    assert!(
-        !is_null(&batch, "heating_xs", 0),
-        "heating_xs is written as an empty list, not as a null"
-    );
-    assert_eq!(list_len(&batch, "heating_xs", 0), 0);
 }
 
 /// A failure means an interpolated cross section is no longer the number the
@@ -1243,30 +1230,25 @@ fn constructed_anomalous_scattering_columns_keep_their_own_abscissae() {
     );
 }
 
-/// PINS A SUSPECTED DEFECT. `element.arrow.heating_xs` can never be populated.
+/// A failure means `element.arrow` grew a heating column back.
 ///
-/// This test does not endorse the behaviour it asserts. `ELEMENT_MTS`
-/// (`photon.rs:31`) is `[501, 502, 504, 515, 517, 522]`: it contains 501,
-/// which `take` at `photon.rs:139` never asks for, and omits 525, which is the
-/// MT named `"heating"` (`crates/endf/src/incident_photon.rs:33`). The filter
-/// at `photon.rs:94` therefore drops the heating reaction before it can be
-/// evaluated and `take("heating")` falls through to `unwrap_or_default`. The
-/// reader substitutes `vec![0.0; n_energy]` for an empty column
-/// (`crates/yamc-element/src/photon_arrow.rs:88-94`), so photon KERMA loads as
-/// identically zero with no error anywhere.
+/// `heating_xs` was declared but unfillable and is now gone. MT 525 is the MT
+/// named `"heating"` (`crates/endf/src/incident_photon.rs:33`) and it reaches
+/// an `IncidentPhoton` only through `from_ace`; the converter is ENDF-only,
+/// and ENDF photoatomic MF=23 has no MT 525. The column was empty in all 261
+/// published elements across endf-b8.1, fendl-3.2d and jendl-5.0, so nothing
+/// ever read a value from it.
 ///
 /// CONSTRUCTED INPUT, not an evaluation: `photoat-001_H_000.endf` has no
-/// MF=23 MT=525 and is the only photoatomic file in the tree, so the branch is
-/// unreachable from vendored bytes. If you have just fixed `ELEMENT_MTS` to
-/// `[502, 504, 515, 517, 522, 525]` then this test is what went red, and the
-/// two assertions below should become a comparison against MT 525 evaluated on
-/// the union grid, the same shape as the five channels in
-/// `element_cross_section_columns_are_the_parsed_reactions_on_the_union_grid`.
+/// MF=23 MT=525 and is the only photoatomic file in the tree, so this is the
+/// only way to hand the writer an MT 525 at all. If an ACE photoatomic route
+/// is ever added, this test is what should go red, and the column, the schema
+/// field and the reader all come back together rather than one at a time.
 #[test]
-fn constructed_mt_525_is_dropped_from_the_heating_column() {
+fn constructed_mt_525_writes_no_heating_column() {
     let data = constructed_element();
     // The input really does carry a heating cross section, under the name the
-    // writer asks for.
+    // writer used to ask for.
     let heating = data.get(525).expect("the constructed element has MT 525");
     assert_eq!(heating.name(), Some("heating"));
     assert_f64_slice_eq(
@@ -1278,17 +1260,17 @@ fn constructed_mt_525_is_dropped_from_the_heating_column() {
     let (_scratch, dir) = write_constructed(&data);
     let batch = section(&dir, "element.arrow");
 
-    // The channels ELEMENT_MTS does list are on the union grid.
+    // The channels ELEMENT_MTS lists are on the union grid.
     assert_eq!(list_len(&batch, "ln_energy", 0), CONSTRUCTED_GRID.len());
     assert_eq!(list_len(&batch, "coherent_xs", 0), CONSTRUCTED_GRID.len());
-    // Heating is not, and it is an empty list rather than a null.
-    assert!(!is_null(&batch, "heating_xs", 0));
-    assert_eq!(
-        list_len(&batch, "heating_xs", 0),
-        0,
-        "heating_xs is written empty even though MT 525 was supplied; see this \
-         test's doc comment before changing the assertion"
+
+    // The heating column is absent, not empty. An empty column is what the old
+    // defect looked like, so asserting absence is what tells the two apart.
+    assert!(
+        batch.column_by_name("heating_xs").is_none(),
+        "MT 525 was supplied and must not produce a heating_xs column"
     );
+    assert_schema_is_declared(&batch, "element.arrow");
 }
 
 /// A failure means `subshells.arrow` is no longer written most-bound-first.
@@ -1622,32 +1604,30 @@ fn constructed_element_fully_populated() -> IncidentPhoton {
 
 /// A failure means two `element.arrow` columns were exchanged.
 ///
-/// CONSTRUCTED INPUT, not an evaluation. `element.arrow` declares seventeen
+/// CONSTRUCTED INPUT, not an evaluation. `element.arrow` declares sixteen
 /// consecutive `list<double>` fields and a permutation among any two that are
 /// EMPTY on the input at hand writes a byte-identical file. On
-/// [`constructed_element`] three of them are empty at once
-/// (`pair_production_nuclear_xs`, `pair_production_electron_xs` and
-/// `heating_xs`), so exchanging the two pair-production slots in
-/// `write_element`'s argument vector leaves all eight constructed tests green.
+/// [`constructed_element`] two of them are empty at once
+/// (`pair_production_nuclear_xs` and `pair_production_electron_xs`), so
+/// exchanging those two slots in `write_element`'s argument vector leaves all
+/// eight constructed tests green.
 ///
-/// Here sixteen of the seventeen carry values that are pairwise different, and
-/// `heating_xs` is empty on every input the writer can be handed
-/// (`constructed_mt_525_is_dropped_from_the_heating_column`), which makes it
-/// the unique empty column and so makes a permutation involving it visible as
-/// well. The pairwise comparison at the end of this test is the property that
-/// says so: no two of the seventeen columns are equal, therefore every
-/// permutation of them changes the file.
+/// Here all sixteen carry values that are pairwise different. The pairwise
+/// comparison at the end of this test is the property that says so: no two of
+/// the sixteen columns are equal, therefore every permutation of them changes
+/// the file. Retiring the unfillable `heating_xs` strengthened this: it was
+/// the one column that could never carry a value, so it was the one slot a
+/// permutation could hide in.
 #[test]
 fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisible() {
-    /// The seventeen list columns, in the order `write_element` passes them.
-    const LIST_COLUMNS: [&str; 17] = [
+    /// The sixteen list columns, in the order `write_element` passes them.
+    const LIST_COLUMNS: [&str; 16] = [
         "ln_energy",
         "coherent_xs",
         "incoherent_xs",
         "photoelectric_xs",
         "pair_production_nuclear_xs",
         "pair_production_electron_xs",
-        "heating_xs",
         "coherent_int_ff_x",
         "coherent_int_ff_y",
         "coherent_ff_x",
@@ -1665,7 +1645,7 @@ fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisi
     let batch = section(&dir, "element.arrow");
     assert_schema_is_declared(&batch, "element.arrow");
 
-    // Those seventeen are every column but the two scalars, in that order, so
+    // Those sixteen are every column but the two scalars, in that order, so
     // the pairwise property below cannot miss one that was added later.
     let names: Vec<String> = batch
         .schema()
@@ -1744,17 +1724,14 @@ fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisi
         assert_f64_slice_eq(col, &f64_list(&batch, col, 0), &expected);
     }
 
-    // Sixteen populated, one empty, and the empty one is the MT 525 defect.
+    // All sixteen populated. There is no longer a column that cannot carry a
+    // value, so there is no slot a permutation can hide in.
     let written: Vec<Vec<f64>> = LIST_COLUMNS
         .iter()
         .map(|&c| f64_list(&batch, c, 0))
         .collect();
     for (col, values) in LIST_COLUMNS.iter().zip(&written) {
-        assert_eq!(
-            values.is_empty(),
-            *col == "heating_xs",
-            "{col} is the wrong side of the populated/empty divide"
-        );
+        assert!(!values.is_empty(), "{col} is empty, so a swap with it is invisible");
     }
 
     // The property this element exists for.

--- a/crates/yamc-convert/tests/sections.rs
+++ b/crates/yamc-convert/tests/sections.rs
@@ -176,12 +176,10 @@ fn nuclide_section_matches_the_published_file() {
     let mine = read_batch(&dir.join("nuclide.arrow"));
     let theirs = read_batch(&ref_dir.join("nuclide.arrow"));
 
-    // The published file still holds the columns this build has retired, and
-    // will until it is rebuilt, so parity is against the published set minus
-    // those. Taken from nuclear_data_schema::retired rather than restated here:
-    // a second copy of that list is how the schema and its compatibility half
-    // drift apart, and this test is the thing that would stop noticing.
-    let retired = nuclear_data_schema::retired("nuclide.arrow");
+    // Straight parity now: the published files no longer carry any column this
+    // build does not write. That was checked across the published data before
+    // the compatibility list was deleted, so a mismatch here means the writer
+    // and the published library have genuinely diverged.
     let names = |b: &arrow_array::RecordBatch| -> Vec<String> {
         b.schema()
             .fields()
@@ -191,14 +189,10 @@ fn nuclide_section_matches_the_published_file() {
     };
     assert_eq!(
         names(&mine),
-        names(&theirs)
-            .into_iter()
-            .filter(|n| !retired.contains(&n.as_str()))
-            .collect::<Vec<_>>(),
-        "column names differ from the published file, allowing for retired columns"
+        names(&theirs),
+        "column names differ from the published file"
     );
 
-    // `metastable` is retired, so it is no longer written and cannot be compared.
     for col in ["Z", "A"] {
         assert_eq!(
             mine.column_by_name(col)

--- a/crates/yamc-element/src/photon.rs
+++ b/crates/yamc-element/src/photon.rs
@@ -265,7 +265,6 @@ pub struct PhotonInteraction {
     pub pair_production_total_xs: Vec<f64>,
     pub pair_production_nuclear_xs: Vec<f64>,
     pub pair_production_electron_xs: Vec<f64>,
-    pub heating_xs: Vec<f64>,
 
     // ------------------------------------------------------------------
     // Form factors (Tabulated1D from reaction_product)
@@ -549,14 +548,16 @@ impl PhotonInteraction {
         // particles per unit flux.  Since yamc does not transport electrons or
         // positrons, all charged-particle kinetic energy is deposited locally.
         //
-        // Use tabulated heating XS from the Arrow data when available (computed by
-        // NJOY HEATR); otherwise fall back to physics-based calculation.
-        let heating_from_table = (self.heating_xs[i_grid]
-            + f * (self.heating_xs[i_grid + 1] - self.heating_xs[i_grid]))
-            .exp();
-        let heating = if heating_from_table > 0.0 {
-            heating_from_table
-        } else {
+        // Computed from the components rather than read from a table. There was
+        // a `heating_xs` column for an NJOY HEATR / ACE KERMA, but nothing could
+        // ever fill it: MT 525 reaches an `IncidentPhoton` only through the ACE
+        // route, and the converter is ENDF-only, where MF=23 has no MT 525. It
+        // was empty in all 261 published elements across endf-b8.1, fendl-3.2d
+        // and jendl-5.0, so this expression is what every run has always used.
+        // OpenMC's photon library has no heating dataset either, and OpenMC
+        // ignores the field when one is present: it scores photon heating by
+        // analog per-collision energy balance instead.
+        let heating = {
             // Compton (incoherent): average electron recoil energy from the
             // Klein-Nishina formula.  α = E / (m_e c²).
             // Average scattered photon energy:
@@ -1586,7 +1587,6 @@ mod tests {
         assert_eq!(fe.pair_production_total_xs.len(), n);
         assert_eq!(fe.pair_production_nuclear_xs.len(), n);
         assert_eq!(fe.pair_production_electron_xs.len(), n);
-        assert_eq!(fe.heating_xs.len(), n);
 
         // Coherent XS should have reasonable log values (not all -900)
         let non_trivial = fe.coherent_xs.iter().filter(|&&v| v > -900.0).count();
@@ -2387,8 +2387,7 @@ mod tests {
 
     #[test]
     fn photoelectric_heating_subtracts_transported_fluorescence() {
-        // End-to-end on Fe (whose fixture has no tabulated heating_xs, so the
-        // physics fallback runs): the photoelectric photon-KERMA coefficient must
+        // End-to-end on Fe: the photoelectric photon-KERMA coefficient must
         // subtract the fluorescence energy that atomic_relaxation banks and
         // transports, leaving it strictly below the old "full incident energy"
         // value wherever photoelectric contributes.

--- a/crates/yamc-element/src/photon_arrow.rs
+++ b/crates/yamc-element/src/photon_arrow.rs
@@ -70,10 +70,9 @@ pub fn read_photon_interaction_from_arrow(dir: &Path) -> Result<PhotonInteractio
     let incoherent_xs = log_transform_xs(&incoherent_xs_raw);
     let photoelectric_total_xs = log_transform_xs(&photoelectric_xs_raw);
 
-    // Pair production and heating
+    // Pair production
     let pp_nuclear_raw = try_get_f64_list(&elem_batch, "pair_production_nuclear_xs", 0);
     let pp_electron_raw = try_get_f64_list(&elem_batch, "pair_production_electron_xs", 0);
-    let heating_raw = try_get_f64_list(&elem_batch, "heating_xs", 0);
 
     // Default to zeros if empty
     let pp_nuclear_raw = if pp_nuclear_raw.is_empty() {
@@ -86,11 +85,6 @@ pub fn read_photon_interaction_from_arrow(dir: &Path) -> Result<PhotonInteractio
     } else {
         pp_electron_raw
     };
-    let heating_raw = if heating_raw.is_empty() {
-        vec![0.0; n_energy]
-    } else {
-        heating_raw
-    };
 
     // Compute pair_production_total = nuclear + electron (in raw space), then log-transform
     let pp_total_raw: Vec<f64> = pp_nuclear_raw
@@ -102,7 +96,6 @@ pub fn read_photon_interaction_from_arrow(dir: &Path) -> Result<PhotonInteractio
     let pair_production_total_xs = log_transform_xs(&pp_total_raw);
     let pair_production_nuclear_xs = log_transform_xs(&pp_nuclear_raw);
     let pair_production_electron_xs = log_transform_xs(&pp_electron_raw);
-    let heating_xs = log_transform_xs(&heating_raw);
 
     // Form factors
     let coh_ff_x = get_f64_list(&elem_batch, "coherent_int_ff_x", 0)?;
@@ -204,7 +197,6 @@ pub fn read_photon_interaction_from_arrow(dir: &Path) -> Result<PhotonInteractio
         pair_production_total_xs,
         pair_production_nuclear_xs,
         pair_production_electron_xs,
-        heating_xs,
         coherent_int_form_factor,
         incoherent_form_factor,
         electron_pdf,

--- a/crates/yamc-gpu/src/photon/transport.rs
+++ b/crates/yamc-gpu/src/photon/transport.rs
@@ -727,9 +727,8 @@ fn multi_cell_photon_transport_kernel(
                 // Macroscopic photon heating / KERMA XS, interpolated the
                 // SAME linear way as the component XS. The host array is
                 // built from the density-weighted per-element
-                // `ElementMicroXS.heating` (log-linear-interp-then-exp of
-                // the tabulated `heating_xs`), so this is a table +
-                // arithmetic match to the CPU `calculate_photon_xs().heating`.
+                // `ElementMicroXS.heating`, so this is an arithmetic match to
+                // the CPU `calculate_photon_xs().heating`.
                 let xh_lo = heating_xs_per_material[(mat_offset + idx_lo) as usize];
                 let xh_hi = heating_xs_per_material[(mat_offset + idx_hi) as usize];
                 let sigma_heating = xh_lo + (xh_hi - xh_lo) * frac;

--- a/crates/yamc-gpu/src/photon/xs/photon_xs.rs
+++ b/crates/yamc-gpu/src/photon/xs/photon_xs.rs
@@ -171,9 +171,8 @@ pub fn extract_photon_material_xs(
                 pair += density * micro.pair_production;
                 // Density-weighted heating, mirroring CPU
                 // `Material::calculate_photon_xs`: `micro.heating` is
-                // the element's KERMA value (log-linear-interp of the
-                // tabulated `heating_xs` then `.exp()`, with the same
-                // physics fallback when the table is absent).
+                // the element's KERMA value, computed from the Compton,
+                // photoelectric and pair-production components.
                 heat += density * micro.heating;
                 // Per-element macro total -- the selection weight the kernel
                 // samples the interacting element from (task #72), mirroring


### PR DESCRIPTION
Closes #10.

**This needs the photon libraries republished before or with the merge.** `check_batch` runs on every read (`crates/yamc-nuclide/src/arrow/arrow_helpers.rs:123`), so once `heating_xs` leaves the schema with no `retired()` entry, the currently published `element.arrow` files are rejected with "columns the schema does not declare". No compat shim, by choice.

## 1. `heating_xs` could never be filled

MT 525 is the MT named `"heating"` (`crates/endf/src/incident_photon.rs:33`) and it reaches an `IncidentPhoton` only through `IncidentPhoton::from_ace`. The converter's only photon entry point is `convert_photon`, which uses `from_endf`, and ENDF photoatomic MF=23 has no MT 525. `ELEMENT_MTS` excluded 525 as well, so even a constructed input carrying one was dropped at `photon.rs:98` before it could be evaluated, and `take("heating")` fell through to `unwrap_or_default()`.

Checked against the published data rather than assumed. Downloaded every published `element.arrow` and read it with the repo's own reader:

| Library | Elements | `heating_xs` declared | Populated |
|---|---|---|---|
| endf-b8.1 | 100 | 100 | **0** |
| fendl-3.2d | 61 | 61 | **0** |
| jendl-5.0 | 100 | 100 | **0** |

Empty in 261 of 261, against `ln_energy` lengths of 630 to 15124. It was also the only always-empty column: probing 12 sections across 522 published files found every other declared column carrying real data.

## 2. The reader branch it fed was unreachable

`photon_arrow.rs` substituted `vec![0.0; n_energy]` for the empty column, `safe_log` mapped that to `-900.0`, and `(-900.0).exp()` is **exactly** `0.0` because f64's smallest denormal is `exp(-744.4)`. So `heating_from_table > 0.0` was always false and the analytic Klein-Nishina / photoelectric / pair-production expression is what every run has always used. The branch, the `heating_xs` field on `PhotonElement`, and the zero-fill all go.

Worth recording, since it decides that filling the column would have been the wrong fix: OpenMC's photon library carries no `heating` dataset at all (checked, 0 of 100 files in the ENDF/B-VIII.1 release have the group), and OpenMC ignores the field when it is present. Its `heating_` is read at `src/photon.cpp:113-119`, log-floored at `photon.cpp:409`, and never consumed. Photon heating there is scored by analog per-collision energy balance (`src/tallies/tally_scoring.cpp:346-366`), with the estimator forced to collision at `src/tallies/tally.cpp:634-638`. Populating our column would have moved us away from the benchmark, not toward it.

## 3. MT 501 was evaluated and discarded

MT 501 is the photoatomic total. It was in `ELEMENT_MTS`, so it was evaluated onto the full union grid at `photon.rs:100` and inserted into the map, and `take` was only ever called for the five named channels. Roughly 940,000 wasted `Tabulated1D` evaluations per endf-b8.1 library conversion, which is the summed `ln_energy` length across the 100 elements.

## 4. `retired()` had nothing left to protect

With `heating_xs` gone there is no reason to keep the compatibility list, and it turned out to be dead already. All twelve retired names were checked against the published data:

| Section | Retired names | Still present |
|---|---|---|
| element.arrow (3 libs, 261 files) | `energy`, `ln_coherent_xs`, `ln_incoherent_xs`, `ln_photoelectric_xs` | none |
| fast_xs.arrow (20 files) | `n_energies`, `n_scatter_mts`, `n_fission_mts`, `scatter_mt_to_idx`, `fission_mt_to_idx` | none |
| nuclide.arrow (20 files) | `metastable`, `fissionable` | none |
| reactions.arrow (20 files) | `n_products` | none |

So the function, its filter inside `check_batch`, and the subtraction in `nuclide_section_matches_the_published_file` are all removed. The neutron sections were sampled on 20 endf-b8.1 nuclides rather than exhaustively; `element.arrow` was checked across all three libraries in full.

`element.arrow` schema version goes `4.0` to `5.0`. Nothing reads that metadata, it is provenance.

## Tests

`constructed_mt_525_is_dropped_from_the_heating_column` pinned the defect and said in its own doc comment what should replace it. It is now `constructed_mt_525_writes_no_heating_column`, asserting the column is **absent** rather than empty, since absent-vs-empty is exactly what distinguishes the fix from the defect.

`constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisible` gets stronger. It guards against two same-typed list columns being exchanged in `write_element`'s argument vector, which is invisible when both are empty. `heating_xs` was the one column that could never carry a value, so it was the one slot a permutation could hide in. All sixteen remaining columns are now populated and pairwise distinct.

## Not touched

`energy_param2_x/y` and `ei`/`wei` are empty in every published file I sampled, but unlike `heating_xs` both have live writers (`distributions.rs:251` for Watt spectra, `covariance.rs:193`). They are rare, not dead. Separately worth noting for its own issue: across 50 nuclides including all 30 fissile actinides and 9068 distribution rows, there is not one Watt spectrum, so that path is implemented and synthetically tested but unexercised by published endf-b8.1 data.

## CI will be red until the data is republished, by design

`check_batch` runs on every read (`crates/yamc-nuclide/src/arrow/arrow_helpers.rs:123`), and CI fetches the published fixtures (`scripts/fetch_test_fixtures.py`), so every photon test fails here until the libraries are rebuilt. Verified locally against a real published `Fe` element.arrow, which is the exact message to expect:

```
element.arrow has columns the schema does not declare: ["heating_xs"].
Either this is not the section it claims to be, or it was written by a
build with a different schema.
```

Any CI failure that is **not** that message is a real regression, not the republish.

The fixture cache key is also fixed here. It hashed only `url_cache.rs`, which this PR does not touch, so CI would have restored the pre-republish files from cache and kept failing even after the data was re-uploaded. The schema decides which columns a file may carry, so it now hashes into the key too, in all 8 cache steps across `ci-rust`, `ci-python` and `ci-wasm`. That also busts the cache now, forcing the fresh fetch.

## Local verification

`cargo clippy --workspace --lib --bins --tests --examples -- -D warnings` is clean.

`cargo test --workspace --no-fail-fast` was run on this branch and on `origin/main` and the failing test binaries diffed: **72 on this branch, 73 on main, zero branch-only**. This machine has no fixture cache, so those 72 are the data-dependent binaries failing identically on both sides. The one main-only failure was `yamc-gpu --lib`, which passes on both when run alone (216 passed); it was GPU contention from two concurrent cargo runs.
