### PR TITLE
Count use_decay_photons as photons in flight

### DIFF
--- a/crates/yamc-convert/tests/section_values_photon.rs
+++ b/crates/yamc-convert/tests/section_values_photon.rs
@@ -1731,7 +1731,10 @@ fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisi
         .map(|&c| f64_list(&batch, c, 0))
         .collect();
     for (col, values) in LIST_COLUMNS.iter().zip(&written) {
-        assert!(!values.is_empty(), "{col} is empty, so a swap with it is invisible");
+        assert!(
+            !values.is_empty(),
+            "{col} is empty, so a swap with it is invisible"
+        );
     }
 
     // The property this element exists for.

--- a/crates/yamc/src/model.rs
+++ b/crates/yamc/src/model.rs
@@ -453,6 +453,7 @@ impl Model {
     /// no flag. Mirrors the native auto-enable in `simulate_transport`.
     pub fn has_photons(&self) -> bool {
         self.transport_secondary_photons
+            || self.use_decay_photons
             || self
                 .sources
                 .iter()
@@ -3111,6 +3112,51 @@ mod tests {
     use yamc_source::source::{
         ParticleSource, Source, SourceEnergyDistribution, SourceSpatialDistribution,
     };
+
+    /// `use_decay_photons` puts photons in flight, so the predicate that gates
+    /// photon data has to count it. It did not.
+    ///
+    /// The gap was invisible from Python, whose constructor refuses
+    /// `use_decay_photons` without `transport_secondary_photons`, so the two
+    /// flags can never disagree there. From Rust, which has no such
+    /// validation, it was a trap: the model reported no photons, so
+    /// `ensure_photon_data_for_gpu` returned before its missing-data check,
+    /// and the coupled path then panicked where that check exists to produce a
+    /// clean error. Issue #43.
+    ///
+    /// No nuclear data is read, so this runs anywhere.
+    #[test]
+    fn a_decay_photon_model_reports_photons() {
+        let sphere = Arc::new(Surface::sphere(
+            0.0,
+            0.0,
+            0.0,
+            10.0,
+            Some(1),
+            Some(BoundaryType::Vacuum),
+        ));
+        let mat = Material::new(
+            HashMap::from([("Fe56".into(), 1.0)]),
+            "atom",
+            "g/cm3",
+            Some(7.874),
+        )
+        .unwrap();
+        let region = Region::new_from_halfspace(HalfspaceType::Below(sphere));
+        let cell = Cell::new(Some(1), region, None, Some(0));
+        let geometry = Geometry::new(vec![cell], vec![Arc::new(mat)]).unwrap();
+        let mut model = Model::new(geometry, vec![], vec![]);
+
+        // Neither flag, no photon source: nothing in flight, nothing to load.
+        assert!(!model.has_photons());
+        assert!(model.required_elements().is_empty());
+
+        // Decay photons alone. This is the state Python forbids and Rust
+        // allows, and the one the predicate used to miss.
+        model.use_decay_photons = true;
+        assert!(model.has_photons());
+        assert_eq!(model.required_elements(), vec!["Fe".to_string()]);
+    }
 
     /// Smoke test: run photon transport through an Fe sphere.
     /// Verifies the transport loop doesn't crash and particles are processed.

--- a/crates/yamc/tests/option_matrix.rs
+++ b/crates/yamc/tests/option_matrix.rs
@@ -412,18 +412,19 @@ mod gpu_guards {
     /// It sets `use_decay_photons` ALONE. The Python constructor rejects that
     /// outright ("use_decay_photons=True requires transport_secondary_photons
     /// =True", `yamc-python/src/simulation/model.rs:277`), so no supported
-    /// caller can produce this model. That matters because `has_photons()`
-    /// (`yamc/src/model.rs:454`) does not count `use_decay_photons`, so with
-    /// only that flag set the model reports "no photons", and
-    /// `ensure_photon_data_for_gpu` returns early WITHOUT running its
-    /// missing-photon-data check. That check exists precisely to turn this into
-    /// a clean message rather than a panic, and its own comment says so.
+    /// caller can produce this model.
     ///
-    /// With the invariant respected the guard fires and the error is about
-    /// photon data, which is what the sibling
-    /// `gpu_coupled_requires_photon_data` already asserts. So to test what THIS
-    /// test wants, the model needs photon data PRESENT and decay data absent,
-    /// which means the two-fixture material `gpu_coupled_photon.rs` builds.
+    /// The third problem is fixed: `has_photons()` now counts
+    /// `use_decay_photons`, so this model no longer reports "no photons" and
+    /// `ensure_photon_data_for_gpu` no longer skips its missing-photon-data
+    /// check. `a_decay_photon_model_reports_photons` in `yamc/src/model.rs`
+    /// pins that.
+    ///
+    /// With the guard now firing the error is about photon data, which is what
+    /// the sibling `gpu_coupled_requires_photon_data` already asserts. So to
+    /// test what THIS test wants, reaching decay-data preparation, the model
+    /// needs photon data PRESENT and decay data absent, which means the
+    /// two-fixture material `gpu_coupled_photon.rs` builds.
     ///
     /// And it still could not get there: `neutron_csg_model()` uses
     /// `build_csg()`, whose "inside the sphere" is `Complement(Above(..))`, and


### PR DESCRIPTION
Fixes #43, taking the one-line fix my own analysis on that issue arrived at, after reading every call site rather than assuming.

`Model::has_photons()` counted `transport_secondary_photons` and photon sources but not `use_decay_photons`, while the GPU dispatch routes on either flag and a comment there already asserts the implication. The predicate disagreed with what both the dispatch and the Python constructor believe.

From Python the two flags cannot disagree, since the constructor refuses `use_decay_photons` without `transport_secondary_photons`, which is why this stayed invisible. From Rust, which has no such validation, it was a trap: the model reported no photons, `ensure_photon_data_for_gpu` returned before its missing-photon-data check, and the coupled path then panicked at exactly the point that check exists to turn into a clean error.

**All five call sites read before changing the predicate**, since it newly reports true for a decay-photon model:

| site | verdict |
|---|---|
| `required_elements` (`model.rs:482`) | correct: a decay-photon model does need photon data per element |
| `ensure_photon_data_for_gpu` (`model.rs:1080`) | correct, and the point of the fix; its own comment already reasons this way |
| tally gate (`model.rs:1667`) | correct: decay photons are in flight, so a photon-scoring tally can score |
| wasm (`simulation_wasm.rs:751`) | cannot change: wasm never sets `use_decay_photons`, zero occurrences |
| Python accessor (`yamc-python/.../model.rs:434`) | unchanged for any Python caller, by the invariant above |

A unit test pins the predicate and `required_elements` for a decay-photon-only model. It reads no nuclear data, so it runs anywhere. The ignored test in `option_matrix.rs` loses one of its three stated reasons and keeps the other two, so its comment now says which rather than naming a cause that no longer holds.

**Two things this PR carries that need saying.**

It includes a one-line rustfmt wrap in `crates/yamc-convert/tests/section_values_photon.rs`. That is not mine: c97a313 landed it unformatted, `cargo fmt --check` fails on `main` as it stands, and the Rust CI job on `main` went from success to failure at 19:23 today. This branch cannot pass its own format gate without it.

Three tests in `model::tests` fail on this branch, and they fail identically on unmodified `main` with the same fixtures, so they are not from this change. The reason is worth recording: `tests/Fe.arrow/element.arrow` has columns the schema does not declare, namely `heating_xs`. c97a313 removed that column from the photon schema while the published data still carries it. I checked both ends: the photon data rebuilt today has no `heating_xs` and the copy downloaded from the CDN does, so the regeneration now running is what closes it.
