### PR TITLE
Refuse to transmute a material whose own nuclides cannot be loaded

### DIFF
--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -593,24 +593,71 @@ pub fn preload_activation_data(
         // bytes and the scope, and `scope` is one value for every item, so the
         // results do not depend on the order they are produced in -- nor does
         // the map they land in, which is keyed by name (issue #576, finding 5a).
-        let decoded: Vec<(String, std::sync::Arc<yamc_nuclide::Nuclide>)> = {
+        // A nuclide the material is MADE of is not optional. `to_load` is the
+        // reachable chain closure, most of which is daughters and
+        // grand-daughters: a library may legitimately not publish one of those,
+        // and dropping it understates a second-generation inventory. Dropping a
+        // nuclide from the composition is different in kind, because the foil
+        // then cannot activate at all and the solve returns a decay curve for
+        // an unirradiated material with no indication that anything is wrong.
+        //
+        // Observed on fendl-3.2d, which publishes 61 elements: an osmium foil
+        // solved in 0.4 s, reported C/E 0.000 at all 21 cooling points, and
+        // said nothing. The precise error already exists one layer down
+        // ("Nuclide 'Os190' is not available in 'fendl-3.2d'.") and was being
+        // discarded by the `.ok()` this replaces.
+        let composition: HashSet<&str> =
+            material.nuclides.keys().map(|s| s.as_str()).collect();
+        let decoded: Vec<
+            Result<Option<(String, std::sync::Arc<yamc_nuclide::Nuclide>)>, String>,
+        > = {
             let load_one = |(name, path): (String, String)| {
                 let sources = HashMap::from([(name.clone(), path)]);
-                get_or_load_nuclide(&name, &sources, &scope)
-                    .ok()
-                    .map(|nd| (name, nd))
+                match get_or_load_nuclide(&name, &sources, &scope) {
+                    Ok(nd) => Ok(Some((name, nd))),
+                    Err(error) if composition.contains(name.as_str()) => {
+                        // Just the first line. The underlying error appends the
+                        // library's whole published index, which is useful once
+                        // and unreadable seven times over, and a foil element
+                        // has one entry per natural isotope.
+                        let text = error.to_string();
+                        Err(text.lines().next().unwrap_or(&text).to_string())
+                    }
+                    // A daughter the library does not publish. Tolerated, as
+                    // before, so a partial network still runs.
+                    Err(_) => Ok(None),
+                }
             };
             #[cfg(not(target_arch = "wasm32"))]
             {
                 use rayon::prelude::*;
-                to_load.into_par_iter().filter_map(load_one).collect()
+                to_load.into_par_iter().map(load_one).collect()
             }
             #[cfg(target_arch = "wasm32")]
             {
-                to_load.into_iter().filter_map(load_one).collect()
+                to_load.into_iter().map(load_one).collect()
             }
         };
-        for (name, nd) in decoded {
+        let mut refused: Vec<String> = Vec::new();
+        let mut loaded = Vec::new();
+        for outcome in decoded {
+            match outcome {
+                Ok(Some(pair)) => loaded.push(pair),
+                Ok(None) => {}
+                Err(message) => refused.push(message),
+            }
+        }
+        if !refused.is_empty() {
+            refused.sort();
+            return Err(format!(
+                "cross sections could not be loaded for {} nuclide(s) the \
+                 material is made of, so it cannot activate:\n  {}",
+                refused.len(),
+                refused.join("\n  ")
+            )
+            .into());
+        }
+        for (name, nd) in loaded {
             material.nuclide_data.insert(name, nd);
         }
     }

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -606,11 +606,8 @@ pub fn preload_activation_data(
         // said nothing. The precise error already exists one layer down
         // ("Nuclide 'Os190' is not available in 'fendl-3.2d'.") and was being
         // discarded by the `.ok()` this replaces.
-        let composition: HashSet<&str> =
-            material.nuclides.keys().map(|s| s.as_str()).collect();
-        let decoded: Vec<
-            Result<Option<(String, std::sync::Arc<yamc_nuclide::Nuclide>)>, String>,
-        > = {
+        let composition: HashSet<&str> = material.nuclides.keys().map(|s| s.as_str()).collect();
+        let decoded: Vec<Result<Option<(String, std::sync::Arc<yamc_nuclide::Nuclide>)>, String>> = {
             let load_one = |(name, path): (String, String)| {
                 let sources = HashMap::from([(name.clone(), path)]);
                 match get_or_load_nuclide(&name, &sources, &scope) {

--- a/crates/yani-transmute/src/material_transmute.rs
+++ b/crates/yani-transmute/src/material_transmute.rs
@@ -607,7 +607,7 @@ pub fn preload_activation_data(
         // ("Nuclide 'Os190' is not available in 'fendl-3.2d'.") and was being
         // discarded by the `.ok()` this replaces.
         let composition: HashSet<&str> = material.nuclides.keys().map(|s| s.as_str()).collect();
-        let decoded: Vec<Result<Option<(String, std::sync::Arc<yamc_nuclide::Nuclide>)>, String>> = {
+        let decoded: Vec<LoadOutcome> = {
             let load_one = |(name, path): (String, String)| {
                 let sources = HashMap::from([(name.clone(), path)]);
                 match get_or_load_nuclide(&name, &sources, &scope) {
@@ -1019,6 +1019,12 @@ pub(crate) fn fold_branching_into_chain(
 }
 
 /// Build the fold's per-target fraction map into `refine`.
+/// What one nuclide's cross-section load produced.
+///
+/// `Ok(Some(..))` loaded, `Ok(None)` absent and tolerable because it is a chain
+/// daughter rather than something the material is made of, and `Err` refused.
+type LoadOutcome = Result<Option<(String, std::sync::Arc<yamc_nuclide::Nuclide>)>, String>;
+
 fn build_fold_refine(
     material: &Material,
     chain: &Arc<HashMap<String, ChainNuclide>>,


### PR DESCRIPTION
## The bug

`crates/yani-transmute/src/material_transmute.rs`, in `preload_activation_data`:

```rust
get_or_load_nuclide(&name, &sources, &scope)
    .ok()
    .map(|nd| (name, nd))
```

Inside a `filter_map`, so every nuclide whose cross sections cannot be loaded is
silently dropped from `material.nuclide_data`. Downstream, `multigroup.rs` turns
the absent entry into `None` and `continue`s past it, and the collapse returns
no rates for it. Nothing in the return type can express the gap.

The error being discarded is already precise and already constructed:

```
Nuclide 'Os190' is not available in 'fendl-3.2d'.
```

`yamc-materials/src/material/loading.rs` does the same load with `?` and
reports it properly, so the two entry points to the same material disagree
about whether a missing evaluation is an error.

## Why it matters

The result is not a smaller answer, it is a confident wrong one.

An osmium foil on `fendl-3.2d` (61 elements, no osmium) solved in **0.4 s**, and
returned **C/E 0.000 at all 21 cooling points** with no diagnostic. Read off a
benchmark page that says FENDL-3.2d is a bad library for osmium. It says FENDL
has no osmium.

Across the FNS decay-heat benchmark this is **22 of 132 experiments** on that
combination. Three fail on a downstream zero-heat guard; **19 are scored**, at
86% to 100% mean deviation, and enter the library's published median.

## Why only the composition is fatal

`to_load` is not the composition, it is the **reachable chain closure**
(`yani::reachable_nuclides` from the composition seeds). Seeding from iron
reaches 182 nuclides on ENDF/B-VIII.1, many of them daughters and
grand-daughters that a library may legitimately not publish.

Failing on all of those would break combinations that work today, and it would
be wrong: a missing daughter understates a second-generation inventory, which
is a library being incomplete. A missing **composition** nuclide means the
material cannot activate at all, which is a library being absent. Only the
second is refused.

## The error

Aggregated, and trimmed to one line per nuclide, because the underlying error
appends the library's entire published index and a foil element has one entry
per natural isotope:

```
ValueError: cross sections could not be loaded for 7 nuclide(s) the material is
made of, so it cannot activate:
  Nuclide 'Os184' is not available in 'fendl-3.2d'.
  Nuclide 'Os186' is not available in 'fendl-3.2d'.
  ...
  Nuclide 'Os192' is not available in 'fendl-3.2d'.
```

## Verification

End to end, with a release build:

| case | before | after |
| --- | --- | --- |
| Os/2000exp_5min on fendl-3.2d | 100.0% mean deviation, C/E 0.000 | raises |
| Fe/2000exp_5min on tendl-2017+decay-2012 | 7.336% | 7.336% (bit-identical) |
| W/2000exp_5min on tendl-2017+decay-2012 | 83.707% | 83.707% (bit-identical) |
| Fe/2000exp_5min on endf-b8.1 | 4.879% | 4.879% (bit-identical) |
| W/2000exp_5min on endf-b8.1 | 78.864% | 78.864% (bit-identical) |

`cargo test -p yani-transmute --lib`: 116 passed.

Note the `tests/data_uncertainty.rs` integration tests fail both with and
without this change, on `main` as well, because they build a fixture directory
this machine has no data for (`read Fe56: ".../Fe56.arrow/reactions.arrow": No
such file or directory`). Unrelated to this PR.

## Related

The harness-side complement is
`yani-verification-and-validation#14`, which screens a foil's composition
against the selected library before spending a solve. That one stops the
benchmark scoring a coverage gap; this one stops yani producing it.