### PR TITLE
Say that the branching subsection is also a source of cross sections

### DIFF
--- a/crates/yani/src/chain.rs
+++ b/crates/yani/src/chain.rs
@@ -47,6 +47,32 @@ pub enum BranchQuantity {
 /// (parent, reaction, final-state) triple, as stored in the `branching/`
 /// subsection. The overlay folds these against the transport spectrum at
 /// rate-compute time to obtain flux-weighted branching fractions.
+///
+/// # The branching subsection is a second source of cross sections
+///
+/// Worth stating plainly, because the name says "branch ratios" and the
+/// setting sits beside `cross_section_data` as though the two were disjoint.
+/// A [`BranchQuantity::CrossSection`] curve is a partial cross section in
+/// barns, not a dimensionless fraction, and for `(n,n')` it is the *only*
+/// thing the metastable production rate is computed from: `build_fold_refine`
+/// folds it directly and grafts the result into the rates, without consulting
+/// the parent's own evaluation at all.
+///
+/// Two consequences follow, and neither is obvious from the setting names.
+///
+/// * A run that names one library for `cross_section_data` and another for
+///   `transmutation_branch_ratios` is taking cross sections from both. On the
+///   published 2026-09-08 TENDL-2025 build, 39409 of the 40905 branching rows
+///   are `CrossSection` rather than `Yield`, so this is the common case and
+///   not a corner.
+/// * Changing only the branching source therefore changes rates, not just how
+///   an existing rate is split. On the FNS decay-heat benchmark, moving that
+///   one setting from TENDL-2017 to ENDF/B-VIII.1 and holding the other four
+///   fixed moves 78 of 132 experiments by more than a point and drops the
+///   count agreeing within 10% from 64 to 38.
+///
+/// Anything reporting the provenance of a result should name the branching
+/// source among its cross-section inputs, not only among its branching ones.
 #[derive(Clone, Debug)]
 pub struct BranchCurve {
     /// Final-state nuclide (GNDS name, e.g. "Ag110" ground or "Ag110_m1").


### PR DESCRIPTION
## What this is

Documentation only. No behaviour change, no number changes, 116 tests still
pass.

## Why

yani sources five things independently, and two of them are called
`cross_section_data` and `transmutation_branch_ratios`. The names imply the
second supplies dimensionless fractions. It does not:

* a `BranchQuantity::CrossSection` curve is a **partial cross section in
  barns**;
* for `(n,n')`, `build_fold_refine` folds that curve directly and grafts the
  result into the rate table **without consulting the parent's own evaluation
  at all**;
* on the published 2026-09-08 TENDL-2025 build, **39409 of 40905** branching
  rows are `CrossSection` rather than `Yield`. This is the common case.

## How I found out, and why it is worth writing down

I was investigating an osmium foil that scored 25.1% on a combination naming
`fendl-3.2d` for cross sections. FENDL-3.2d publishes 61 elements and no
osmium, so the foil should not have activated at all.

I built an isolated cache containing only FENDL's 191 nuclides, the TENDL-2025
chain and ENDF decay, blocked the network, and it still produced a full decay
curve carried by Os190m, Os189m and Os192m. My first conclusion was that rates
were being fabricated.

They were not. Every one of those rates is a real evaluated MF=10 partial cross
section from TENDL-2025, folded against the real spectrum. The design is
correct and the naming is what misled me.

Two consequences follow that are genuinely surprising from the setting names,
and both matter for anyone reading a result:

* A run naming one library for cross sections and another for branching is
  **taking cross sections from both**.
* Changing only the branching source **changes rates**, not just how an
  existing rate is split. On the FNS decay-heat benchmark, holding the other
  four settings fixed and moving branching from TENDL-2017 to ENDF/B-VIII.1
  moves 78 of 132 experiments by more than a point and drops the count agreeing
  within 10% from 64 to 38. That is the largest single-setting sensitivity in
  the benchmark.

## What I did not do

I first tried requiring the parent to have loaded cross sections before
grafting a rate onto it. That breaks
`material_transmute::tests::fold_nnprime_injects_rate_and_branching`, whose
fixture is explicitly "a minimal material (no cross-section data); enough for
the (n,n') path". The independence is deliberate and tested, and it is right:
an MF=10 partial is a complete description of its channel.

The osmium case is better fixed at the composition level, which is
`fix/composition-nuclide-must-load` (#76). With that in, a foil made of an
element the cross-section library does not publish raises before it reaches
this code.