### PR TITLE
Expect the 2026-09-08 data

### DIFF
--- a/crates/yamc-nuclide/src/storage/url_cache.rs
+++ b/crates/yamc-nuclide/src/storage/url_cache.rs
@@ -462,15 +462,23 @@ const EXPECTED_DATA_VERSION: &[(&str, &str)] = &[
     // nothing to pin for it there.
     //
     // This pin has to move with a republish. The previous value was
-    // "2026-08-21", and leaving it behind does not serve stale data: it fails
+    // "2026-09-02", and leaving it behind does not serve stale data: it fails
     // every fresh download outright, because the stamp the origin now carries
     // no longer matches what this build expects.
-    ("tendl-2025", "2026-09-02"),
-    ("tendl-2017", "2026-09-02"),
-    ("fendl-3.2d", "2026-09-02"),
-    ("endf-b8.1", "2026-09-02"),
-    ("jeff-4.0", "2026-09-02"),
-    ("jendl-5.0", "2026-09-02"),
+    //
+    // The 2026-09-08 rebuild is the first carrying the placeholder and decay
+    // consistency records in the transmutation provenance, isomer excitation
+    // energies read from the decay headers, TENDL branching scoped to TENDL's
+    // own parents, and photon sections without the heating column this schema
+    // stopped declaring. A released wheel pinning 2026-09-02 can read none of
+    // it, and one pinning this can read none of what came before, which is the
+    // coupling issue #366 accepted and #28 in the generation scripts is about.
+    ("tendl-2025", "2026-09-08"),
+    ("tendl-2017", "2026-09-08"),
+    ("fendl-3.2d", "2026-09-08"),
+    ("endf-b8.1", "2026-09-08"),
+    ("jeff-4.0", "2026-09-08"),
+    ("jendl-5.0", "2026-09-08"),
 ];
 
 /// The `data_version` this build expects for `source`, if it pins one.


### PR DESCRIPTION
All six libraries were republished on 2026-09-08 and are live. I checked each one on both a plain and a cache-busted fetch, so this is the edge agreeing with the origin rather than a stale copy:

| library | neutron | transmutation | photon |
|---|---|---|---|
| endf-b8.1 | 2026-09-08 | 2026-09-08 | 2026-09-08 |
| jeff-4.0 | 2026-09-08 | 2026-09-08 | n/a |
| jendl-5.0 | 2026-09-08 | 2026-09-08 | 2026-09-08 |
| tendl-2017 | 2026-09-08 | 2026-09-08 | n/a |
| tendl-2025 | 2026-09-08 | 2026-09-08 | n/a |
| fendl-3.2d | 2026-09-08 | n/a | 2026-09-08 |

A build pinning `2026-09-02` refuses every fresh download against them. Verified rather than assumed, with a real load on a cleared cache:

```
Failed to load transmutation chain: 'endf-b8.1' was downloaded fresh and still
reports data_version "2026-09-08", but this build of yamc expects "2026-09-02".
```

**No version bump.** 0.16.0 and 0.11.0 are committed and neither has reached PyPI, so this rides them rather than earning new numbers.

The comment above the table is updated to name the previous value and say what the rebuild carries: the placeholder and decay-consistency records in the transmutation provenance, isomer excitation energies read from the decay headers, TENDL branching scoped to TENDL's own parents, and photon sections without the heating column the schema stopped declaring.

That last one is worth noting for review. `test_handle_photon_collision_fe`, `test_coupled_neutron_gamma_fe_sphere` and `test_transport_secondary_photons_fe_sphere` have been failing on `main` since #70, because it removed `heating_xs` from the photon schema while the published data still carried it. With the republished data they pass, which I confirmed on an unmodified `main` checkout with freshly fetched fixtures.