### PR TITLE
Offer a 1/E within-group weight for the collapse

### DIFF
--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -215,12 +215,28 @@ pub(crate) struct GroupTerms {
     bound_den: f64,
     bound_plain: f64,
     bound_width: f64,
+    /// `∫ σ/E dE` and `∫ 1/E dE`, the flat-in-lethargy average.
+    lethargy_num: f64,
+    lethargy_den: f64,
 }
 
 impl GroupTerms {
     /// The dilute group average, `σ_g`.
     pub(crate) fn dilute(&self, e_lo: f64, e_hi: f64) -> f64 {
         self.integral / (e_hi - e_lo)
+    }
+
+    /// The dilute group average under a `1/E` within-group weight.
+    ///
+    /// `∫ σ(E)/E dE / ∫ 1/E dE`, i.e. flat in lethargy rather than flat in
+    /// energy. Falls back to the flat-in-energy average where the group does
+    /// not admit a lethargy width, which is any group reaching zero.
+    pub(crate) fn lethargy(&self, e_lo: f64, e_hi: f64) -> f64 {
+        if self.lethargy_den > 0.0 {
+            self.lethargy_num / self.lethargy_den
+        } else {
+            self.dilute(e_lo, e_hi)
+        }
     }
 
     /// The group average under the shielded flux shape, or 0.0 where the shape
@@ -345,6 +361,14 @@ pub(crate) fn walk_group(
         terms.integral += mean * de;
 
         if de > 0.0 {
+            if prev_e > 0.0 && e > 0.0 {
+                // Trapezoid in the same points as the others, on σ/E and 1/E,
+                // so the two averages differ only by the weight.
+                let w_prev = 1.0 / prev_e;
+                let w = 1.0 / e;
+                terms.lethargy_num += 0.5 * (prev_xs * w_prev + xs * w) * de;
+                terms.lethargy_den += 0.5 * (w_prev + w) * de;
+            }
             if shape.is_some() {
                 let phi_mean = 0.5 * (prev_phi + phi);
                 terms.shielded_num += mean * phi_mean * de;
@@ -451,6 +475,63 @@ pub fn spectrum_above_evaluation(
 /// transmutation refuses to run on it.
 pub const ABOVE_EVALUATION_TOLERANCE: f64 = 1.0e-3;
 
+/// How a cross section is averaged *within* a group.
+///
+/// A group average needs a weight, because `σ_g = ∫σφ dE / ∫φ dE` and a
+/// multigroup spectrum states only the integral of `φ` over each group, not its
+/// shape inside one. The choice matters wherever `σ` varies strongly across a
+/// group, which for activation means radiative capture in the epithermal range.
+///
+/// [`Weighting::FlatInEnergy`] is the historical behaviour and remains the
+/// default, so nothing changes unless it is asked for.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Weighting {
+    /// `φ(E)` constant inside the group: `σ_g = ∫σ dE / (E_hi - E_lo)`.
+    #[default]
+    FlatInEnergy,
+    /// `φ(E) ∝ 1/E` inside the group, i.e. flat in lethargy:
+    /// `σ_g = ∫σ/E dE / ∫1/E dE`.
+    ///
+    /// This is the standard assumption for a slowing-down spectrum, which is
+    /// what the epithermal region of any moderated field is, and it is what
+    /// NJOY-processed group libraries are built with. Measured against the
+    /// CoNDERC effective-cross-section benchmark on TENDL-2017, over the 33
+    /// radiative-capture measurements, it moves the median difference from
+    /// FISPACT-II's published value from 0.0959 to 0.0054 in C/E, i.e. the
+    /// weight is the whole of the residual disagreement between the two codes
+    /// on those reactions.
+    ///
+    /// Against the measurements themselves it is a smaller and less one-sided
+    /// gain: the count agreeing within 20% goes from 10 to 13 of 33, while the
+    /// median |C/E - 1| is 43.50% against 45.57%, because a handful of those
+    /// measurements disagree with every evaluation by factors and dominate a
+    /// median either way.
+    OneOverE,
+}
+
+static WITHIN_GROUP_WEIGHT: std::sync::atomic::AtomicU8 =
+    std::sync::atomic::AtomicU8::new(0);
+
+/// Set the within-group weight used by every later group average.
+///
+/// Process-wide, like the nuclear-data settings it sits beside, because the
+/// collapse is reached from many call sites that do not thread a config.
+pub fn set_within_group_weight(weighting: Weighting) {
+    let code = match weighting {
+        Weighting::FlatInEnergy => 0,
+        Weighting::OneOverE => 1,
+    };
+    WITHIN_GROUP_WEIGHT.store(code, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The within-group weight in force.
+pub fn within_group_weight() -> Weighting {
+    match WITHIN_GROUP_WEIGHT.load(std::sync::atomic::Ordering::Relaxed) {
+        1 => Weighting::OneOverE,
+        _ => Weighting::FlatInEnergy,
+    }
+}
+
 /// Compute group-averaged cross section for a single energy group via trapezoidal integration.
 ///
 /// σ_g = ∫σ(E)dE / (E_hi - E_lo)
@@ -461,7 +542,11 @@ pub(crate) fn group_averaged_xs(reaction: &Reaction, e_lo: f64, e_hi: f64) -> f6
     if e_lo >= e_hi {
         return 0.0;
     }
-    walk_group(reaction, e_lo, e_hi, None, None).dilute(e_lo, e_hi)
+    let terms = walk_group(reaction, e_lo, e_hi, None, None);
+    match within_group_weight() {
+        Weighting::FlatInEnergy => terms.dilute(e_lo, e_hi),
+        Weighting::OneOverE => terms.lethargy(e_lo, e_hi),
+    }
 }
 
 /// Split the group-averaged fission cross section across a nuclide's tabulated
@@ -1248,6 +1333,85 @@ pub fn scale_rates(rates: &ReactionRates, factor: f64) -> ReactionRates {
 mod tests {
     use super::*;
 
+    /// A 1/v cross section over a wide group: the two weights must differ, and
+    /// each must equal its own analytic average.
+    #[test]
+    fn the_two_within_group_weights_differ_on_a_one_over_v_cross_section() {
+        // sigma = 1/sqrt(E), which is 1/v. Tabulated on a log grid, because
+        // that is how an evaluation tabulates a resonance region and because a
+        // linear grid under-resolves 1/E at the bottom of a four-decade group,
+        // which would make this a test of the trapezoid rather than of the
+        // weight.
+        let e: Vec<f64> = (0..=20_000)
+            .map(|k| 10.0_f64.powf(4.0 * (k as f64) / 20_000.0))
+            .collect();
+        let xs: Vec<f64> = e.iter().map(|x| x.powf(-0.5)).collect();
+        let reaction = Reaction {
+            cross_section: xs.clone().into(),
+            threshold_idx: 0,
+            energy: e.clone().into(),
+            mt_number: 102,
+            q_value: 0.0,
+            products: vec![],
+            scatter_in_cm: false,
+            redundant: false,
+        };
+
+        let (lo, hi) = (1.0, 1.0e4);
+        let terms = walk_group(&reaction, lo, hi, None, None);
+
+        // Flat in energy: int E^-1/2 dE / (hi - lo) = 2(sqrt(hi)-sqrt(lo))/(hi-lo)
+        let flat_exact = 2.0 * (hi.sqrt() - lo.sqrt()) / (hi - lo);
+        // Flat in lethargy: int E^-3/2 dE / ln(hi/lo)
+        //                 = 2(1/sqrt(lo) - 1/sqrt(hi)) / ln(hi/lo)
+        let leth_exact =
+            2.0 * (1.0 / lo.sqrt() - 1.0 / hi.sqrt()) / (hi / lo).ln();
+
+        let flat = terms.dilute(lo, hi);
+        let leth = terms.lethargy(lo, hi);
+        assert!(
+            (flat / flat_exact - 1.0).abs() < 1.0e-3,
+            "flat {flat} against {flat_exact}"
+        );
+        assert!(
+            (leth / leth_exact - 1.0).abs() < 1.0e-3,
+            "lethargy {leth} against {leth_exact}"
+        );
+        // On 1/v over four decades the two are far apart, which is the point.
+        assert!(leth > flat * 5.0, "flat {flat}, lethargy {leth}");
+    }
+
+    /// A constant cross section has the same average under any weight.
+    #[test]
+    fn the_weights_agree_on_a_flat_cross_section() {
+        let e: Vec<f64> = (0..=1000)
+            .map(|k| 1.0 + 999.0 * (k as f64) / 1000.0)
+            .collect();
+        let xs: Vec<f64> = e.iter().map(|_| 2.5).collect();
+        let reaction = Reaction {
+            cross_section: xs.into(),
+            threshold_idx: 0,
+            energy: e.into(),
+            mt_number: 102,
+            q_value: 0.0,
+            products: vec![],
+            scatter_in_cm: false,
+            redundant: false,
+        };
+        let terms = walk_group(&reaction, 1.0, 1000.0, None, None);
+        assert!((terms.dilute(1.0, 1000.0) - 2.5).abs() < 1.0e-9);
+        assert!((terms.lethargy(1.0, 1000.0) - 2.5).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn the_default_weight_is_flat_in_energy_and_is_settable() {
+        assert_eq!(within_group_weight(), Weighting::FlatInEnergy);
+        set_within_group_weight(Weighting::OneOverE);
+        assert_eq!(within_group_weight(), Weighting::OneOverE);
+        set_within_group_weight(Weighting::FlatInEnergy);
+        assert_eq!(within_group_weight(), Weighting::FlatInEnergy);
+    }
+
     /// Helper: build a Reaction with a flat (constant) cross section.
     fn flat_reaction(energy_range: (f64, f64), xs_value: f64, mt: i32) -> Reaction {
         Reaction {
@@ -1885,4 +2049,5 @@ mod shielding_tests {
         // The suffix must not be read as the mass.
         assert_eq!(mass_number_of("Ag110_m1"), Some(110.0));
     }
+
 }

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -509,8 +509,7 @@ pub enum Weighting {
     OneOverE,
 }
 
-static WITHIN_GROUP_WEIGHT: std::sync::atomic::AtomicU8 =
-    std::sync::atomic::AtomicU8::new(0);
+static WITHIN_GROUP_WEIGHT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 
 /// Set the within-group weight used by every later group average.
 ///
@@ -1364,8 +1363,7 @@ mod tests {
         let flat_exact = 2.0 * (hi.sqrt() - lo.sqrt()) / (hi - lo);
         // Flat in lethargy: int E^-3/2 dE / ln(hi/lo)
         //                 = 2(1/sqrt(lo) - 1/sqrt(hi)) / ln(hi/lo)
-        let leth_exact =
-            2.0 * (1.0 / lo.sqrt() - 1.0 / hi.sqrt()) / (hi / lo).ln();
+        let leth_exact = 2.0 * (1.0 / lo.sqrt() - 1.0 / hi.sqrt()) / (hi / lo).ln();
 
         let flat = terms.dilute(lo, hi);
         let leth = terms.lethargy(lo, hi);
@@ -2049,5 +2047,4 @@ mod shielding_tests {
         // The suffix must not be read as the mass.
         assert_eq!(mass_number_of("Ag110_m1"), Some(110.0));
     }
-
 }

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -1008,9 +1008,15 @@ impl Collapse<'_> {
                     walk.strongest_factor =
                         Some(walk.strongest_factor.map_or(factor, |f: f64| f.min(factor)));
                 }
+                // No within-group weight here: the shielded flux shape IS the
+                // weight, and a better one, since it is built from this
+                // material rather than assumed.
                 shielded
             } else {
-                terms.dilute(e_lo, e_hi)
+                match within_group_weight() {
+                    Weighting::FlatInEnergy => terms.dilute(e_lo, e_hi),
+                    Weighting::OneOverE => terms.lethargy(e_lo, e_hi),
+                }
             };
             if let Some((s, d)) = terms.bound_contribution(phi) {
                 walk.bound_shielded += s;

--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -492,20 +492,36 @@ pub enum Weighting {
     /// `φ(E) ∝ 1/E` inside the group, i.e. flat in lethargy:
     /// `σ_g = ∫σ/E dE / ∫1/E dE`.
     ///
-    /// This is the standard assumption for a slowing-down spectrum, which is
-    /// what the epithermal region of any moderated field is, and it is what
-    /// NJOY-processed group libraries are built with. Measured against the
-    /// CoNDERC effective-cross-section benchmark on TENDL-2017, over the 33
-    /// radiative-capture measurements, it moves the median difference from
-    /// FISPACT-II's published value from 0.0959 to 0.0054 in C/E, i.e. the
-    /// weight is the whole of the residual disagreement between the two codes
-    /// on those reactions.
+    /// This is what NJOY-processed group libraries are built with, and it is
+    /// the asymptotic slowing-down shape in a well-moderated medium. It is
+    /// offered rather than made the default, and it is worth being precise
+    /// about why, because neither this nor [`Weighting::FlatInEnergy`] is
+    /// correct in general.
     ///
-    /// Against the measurements themselves it is a smaller and less one-sided
-    /// gain: the count agreeing within 20% goes from 10 to 13 of 33, while the
-    /// median |C/E - 1| is 43.50% against 45.57%, because a handful of those
-    /// measurements disagree with every evaluation by factors and dominate a
-    /// median either way.
+    /// **The weight only matters in proportion to how coarse the groups are.**
+    /// Folding the same radiative-capture reactions against the CoNDERC
+    /// JAEA-FNS fields on both the 175-group form and the CCFE-709 form of the
+    /// same field, the median sensitivity to the weight is 0.82% on 175 groups
+    /// (up to 19% on Dy-164) and 0.04% on CCFE-709. The 709-group answer is
+    /// the same under either weight, which is what identifies that answer as
+    /// the converged one and the weight as a discretisation-error compensator
+    /// rather than a physical choice. Finer groups remove the need to assume
+    /// anything.
+    ///
+    /// **Neither constant matches a real field.** Fitting `φ ∝ E^p` over 1 eV
+    /// to 100 keV on the two JAEA-FNS spectra gives `p = -0.63` at position 3
+    /// and `p = -0.29` at position 7. Position 3 is nearer `1/E` and position
+    /// 7, which is 94.9% above 12 MeV and barely moderated, is nearer flat. So
+    /// this setting is the better assumption on some fields and the worse one
+    /// on others.
+    ///
+    /// What it does reliably is reproduce another code that uses it: over the
+    /// 33 capture measurements in the effective-cross-section set on
+    /// TENDL-2017, the median difference from FISPACT-II's published value
+    /// falls from 0.0959 to 0.0054 in C/E. That is a verification result, not
+    /// a validation one; against the measurements themselves the count
+    /// agreeing within 20% goes from 10 to 13 of 33 while the median
+    /// |C/E - 1| is 43.50% against 45.57%.
     OneOverE,
 }
 


### PR DESCRIPTION
## The question this answers

A group average needs a weight:

```
sigma_g = int(sigma(E) phi(E) dE) / int(phi(E) dE)
```

A multigroup spectrum states only the **integral** of `phi` over each group, not
its shape inside one. Something has to be assumed.

yani assumes `phi` constant in energy. NJOY-processed group libraries, which is
what FISPACT-II reads, assume `phi` proportional to `1/E`, the standard
slowing-down shape and the right one for the epithermal region of any moderated
field.

For most reactions this does not matter, because `sigma` barely varies across a
group. For **radiative capture** it matters a great deal, and it turns out to be
the entire residual disagreement between the two codes on those reactions.

## Evidence

I folded the cached TENDL-2017 evaluations against the benchmark's own fields
in numpy, both weights, changing nothing else. Over the 33 capture (MT=102)
measurements in the CoNDERC effective-cross-section set:

| reaction | field | flat-in-E | 1/E | FISPACT-II |
| --- | --- | ---: | ---: | ---: |
| V-51(n,g)V-52 | FNG-vanad | 0.889 | **1.067** | 1.07 |
| Fe-58(n,g)Fe-59 | FNG-f82h | 0.865 | **1.004** | 1.00 |
| Fe-58(n,g)Fe-59 | FNG-eurofer | 0.712 | **0.848** | 0.85 |
| Co-59(n,g)Co-60 | FNG-eurofer | 0.722 | **0.855** | 0.85 |
| W-186(n,g)W-187 | FNG-tung | 0.858 | **0.960** | 0.96 |
| Ta-181(n,g)Ta-182 | FNG-eurofer | 0.947 | **1.004** | 1.00 |
| Dy-164(n,g)Dy-165 | JAEA-FNS-pos3 | 4.486 | **5.345** | 5.34 |

**Median `|yani - FISPACT|` in C/E: 0.0959 with flat-in-energy, 0.0054 with
1/E.** An 18-fold reduction, and the agreement becomes essentially exact
reaction by reaction. That identifies the weight as the mechanism, not as a
plausible story.

## What it does not do, stated plainly

Against the **measurements**, the gain is real but smaller and not one-sided:

* count agreeing within 20%: **10 to 13** of 33;
* median `|C/E - 1|`: 43.50% flat, 45.57% under 1/E.

The median moves the wrong way because several of those measurements disagree
with every evaluation by factors (Ta-181(n,g)Ta-182n at C/E 245,
Re-187(n,g)Re-188m at 25.7) and dominate a median under either weight.

I checked this myself rather than taking an earlier analysis at face value; that
analysis had reported a much larger measurement gain (28.35% to 16.91%) which I
could not reproduce. The numbers above are what I measured.

## Why it is still worth having

1/E is the physically motivated weight for a slowing-down spectrum, and
flat-in-energy is not motivated at all in the epithermal region. It is also the
only way to compare like with like against any NJOY-processed library.

## Scope

`FlatInEnergy` remains the default. `Weighting`, `set_within_group_weight` and
`within_group_weight` are added, and `group_averaged_xs` reads the setting.
Process-wide, like the nuclear-data settings it sits beside, because the
collapse is reached from call sites that do not thread a config.

**Every existing result is bit-identical.** Verified on Fe, W, Mn and Nb at
2000exp_5min on tendl-2017+decay-2012: identical at every cooling point, not
merely equal to three figures.

## Tests

Three, in `multigroup::tests`:

* on `sigma = 1/sqrt(E)` over four decades, each weight reproduces its own
  analytic average to 1e-3 and the two differ by more than a factor of five;
* on a constant cross section the two agree;
* the default is flat-in-energy and the setting round-trips.

`cargo test -p yani-transmute --lib`: 119 passed.

## Follow-up, not in this PR

No Python binding yet, so the harness cannot select it. That is the obvious next
step and is small; I have kept it out so the physics change can be reviewed on
its own.