### PR TITLE
Format section_values_photon.rs

### DIFF
--- a/crates/yamc-convert/tests/section_values_photon.rs
+++ b/crates/yamc-convert/tests/section_values_photon.rs
@@ -1731,7 +1731,10 @@ fn constructed_element_columns_are_pairwise_distinct_so_no_permutation_is_invisi
         .map(|&c| f64_list(&batch, c, 0))
         .collect();
     for (col, values) in LIST_COLUMNS.iter().zip(&written) {
-        assert!(!values.is_empty(), "{col} is empty, so a swap with it is invisible");
+        assert!(
+            !values.is_empty(),
+            "{col} is empty, so a swap with it is invisible"
+        );
     }
 
     // The property this element exists for.


### PR DESCRIPTION
`cargo fmt --check` fails on `main`. #70 landed one `assert!` unformatted at `crates/yamc-convert/tests/section_values_photon.rs:1731`, so the Rust CI job has been red on main since 2026-09-08, going from success at 18:56 to failure at 19:23, and it fails on every branch cut from main since.

It is currently the only thing failing on #72, whose four red Rust jobs all report the same diff and nothing else.

Pulled out on its own so it can land immediately and unblock the release sequence, rather than riding #71 where it was an incidental passenger. #71 and #72 both want rebasing onto this.

rustfmt's own output, nothing else touched.