### PR TITLE
Make 1/E the default within-group weight

### DIFF
--- a/crates/yani-transmute/src/multigroup.rs
+++ b/crates/yani-transmute/src/multigroup.rs
@@ -487,7 +487,9 @@ pub const ABOVE_EVALUATION_TOLERANCE: f64 = 1.0e-3;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Weighting {
     /// `φ(E)` constant inside the group: `σ_g = ∫σ dE / (E_hi - E_lo)`.
-    #[default]
+    ///
+    /// Kept selectable to reproduce results produced before `OneOverE` became
+    /// the default, and for bit-exact regression against them.
     FlatInEnergy,
     /// `φ(E) ∝ 1/E` inside the group, i.e. flat in lethargy:
     /// `σ_g = ∫σ/E dE / ∫1/E dE`.
@@ -522,10 +524,17 @@ pub enum Weighting {
     /// a validation one; against the measurements themselves the count
     /// agreeing within 20% goes from 10 to 13 of 33 while the median
     /// |C/E - 1| is 43.50% against 45.57%.
+    #[default]
     OneOverE,
 }
 
-static WITHIN_GROUP_WEIGHT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+/// Nothing has called [`set_within_group_weight`], so [`Weighting::default`]
+/// decides. Held as a sentinel rather than as the default's own code so the two
+/// cannot drift apart when the default changes.
+const WEIGHT_UNSET: u8 = u8::MAX;
+
+static WITHIN_GROUP_WEIGHT: std::sync::atomic::AtomicU8 =
+    std::sync::atomic::AtomicU8::new(WEIGHT_UNSET);
 
 /// Set the within-group weight used by every later group average.
 ///
@@ -542,8 +551,9 @@ pub fn set_within_group_weight(weighting: Weighting) {
 /// The within-group weight in force.
 pub fn within_group_weight() -> Weighting {
     match WITHIN_GROUP_WEIGHT.load(std::sync::atomic::Ordering::Relaxed) {
-        1 => Weighting::OneOverE,
-        _ => Weighting::FlatInEnergy,
+        WEIGHT_UNSET => Weighting::default(),
+        0 => Weighting::FlatInEnergy,
+        _ => Weighting::OneOverE,
     }
 }
 
@@ -1348,6 +1358,21 @@ pub fn scale_rates(rates: &ReactionRates, factor: f64) -> ReactionRates {
 mod tests {
     use super::*;
 
+    /// The flat-in-energy group average, whatever the process-wide setting is.
+    ///
+    /// Every test below was written to check the structure of the walk -- that
+    /// a boundary on a grid point is not counted twice, that a threshold flag
+    /// is read, that a duplicated energy stays bit-identical -- by comparing
+    /// against a hand-computed flat average. Routing them through
+    /// `group_averaged_xs` would make each one also a test of which weight is
+    /// currently selected, which is not what any of them is for.
+    fn flat_group_average(reaction: &Reaction, e_lo: f64, e_hi: f64) -> f64 {
+        if e_lo >= e_hi {
+            return 0.0;
+        }
+        walk_group(reaction, e_lo, e_hi, None, None).dilute(e_lo, e_hi)
+    }
+
     /// A 1/v cross section over a wide group: the two weights must differ, and
     /// each must equal its own analytic average.
     #[test]
@@ -1418,12 +1443,13 @@ mod tests {
     }
 
     #[test]
-    fn the_default_weight_is_flat_in_energy_and_is_settable() {
-        assert_eq!(within_group_weight(), Weighting::FlatInEnergy);
-        set_within_group_weight(Weighting::OneOverE);
+    fn the_default_weight_is_one_over_e_and_is_settable() {
+        assert_eq!(Weighting::default(), Weighting::OneOverE);
         assert_eq!(within_group_weight(), Weighting::OneOverE);
         set_within_group_weight(Weighting::FlatInEnergy);
         assert_eq!(within_group_weight(), Weighting::FlatInEnergy);
+        set_within_group_weight(Weighting::OneOverE);
+        assert_eq!(within_group_weight(), Weighting::OneOverE);
     }
 
     /// Helper: build a Reaction with a flat (constant) cross section.
@@ -1460,14 +1486,14 @@ mod tests {
         let rxn = flat_reaction((1.0, 1e6), 10.0, 102);
 
         // Group that spans the whole range
-        let avg = group_averaged_xs(&rxn, 1.0, 1e6);
+        let avg = flat_group_average(&rxn, 1.0, 1e6);
         assert!(
             (avg - 10.0).abs() < 1e-10,
             "Flat XS should average to 10.0, got {avg}"
         );
 
         // Subgroup should also be 10.0
-        let avg2 = group_averaged_xs(&rxn, 100.0, 1000.0);
+        let avg2 = flat_group_average(&rxn, 100.0, 1000.0);
         assert!(
             (avg2 - 10.0).abs() < 1e-10,
             "Flat XS subgroup should be 10.0, got {avg2}"
@@ -1481,12 +1507,12 @@ mod tests {
     fn the_average_stops_at_the_evaluations_last_point() {
         let rxn = flat_reaction((1e6, 1e7), 2.0, 16);
         // Half of this group is above the grid.
-        let avg = group_averaged_xs(&rxn, 5e6, 1.5e7);
+        let avg = flat_group_average(&rxn, 5e6, 1.5e7);
         assert!((avg - 1.0).abs() < 1e-12, "got {avg}");
         // All of it.
-        assert_eq!(group_averaged_xs(&rxn, 2e7, 3e7), 0.0);
+        assert_eq!(flat_group_average(&rxn, 2e7, 3e7), 0.0);
         // None of it: unchanged.
-        assert!((group_averaged_xs(&rxn, 2e6, 4e6) - 2.0).abs() < 1e-12);
+        assert!((flat_group_average(&rxn, 2e6, 4e6) - 2.0).abs() < 1e-12);
     }
 
     #[test]
@@ -1511,7 +1537,7 @@ mod tests {
         let rxn = ramp_reaction(0.0, 1e6, 0.0, 100.0, 102);
 
         // Average of a linear function over full range = (0 + 100) / 2 = 50
-        let avg = group_averaged_xs(&rxn, 0.0, 1e6);
+        let avg = flat_group_average(&rxn, 0.0, 1e6);
         assert!(
             (avg - 50.0).abs() < 1e-6,
             "Ramp XS average should be 50.0, got {avg}"
@@ -1533,14 +1559,14 @@ mod tests {
         };
 
         // Group entirely below threshold
-        let avg_below = group_averaged_xs(&rxn, 1.0, 1e4);
+        let avg_below = flat_group_average(&rxn, 1.0, 1e4);
         assert!(
             avg_below.abs() < 1e-10,
             "Below threshold should be 0, got {avg_below}"
         );
 
         // Group spanning threshold
-        let avg_span = group_averaged_xs(&rxn, 1e4, 1e6);
+        let avg_span = flat_group_average(&rxn, 1e4, 1e6);
         assert!(
             avg_span > 0.0,
             "Spanning threshold should give non-zero average"
@@ -1550,7 +1576,7 @@ mod tests {
     #[test]
     fn test_group_averaged_xs_zero_width() {
         let rxn = flat_reaction((1.0, 1e6), 10.0, 102);
-        let avg = group_averaged_xs(&rxn, 100.0, 100.0);
+        let avg = flat_group_average(&rxn, 100.0, 100.0);
         assert!(avg.abs() < 1e-10, "Zero-width group should return 0");
     }
 
@@ -1588,7 +1614,7 @@ mod tests {
     }
 
     /// The trapezoid rule over the old point set, to the bit.
-    fn scanned_group_averaged_xs(reaction: &Reaction, e_lo: f64, e_hi: f64) -> f64 {
+    fn scanned_flat_group_average(reaction: &Reaction, e_lo: f64, e_hi: f64) -> f64 {
         if e_lo >= e_hi {
             return 0.0;
         }
@@ -1667,8 +1693,8 @@ mod tests {
                 (2.0, 3.0),
             ] {
                 assert_eq!(
-                    group_averaged_xs(&rxn, e_lo, e_hi).to_bits(),
-                    scanned_group_averaged_xs(&rxn, e_lo, e_hi).to_bits(),
+                    flat_group_average(&rxn, e_lo, e_hi).to_bits(),
+                    scanned_flat_group_average(&rxn, e_lo, e_hi).to_bits(),
                     "group ({e_lo}, {e_hi}) moved"
                 );
             }
@@ -1681,23 +1707,23 @@ mod tests {
 
         // A threshold reaction is zero below its first grid point.
         rxn.threshold_idx = 1;
-        assert_eq!(group_averaged_xs(&rxn, 1.0, 5.0), 0.0);
+        assert_eq!(flat_group_average(&rxn, 1.0, 5.0), 0.0);
 
         // A non-threshold one (capture, say) is flat-clamped to its first value.
         rxn.threshold_idx = 0;
-        assert_eq!(group_averaged_xs(&rxn, 1.0, 5.0), 3.0);
+        assert_eq!(flat_group_average(&rxn, 1.0, 5.0), 3.0);
 
         // Above the last grid point there is no cross section either way:
         // `cross_section_at` holds its last value up there for a single
         // lookup, but an integral over energies the evaluation never reached
         // counts nothing.
-        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 0.0);
+        assert_eq!(flat_group_average(&rxn, 30.0, 40.0), 0.0);
         rxn.threshold_idx = 1;
-        assert_eq!(group_averaged_xs(&rxn, 30.0, 40.0), 0.0);
+        assert_eq!(flat_group_average(&rxn, 30.0, 40.0), 0.0);
         // A group straddling the end integrates to the end and no further:
         // 4.0 over half the group.
         assert_eq!(
-            group_averaged_xs(&rxn, 15.0, 25.0),
+            flat_group_average(&rxn, 15.0, 25.0),
             (0.5 * (3.5 + 4.0) * 5.0) / 10.0
         );
     }
@@ -1708,7 +1734,7 @@ mod tests {
         // `unwrap_or(0.0)` turns into a zero integrand rather than an index
         // out of bounds.
         let rxn = on_grid(vec![], vec![]);
-        assert_eq!(group_averaged_xs(&rxn, 1.0, 100.0), 0.0);
+        assert_eq!(flat_group_average(&rxn, 1.0, 100.0), 0.0);
     }
 
     #[test]
@@ -1717,9 +1743,9 @@ mod tests {
         // halves must add back to the whole, which they cannot if a shared
         // boundary appears as both an interior point and an edge.
         let rxn = on_grid(vec![0.0, 10.0, 20.0], vec![0.0, 10.0, 20.0]);
-        let whole = group_averaged_xs(&rxn, 0.0, 20.0) * 20.0;
-        let lower = group_averaged_xs(&rxn, 0.0, 10.0) * 10.0;
-        let upper = group_averaged_xs(&rxn, 10.0, 20.0) * 10.0;
+        let whole = flat_group_average(&rxn, 0.0, 20.0) * 20.0;
+        let lower = flat_group_average(&rxn, 0.0, 10.0) * 10.0;
+        let upper = flat_group_average(&rxn, 10.0, 20.0) * 10.0;
         assert!(
             (whole - (lower + upper)).abs() < 1e-12 * whole,
             "{whole} != {lower} + {upper}"
@@ -1788,7 +1814,7 @@ mod tests {
                 &mut out,
             );
             let split: f64 = out.iter().sum();
-            let whole = group_averaged_xs(&rxn, e_lo, e_hi);
+            let whole = flat_group_average(&rxn, e_lo, e_hi);
             assert!(
                 (split - whole).abs() <= 1e-12 * whole.abs().max(1.0),
                 "group ({e_lo}, {e_hi}): shares sum to {split}, group average is {whole}"
@@ -2014,7 +2040,7 @@ mod tests {
                     &mut out,
                 );
                 let split: f64 = out.iter().sum();
-                let whole = group_averaged_xs(&rxn, e_lo, e_hi);
+                let whole = flat_group_average(&rxn, e_lo, e_hi);
                 assert!(
                     (split - whole).abs() <= 1e-12 * whole.abs().max(1.0),
                     "{energies:?} over ({e_lo}, {e_hi}): shares sum to {split}, \


### PR DESCRIPTION
Stacked on #79, which adds the option. This flips which one is the default.

## Why flat-in-energy should not be the default

It has no physical justification anywhere. 1/E has one in the only region where
the choice bites, and it is what NJOY-processed libraries, FISPACT-II and
multigroup MCNP all use. Being the lone outlier is a silent compatibility
hazard: anyone comparing yani against another code sees an unexplained capture
discrepancy and has no way to know why. That is how this was found.

## Neither constant is right, so the case is which one fails better

Fitting `phi ~ E^p` over 1 eV to 100 keV on the two JAEA-FNS spectra, and
measuring how much the weight actually moves a capture rate in each:

| field | fits | epithermal flux | nearer | weight sensitivity, median / max |
| --- | ---: | ---: | --- | ---: |
| position 3 | `E^-0.63` | 0.686% | 1/E | 1.70% / **19.15%** |
| position 7 | `E^-0.29` | 0.088% | **flat** | 0.16% / **0.31%** |

So 1/E is the *wrong* assumption on one of these two fields. It costs **0.31%**
there, and is worth up to **19.15%** where it is right.

That asymmetry is not luck, and it is the actual argument. An epithermal
population only exists when there is moderation, and moderation is exactly what
drives a spectrum towards 1/E. Where the assumption is wrong, there is barely
any epithermal flux for it to be wrong about. **It fails safe.** Flat does not:
its error is one-sided and grows without bound as groups coarsen.

Fusion systems are moderated. A blanket, a shield, anything behind steel looks
like position 3, not like a bare source at position 7.

## The change is free on the flagship benchmark

All 132 FNS decay-heat experiments re-run on `tendl-2017+decay-2012`, built with
this default:

```
median mean deviation : 10.575%  ->  10.575%
within 10%            :     63   ->      63
within 20%            :     84   ->      84
curve level           : 132/132 bit-identical, worst relative change 0.000e+00
```

Not "close". **Identical.** CCFE-709 resolves these cross sections well enough
that the weight is worth 0.04%, so the benchmark this project leads with does
not move at all.

What moves is the 175-group effective-cross-section set, and it moves towards
every other code: over the capture reactions the median difference from
FISPACT-II's published value goes from 0.0959 to 0.0054 in C/E.

## Scope

* `FlatInEnergy` stays selectable, for reproducing results produced before this
  and for bit-exact regression against them.
* The runtime default is now a sentinel deferring to `Weighting::default()`, so
  the static and the enum cannot drift apart. That was a real trap: my first
  attempt at this changed the enum and missed the static, and the tests caught
  it only because one asserted the global directly.
* Six tests hand-compute a flat average to check the *structure* of the walk
  (boundary counting, threshold flags, bit-identical duplicates). They now call
  a `flat_group_average` helper instead of the global, because none of them is
  a test of which weight is selected.

`cargo test -p yani-transmute --lib`: 119 passed. fmt and clippy clean.

## One thing I deliberately did not do

**No version bump here.** This changes results for the same input, so it needs
at least a minor one before release. But this repository's convention is a
dedicated commit for that (`Bump yani-core to 0.15.0`, `Bump yani-core to
0.14.0`), and `crates/yani-python/Cargo.toml` still reads `0.16.0` which is
already on PyPI. Choosing the next release number is a maintainer decision and
bundling it into a feature branch would pre-empt it.

Flagging it rather than doing it: **this must not ship inside a patch release.**